### PR TITLE
docs: require direct UI readiness proof

### DIFF
--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -279,6 +279,22 @@ feature task, **assume Verification** — it has the strictest rules.
 
 ### Verification Discipline (non-negotiable during verification)
 
+**Readiness proof:** Do not claim readiness for device/UI work until rn-dev-agent
+has proven, on the same real target, the target claim, a real-app launch, usable
+UI evidence, and representative navigation. App, Metro, Observe, device-claim,
+and ownership health are not evidence of UI control; all can be green while
+mutating tools are latched off. If any proof step cannot be produced, report
+`UNPROVEN` or `FAIL` at that step—never infer readiness or report a flow as running
+unless the requested MCP operation directly proves it started.
+
+**Control-path integrity:** As required by **Tool Routing — STRICT RULES**, raw
+platform tooling and non-rn-dev-agent control paths (raw `adb`/`xcrun simctl`
+input, ad-hoc scripts, or other automation) are not substitutes and must never
+be reported as rn-dev-agent success; use an exact fallback only with explicit
+user authorization. rn-dev-agent MCP tool success, physical hand-driving by a
+human, and non-MCP automation are three distinct outcomes; none substitutes for
+another.
+
 When verifying a feature works for real users, the following are **SHORTCUTS** that
 invalidate the verification unless the user explicitly accepts them:
 

--- a/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
@@ -279,6 +279,22 @@ feature task, **assume Verification** — it has the strictest rules.
 
 ### Verification Discipline (non-negotiable during verification)
 
+**Readiness proof:** Do not claim readiness for device/UI work until rn-dev-agent
+has proven, on the same real target, the target claim, a real-app launch, usable
+UI evidence, and representative navigation. App, Metro, Observe, device-claim,
+and ownership health are not evidence of UI control; all can be green while
+mutating tools are latched off. If any proof step cannot be produced, report
+`UNPROVEN` or `FAIL` at that step—never infer readiness or report a flow as running
+unless the requested MCP operation directly proves it started.
+
+**Control-path integrity:** As required by **Tool Routing — STRICT RULES**, raw
+platform tooling and non-rn-dev-agent control paths (raw `adb`/`xcrun simctl`
+input, ad-hoc scripts, or other automation) are not substitutes and must never
+be reported as rn-dev-agent success; use an exact fallback only with explicit
+user authorization. rn-dev-agent MCP tool success, physical hand-driving by a
+human, and non-MCP automation are three distinct outcomes; none substitutes for
+another.
+
 When verifying a feature works for real users, the following are **SHORTCUTS** that
 invalidate the verification unless the user explicitly accepts them:
 

--- a/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
@@ -279,6 +279,22 @@ feature task, **assume Verification** — it has the strictest rules.
 
 ### Verification Discipline (non-negotiable during verification)
 
+**Readiness proof:** Do not claim readiness for device/UI work until rn-dev-agent
+has proven, on the same real target, the target claim, a real-app launch, usable
+UI evidence, and representative navigation. App, Metro, Observe, device-claim,
+and ownership health are not evidence of UI control; all can be green while
+mutating tools are latched off. If any proof step cannot be produced, report
+`UNPROVEN` or `FAIL` at that step—never infer readiness or report a flow as running
+unless the requested MCP operation directly proves it started.
+
+**Control-path integrity:** As required by **Tool Routing — STRICT RULES**, raw
+platform tooling and non-rn-dev-agent control paths (raw `adb`/`xcrun simctl`
+input, ad-hoc scripts, or other automation) are not substitutes and must never
+be reported as rn-dev-agent success; use an exact fallback only with explicit
+user authorization. rn-dev-agent MCP tool success, physical hand-driving by a
+human, and non-MCP automation are three distinct outcomes; none substitutes for
+another.
+
 When verifying a feature works for real users, the following are **SHORTCUTS** that
 invalidate the verification unless the user explicitly accepts them:
 


### PR DESCRIPTION
## Intent

