### PR TITLE
docs: codify Domain-Driven Design architecture rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,20 @@ sibling workspace only when explicitly requested.
   with Metro's dev registry (`globalThis.__r.getModules()`, per-module
   `verboseName`) or fiber/render evidence, bounded and fail-closed.
 
+## Architecture Rules
+
+- All nontrivial code architecture, including session, reconnect, ownership,
+  and authority behavior, must follow Domain-Driven Design (DDD). Define
+  explicit domain language and bounded contexts before implementation.
+- Domain models own domain invariants and lifecycle transitions. Application
+  layers orchestrate use cases; infrastructure, tools, runners, transports,
+  UI, and platform modules implement adapters, with dependencies directed
+  inward toward the domain.
+- Adapters, tools, runners, transports, and UI or platform modules must not
+  become competing owners of domain policy or authority. Trivial mechanical
+  code does not need new layers or types, but it must reuse established domain
+  boundaries and must not bypass or duplicate them.
+
 ## Where To Make Changes
 
 - Core MCP behavior: edit `packages/rn-dev-agent-core/src/`, then run


### PR DESCRIPTION
## Intent

Codify the captain-mandated project-wide code-architecture rule that all nontrivial architecture must follow Domain-Driven Design (DDD). Inspect existing repository architecture guidance and project memory first, preserve one authoritative owner, and avoid duplicating any existing rule. Add a concise, enforceable rule to AGENTS.md, or point there to a stronger existing canonical architecture owner. Require explicit domain language and bounded contexts; domain-model ownership of invariants and lifecycle transitions; application-layer orchestration; infrastructure, tool, transport, runner, UI, and platform details as adapters; and dependencies directed inward toward the domain. Adapters, tools, runners, transports, and UI/platform modules must not become competing owners of domain policy or authority. Trivial mechanical code need not gain ceremony, but it must not bypass or duplicate established domain boundaries; DDD is mandatory, not optional. Apply the rule directly to current session/reconnect-authority architecture and future features without copying Issue 626 details into permanent project memory. Run /Users/antonlykhoyda/Github/anton-factory/bin/fm-ensure-agents-md.sh . and preserve its self-governance section. Add focused documentation or contract validation only if the repository has an established AGENTS.md check; otherwise run relevant documentation and formatting checks and report them. Keep this a documentation/policy-only change: do not refactor product code, merge, or release.

## What Changed

- Establish mandatory Domain-Driven Design rules for nontrivial architecture, including session, reconnect, ownership, and authority behavior.
- Define domain, application, and adapter responsibilities, with dependencies directed inward toward the domain.
- Prevent adapters and platform-facing modules from owning domain policy while allowing trivial code to reuse established boundaries without added ceremony.

## Risk Assessment

✅ Low: The documentation-only change is concise, preserves AGENTS.md governance, establishes one canonical DDD policy, and satisfies all source-verifiable intent requirements without duplication.

## Testing

No prior baseline results were supplied; targeted semantic review, repository-owner discovery, the canonical self-governance executable, whitespace validation, scope verification, and reviewer-visible diff capture all passed, with no screenshot produced because this is a root agent-policy Markdown change with no rendered UI surface.

<details>
<summary>Evidence: Reviewer-visible DDD architecture policy diff</summary>

```text
diff --git a/AGENTS.md b/AGENTS.md
index d7f285db..f3506e11 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,26 @@ sibling workspace only when explicitly requested.
 - Code in `src/injected-helpers.ts` is evaluated via CDP inside an
   already-bundled Metro/Hermes runtime: `require('<package-name>')` throws
   there (Metro resolves only exact dev verboseNames). Prove "is X bundled?"
   with Metro's dev registry (`globalThis.__r.getModules()`, per-module
   `verboseName`) or fiber/render evidence, bounded and fail-closed.
 
+## Architecture Rules
+
+- All nontrivial code architecture, including session, reconnect, ownership,
+  and authority behavior, must follow Domain-Driven Design (DDD). Define
+  explicit domain language and bounded contexts before implementation.
+- Domain models own domain invariants and lifecycle transitions. Application
+  layers orchestrate use cases; infrastructure, tools, runners, transports,
+  UI, and platform modules implement adapters, with dependencies directed
+  inward toward the domain.
+- Adapters, tools, runners, transports, and UI or platform modules must not
+  become competing owners of domain policy or authority. Trivial mechanical
+  code does not need new layers or types, but it must reuse established domain
+  boundaries and must not bypass or duplicate them.
+
 ## Where To Make Changes
 
 - Core MCP behavior: edit `packages/rn-dev-agent-core/src/`, then run
   `corepack yarn build:core` and `corepack yarn build:host-runtimes`.
 - The registered `cdp_connect` tool is `createRegisteredConnectHandler`
   (`src/session/registered-connect.ts` → `rn_session` `pin_dev_client` →
```
</details>
<details>
<summary>Evidence: Self-governance script idempotence</summary>

```text
unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3dc5ca1641d1991f1b00ee5135e0cc3e4bcf38c4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --no-ext-diff ddb82f7c97e65c26771b294b89c4a5e51a326191..3dc5ca1641d1991f1b00ee5135e0cc3e4bcf38c4 -- AGENTS.md` against every authoritative acceptance constraint.</code>
- <code>Searched repository guidance with `rg -n --hidden --glob &#39;!node_modules&#39; --glob &#39;!.git&#39; &#39;AGENTS\.md|ensure-agents|self-governance|Architecture Rules|Domain-Driven|bounded context&#39; .`; no competing DDD policy owner or established in-repo AGENTS.md contract check was found.</code>
- <code>Reviewed the configured project memory and canonical `/Users/antonlykhoyda/Github/anton-factory/bin/fm-ensure-agents-md.sh` before validation.</code>
- <code>Ran `/Users/antonlykhoyda/Github/anton-factory/bin/fm-ensure-agents-md.sh .` twice; the second run reported the AGENTS.md contract unchanged, proving idempotence and preservation of the canonical maintenance section.</code>
- <code>Ran `git diff --check ddb82f7c97e65c26771b294b89c4a5e51a326191..3dc5ca1641d1991f1b00ee5135e0cc3e4bcf38c4`.</code>
- <code>Ran `git show --format= --name-only 3dc5ca1641d1991f1b00ee5135e0cc3e4bcf38c4`; only `AGENTS.md` changed.</code>
- <code>Removed the ignored `CLAUDE.md` symlink created transiently by the required self-governance script and confirmed `git status --short --untracked-files=all` was clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a repository-wide Domain-Driven Design policy to the canonical contributor guidance.
- Requires explicit domain language and bounded contexts for nontrivial architecture.
- Assigns invariants and lifecycle transitions to domain models, orchestration to application layers, and implementation details to adapters.
- Directs dependencies inward and prevents adapters or platform modules from becoming competing owners of domain policy.

<h3>Confidence Score: 5/5</h3>

The documentation-only policy change appears safe to merge.

The new architecture section establishes a single DDD policy while preserving existing AGENTS.md governance and presenting no concrete behavioral, security, or documentation defect.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds concise DDD architecture requirements without conflicting with existing ownership, maintenance, or architecture guidance. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: require domain-driven architecture"](https://github.com/lykhoyda/rn-dev-agent/commit/3dc5ca1641d1991f1b00ee5135e0cc3e4bcf38c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57161911)</sub>

<!-- /greptile_comment -->