Add one concise readiness rule to the canonical CLAUDE-MD-TEMPLATE.md inside the existing Verification Discipline section without restructuring it, and keep packages/claude-plugin/CLAUDE-MD-TEMPLATE.md and packages/codex-plugin/CLAUDE-MD-TEMPLATE.md byte-identical. The rule must require rn-dev-agent proof on the same real target of the target claim, a real-app launch, usable UI evidence, and representative navigation before device/UI readiness is claimed; state that app, Metro, Observe, device-claim, and ownership health are not UI-control evidence and may be green while mutating tools are latched off; require UNPROVEN or FAIL at the failing step and forbid inferring readiness or reporting a flow as running without direct evidence from the requested MCP operation. Keep the raw-platform and non-rn-dev-agent prohibition explicit and adjacent by cross-referencing Tool Routing, allow the exact fallback only with explicit user authorization, and distinguish rn-dev-agent MCP success, physical human hand-driving, and non-MCP automation as three non-substitutable outcomes. Change no other documentation, product code, schema, tool behavior, device/session state, or actions corpus. Make scripts/check-agent-package-sync.sh pass. Deliver a green PR, but do not merge it, enable auto-merge, or release.

## What Changed

- Require same-target rn-dev-agent proof of real-app launch, usable UI evidence, and representative navigation before claiming device/UI readiness.
- Treat health signals, physical hand-driving, and non-MCP automation as non-substitutable evidence, requiring `UNPROVEN` or `FAIL` when direct MCP proof is unavailable.
- Keep the canonical, Claude plugin, and Codex plugin templates aligned.

## Risk Assessment

✅ Low: The documentation-only change is narrowly scoped, satisfies the stated readiness-proof requirements, and keeps all three template copies byte-identical.

## Testing

No prior baseline results were supplied; targeted scope inspection, the package-sync consumer, byte-identity checks, and manual review of the shipped Markdown artifact all passed. No screenshot was captured because this is a non-UI instruction-template change; the actual public Markdown output is attached as evidence.

<details>
<summary>Evidence: Shipped readiness template</summary>

`SHA-256: 5a60a4be1ddf3df00c3ae80589f8ebcc2b81768a4ee7f3c02299c2d92315bea8`

```text
# rn-dev-agent — Project Instructions Template

Copy the section below into your project's `CLAUDE.md` file to ensure Claude
always uses the rn-dev-agent plugin tools instead of raw bash commands.

The `<!-- rn-dev-agent:template-end -->` sentinel on the last line is part of
the template body: `/rn-dev-agent:setup` uses it to delimit the injected block
when diffing a project's copy against this file for refresh. Keep it last.

---

## React Native Development (rn-dev-agent)

This project uses the **rn-dev-agent** plugin for React Native development and testing.
It provides MCP tools across three categories: CDP introspection, device control, and testing.
Run `/rn-dev-agent:check-env` to verify the current plugin version and tool count.

### 🧠 Repo-local troubleshooting memory

This project keeps an auto-maintained, gitignored notes file at
`.rn-agent/local/troubleshooting.md` with two sections: **Configuration & How-To**
(repo-specific facts — Metro start dir, store exposure, testID conventions,
auth/deeplink, build quirks) and **Troubleshooting** (failure→resolution gotchas).

- **Read it first.** At the start of any device/CDP task, consult this file (the
  SessionStart hook also injects it) so you don't re-derive known gotchas or
  re-hit a known failure.
- **It updates itself.** When rn-dev-agent tool calls fail, a hook records them;
  at session end a Stop hook asks you to merge new gotchas into this file. If
  prompted, do it — keep entries concise and under ~2000 tokens total.
- It is per-developer and never committed.

### 🚨 MANDATORY PRE-FLIGHT (before ANY device_* call)

For a full journey (build, test, or proof end to end), `/rn-dev-agent:run-workflow`
sequences the entire proven operating chain — preflight, typed session recovery,
exclusive device, managed Metro, proof, reverse cleanup — in one contract.

Run this 3-step checklist at the start of every UI-touching task. This is the
single highest-leverage rule in the plugin — it prevents the most common
failure mode (multi-minute manual `device_*` walks for flows that already
exist as YAML).

1. **List existing automation:** `/rn-dev-agent:list-learned-actions [feature-keyword]`
   — surfaces matching Maestro flows + UI skeletons + feedback memories for the
   current project.
2. **If a flow matches your intent:** replay it first.
   `/rn-dev-agent:run-action <flow-name> [-e KEY=VALUE …]` — pre-flights
   mutates flag, appId match, parameter coverage, action engine pin, and
   selector compatibility; it resolves pin-cache maestro-runner `>= 1.1.24` from
   rn-dev-agent's versioned pin-cache. For non-login actions, a passing replay
   IS your evidence — skip ahead to capturing proof.
3. **Only if no non-login match (or replay fails with a concrete error):** fall back to
   manual primitives (`device_press` / `device_fill` / `device_find`). When
   you do, **end the session by persisting the verified flow** as a new YAML
   under `<test-app>/.rn-agent/actions/<feature-slug>.yaml` so the next session
   starts at step 2, not step 3.

Authentication is fail-stop: when login is required, call
`cdp_login_prologue`. It inventories learned actions, resolves only the exact
`user-login` action, and requires a fresh passing RunRecord. That result is a
navigation helper, not PR proof. Any missing action, runner drift, selector
failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`. Do not continue with
credentials, ad-hoc Maestro, navigation shortcuts, or store mutation after
that result. Formal login proof is `cdp_lock_e2e_test` / `cdp_run_e2e_suite` on
the exact candidate; helper and locked tests coexist without sharing that proof.

Manual walks are a fallback, not a default. Codified in
`feedback_execute_artifacts_before_manual.md`. Enforced as Step 0 of
`/rn-dev-agent:test-feature` and Step 0a of the `rn-tester` / `rn-debugger`
agent protocols.

### 🧩 Hybrid composition — actions are skill primitives, not just full replays

Use deterministic actions wherever they fit, and walk only the parts that
don't have a saved action. The all-or-nothing "match → replay; else fully
manual" rule is gone — most real tasks share *partial* overlap with existing
actions (login, onboarding, locale, subscription gate). Compose action +
manual when state mismatches; never re-walk a flow you already have.

**Three rules:**

1. **State-detection prologue.** Before any goal-state task, read current
   state — `cdp_navigation_state` for the route, `cdp_store_state` for the
   relevant slice. Note any mismatch with the expected starting state.
2. **Compose action + manual.** If current state ≠ expected start, scan
   `list-learned-actions` for an action whose `produces` covers the gap.
   Replay via `cdp_run_action`; for authentication, use
   `cdp_login_prologue`. Re-verify state. Then continue
   interactively for the novel part.
3. **No fully-manual fallback when partial replay would cover half the work.**
   Login is the cardinal example — enter through `cdp_login_prologue` and
   never re-walk login interactively if the exact action is absent or fails.

**Worked example.** User: "tap the cart badge."

- Agent: `cdp_navigation_state` → `LoginScreen` (mismatch with home)
- Agent: `list-learned-actions` → finds `user-login` with
  `produces: { authenticated: true, route: home }`
- Agent: `cdp_login_prologue({ params: { EMAIL, PASSWORD } })` → fresh passing RunRecord
- Agent: `cdp_navigation_state` → `HomeScreen` (state delta closed)
- Agent: `cdp_component_tree({ filter: "cart" })` → finds `cart-badge` ref
- Agent: `device_press({ ref: "cart-badge" })`

**The `produces:` field is optional metadata in the M7 action header.** Existing
actions without `produces` fall back to today's intent-string matching.
Recorders are encouraged to populate it from observed end-of-flow state when
saving via `cdp_record_test_save_as_action`.

---

### Reusable Actions (the L3 corpus)

An "action" is a Maestro YAML flow stored at `<project>/.rn-agent/actions/<id>.yaml`
paired with a runtime sidecar at `<project>/.rn-agent/state/<id>.state.json`.
The YAML is the executable test; the sidecar tracks `revision`, `status`
(`experimental` / `active` / `deprecated`), `runHistory[]`, and `repairHistory[]`.
The plugin records, replays, and self-heals these flows so an identical user
flow that took ~13 minutes the first time costs ~4 seconds on every replay
afterward — discovery is a one-time cost, replay is the steady state.

**Lifecycle and tooling:**

| Stage | Tool / command | What it does |
|---|---|---|
| **Discover** (record) | `cdp_record_test_start` → walk the app → `cdp_record_test_stop` | Buffers events to `.rn-agent/recordings/<id>.json` (pre-save) |
| **Save** | `cdp_record_test_save_as_action` | Promotes a recording into a paired YAML + sidecar at `.rn-agent/actions/` + `.rn-agent/state/`. Auto-writes the M7 metadata header (`id`, `intent`, `tags`, `mutates`, `status`, required `enginePin`, optional `produces`) |
| **List** | `/rn-dev-agent:list-learned-actions [keyword]` | Browse the corpus by intent / tags / appId. Section B of the output shows actions, Section C shows the UI skeleton, Section A surfaces feedback memories |
| **Run** | `/rn-dev-agent:run-action <id> [-e KEY=VALUE …]` (calls `cdp_run_action`) | Replays with safety pre-flights (mutates flag, appId match, parameter coverage) and auto-repair on `SELECTOR_NOT_FOUND` |
| **Self-heal** | `cdp_repair_action <id>` | Fuzzy-matches the stale testID against the live snapshot, patches the YAML in place, bumps `revision`, demotes `status` to `experimental` until next clean replay. Bounded: max 3 attempts/24h, refuses on human edits (mtime check) |
| **Assert state** | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` | Macro-Asserts — embed internal-state assertions inside replays. Maestro asserts pixels; these assert what the app actually believes |
| **Lock** (promote to regression) | `/rn-dev-agent:lock-e2e <id>` (calls `cdp_lock_e2e_test`) | Runs the action once strict (no repair); freezes the passing flow to `.rn-agent/e2e/<id>.yaml` as an immutable regression test |
| **Regress

... [38427 bytes truncated] ...

p cleanup instead | Do not retry `adopt_stale`. Run `... session-doctor.js repair` (headless) or reconnect with `/mcp` |
| `recoveryRequirement: attach`, `priorOwner: unknown` | `... session-doctor.js report` | The recorded owner's process identity could not be read, so it is conservatively treated as live | Close the other session, or work in a separate worktree. A pid now held by a process you cannot inspect is disproof and IS released automatically (GH #792); a genuinely unreadable identity is not |
| `DEVICE_AUTHORITY_MISMATCH` on `bind_device` while `deviceBound: false` | `rn_session(action="status")` | A runner, proof, or explicitly started Observe binding still holds the device axis — the device binding itself is already absent | Release the named axis first: `observe action="stop"` for an Observe you started, otherwise release the runner/proof binding. This is not a stale-lock wedge |
| `RUNNER_COMMANDS_STALE` / `RUNNER_PROTOCOL_MISMATCH` | failing `device_*` result | Runner artifact predates the installed plugin | `device_snapshot action=open` auto-invalidates + rebuilds; only a surviving mismatch needs the rebuild commands in the error |
| `KEYBOARD_DISMISS_FAILED` refusal (iOS) | `device_snapshot` | A visible keyboard could not be proven hidden by a safe native hide/dismiss control or the optional injected JS tier, so no app tap was performed | Connect CDP so the JS tier can run, or dismiss explicitly, then retry with a fresh snapshot/ref |
| `KEYBOARD_TARGET_STALE` refusal (iOS) | `device_snapshot` | The retained latest-snapshot `Key`/`Keyboard` no longer uniquely matches the live keyboard; no gesture or dismissal ran | Capture a fresh snapshot and use its new exact ref; rebuild/reopen if the runner lacks `EXACT_KEYBOARD_TARGET_GUARD` |
| `maestro_run` fails with `RUNTIME_DEGRADED` hint | — | Simulator runtime is wedged (taps report success, `onPress` never fires) | `xcrun simctl shutdown/boot` the simulator, relaunch, retry — don't chase app code |
| `APP_NOT_INSTALLED` | — | Relaunch/recovery target isn't installed (e.g. after clearState) | Follow the `simctl install` advice in the error, then reconnect |
| Replay fails, `meta.cdpJsFallback` present | `cdp_status` | iOS 26.x WDA reads an empty a11y tree (TRANSPORT_BLIND) | The CDP/JS replay fallback engages automatically; a `cdp-unreachable` skip means fix the CDP connection first |
| All `cdp_*`/`device_*` tools missing after a Claude plugin upgrade | `/reload-plugins`, then inspect MCP inventory | The active Claude process still has the previous plugin snapshot | Reload Claude plugins; if the tools remain absent, exit and relaunch Claude Code. Do not describe Codex `/mcp verbose` as reconnect. |
| Verifying against stale code with Metro running | `rn_session(action="status")`, then `cdp_status` | Session Metro or signed bundle does not match the worktree | Restart through the integrated package script and re-pin with `cdp_connect` |
| `cdp_interact accessibilityLabel="..."` fails (label matching is fuzzy) | Prefer testID-keyed calls: `cdp_interact(testID="...")` or `device_batch` with `testID=` field. Fall back to `device_snapshot` + `device_press(ref="@eN")` only when no testID exists. | Label matching unreliable; testID matching is exact and fiber-tree-resolved | — |
| "Disconnected due to opening a second DevTools window" / React Native DevTools keeps getting kicked | `RN_CDP_AUTOCONNECT` and `.rn-agent/config.json` | RN allows one debugger frontend per app; bridge auto-reconnects by default (agent-first) | Set `RN_CDP_AUTOCONNECT=0` or `.rn-agent/config.json` → `{ "cdp": { "autoConnect": false } }`. `cdp_status` stays passive; `cdp_connect` and gated CDP tools reclaim the authority-bound seat when needed. |

### Authentication & Permission Pre-flight

Before testing **auth-gated features:**
1. `cdp_navigation_state` — check if on a login screen
2. Call `cdp_login_prologue` — it inventories and resolves the exact `user-login` action itself
3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue. Treat that pass as a navigation helper, not PR proof
4. On `LOGIN_PROLOGUE_BLOCKED`, stop the journey; never fall through to manual credentials, `cdp_auto_login`, or ad-hoc Maestro
5. Formal login proof is locking and running the login e2e on the exact candidate (`cdp_lock_e2e_test` / `cdp_run_e2e_suite`)

Before testing **permission-gated features:**
1. `device_permission(action="query", permission="<name>")` — check current state
2. Grant/revoke as needed — **remember: some permissions (camera/mic/location) kill the app process; notifications on Android usually do not**
3. If revoked and the app died, relaunch + `cdp_connect` before continuing
4. For a full clean-slate preflight (permissions + MMKV keys + force-stop + relaunch + reconnect), `device_reset_state` does it in one atomic call

### Verification Flow

After implementing any feature, in this order:

1. `cdp_status` — verify connection is healthy
2. `cdp_error_log(clear=true)` — clear error baseline
3. **Declare the user journey** — write out the user-facing steps you expect in plain language *before* you start clicking. This is your contract.
4. Navigate to the feature **via the entry point a real user would use** (home screen tab, deep link a user could receive, etc.). Only use `cdp_nav_graph(action="go", ...)` if that screen is itself the entry point.
5. `device_snapshot` — first action on every new screen. Confirm UI settled.
6. `cdp_component_tree(filter="<testID>")` — verify component structure and props
7. `device_find` / `device_press` — test user interaction
8. `device_snapshot` — wait for UI to settle after interaction
9. `cdp_network_log` — verify the expected mutation fired through the UI (mutation-as-proof)
10. `cdp_store_state` — verify state changes propagated
11. `cdp_error_log` — check for regressions
12. `device_screenshot` + `proof_step` — capture proof
13. **Terminal check:** does your network log include the real-user mutation? Did you take any shortcuts? If so, list them and flag the verification as "partial / with bypasses." A clean verify is one where no step bypassed the real user path.

### Key Commands

| Command | When to use |
|---------|-------------|
| `/rn-dev-agent:run-workflow [journey]` | Before any real device journey — validates and establishes the proven operating sequence (declared package manager + deps, typed session recovery, one exclusive device, managed Metro, reverse cleanup) |
| `/rn-dev-agent:rn-feature-dev <desc>` | Building a new feature end-to-end (8-phase pipeline: explore, design, implement, verify) |
| `/rn-dev-agent:test-feature` | Feature is implemented, need to verify it works on simulator |
| `/rn-dev-agent:build-and-test` | Need to build from scratch (EAS/local), install, and test |
| `/rn-dev-agent:debug-screen` | Screen is broken, blank, or showing unexpected content |
| `/rn-dev-agent:check-env` | Verify Metro, CDP, simulator are ready before starting work |
| `/rn-dev-agent:doctor` | Diagnose installation health — runners, Metro, CDP, helpers, ffmpeg/idb, plugin version. Read-only |
| `/rn-dev-agent:list-learned-actions [keyword]` | Inventory of saved actions + UI skeleton + feedback memories — run before any manual `device_*` walk |
| `/rn-dev-agent:run-action <id> [-e K=V]` | Replay a saved action with pre-flights + auto-repair |
| `/rn-dev-agent:lock-e2e <action-id>` | Freeze a proven action into a strict locked regression test |
| `/rn-dev-agent:proof-capture` | Feature is done, need PR-ready video + screenshots + PR body |
| `/rn-dev-agent:nav-graph` | Need to understand or query the app's navigation structure |
| `/rn-dev-agent:observe` | The observe web UI autostarts with the session at `http://127.0.0.1:7333` — tool-call timeline, live device mirror (MJPEG), route/store/tree panels, learned-actions runner, e2e tab. Use the command to get the URL, `stop`, or `restart`; opt out via `observe.autoStart: false` or `RN_AGENT_OBSERVE_AUTOSTART=0` |
| `/rn-dev-agent:send-feedback` | Report a plugin bug or issue (creates sanitized GitHub issue) |

<!-- rn-dev-agent:template-end -->
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ac3fc4311c4b2a59881353d4c021d919e9b2045d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --name-status` and the complete template diff from `ddb82f7c…` to `ac3fc431…`; only the three permitted template files changed.</code>
- `bash scripts/check-agent-package-sync.sh`
- `cmp -s CLAUDE-MD-TEMPLATE.md packages/claude-plugin/CLAUDE-MD-TEMPLATE.md`
- `cmp -s CLAUDE-MD-TEMPLATE.md packages/codex-plugin/CLAUDE-MD-TEMPLATE.md`
- `shasum -a 256 CLAUDE-MD-TEMPLATE.md packages/claude-plugin/CLAUDE-MD-TEMPLATE.md packages/codex-plugin/CLAUDE-MD-TEMPLATE.md`
- <code>Copied and inspected the shipped public template at `/Users/antonlykhoyda/.no-mistakes/evidence/01M0ZB4F57KN5H9GYAC6N1H7R4/CLAUDE-MD-TEMPLATE.md`.</code>
- <code>Verified `HEAD` is `ac3fc4311c4b2a59881353d4c021d919e9b2045d` and `git status --short` is clean after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds direct, same-target rn-dev-agent evidence requirements before device or UI readiness may be claimed.
- Requires real-app launch, usable UI evidence, and representative navigation through the requested MCP operation.
- Distinguishes MCP success, physical hand-driving, and non-MCP automation as non-substitutable outcomes.
- Keeps the canonical, Claude plugin, and Codex plugin templates aligned.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CLAUDE-MD-TEMPLATE.md | Adds the canonical UI readiness-proof and control-path-integrity guidance without an eligible follow-up defect. |
| packages/claude-plugin/CLAUDE-MD-TEMPLATE.md | Mirrors the canonical readiness guidance in the Claude plugin template. |
| packages/codex-plugin/CLAUDE-MD-TEMPLATE.md | Mirrors the canonical readiness guidance in the Codex plugin template. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: require UI control readiness proof"](https://github.com/lykhoyda/rn-dev-agent/commit/ac3fc4311c4b2a59881353d4c021d919e9b2045d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57124315)</sub>

<!-- /greptile_comment -->