### PR TITLE
feat(core): add bounded Hermes target wait

### DIFF
--- a/.changeset/calm-hermes-wait.md
+++ b/.changeset/calm-hermes-wait.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Add a bounded passive `cdp_status` option that waits for the exact authority-bound Hermes target without connecting or relaunching.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Claude Code / Codex
 | Problem | Solution |
 |---------|----------|
 | "Metro not found" | Inspect `rn_session(action="status")`, then use literal `pnpm ios` or `pnpm android` through the confirmed project integration |
-| "No Hermes target" | Open the bound app, inspect passive `cdp_status`, then use `cdp_connect` to pin the exact signed target |
+| "No Hermes target" | Open the bound app, call `cdp_status({ waitForTargetMs: 120000 })`, then use `cdp_connect` to pin the exact signed target |
 | CDP rejected (1006) | Close React Native DevTools, Flipper, or Chrome DevTools |
 | Zustand store error | Add `global.__ZUSTAND_STORES__` ([setup](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)) |
 | Plugin not detected (Claude) | `/plugin install rn-dev-agent@rn-dev-agent` then `/reload-plugins` |

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_status.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_status.mdx
@@ -1,11 +1,11 @@
 ---
 title: "cdp_status"
-description: "Passively report the current authority session, Metro client, and CDP target without connecting, relaunching, dismissing UI, or choosing an ambient target"
+description: "Passively report the current authority session, Metro client, and CDP target"
 sidebar:
   order: 0
 ---
 
-Passively report the current authority session, Metro client, and CDP target without connecting, relaunching, dismissing UI, or choosing an ambient target.
+Passively report the current authority session, Metro client, and CDP target. waitForTargetMs observes only the exact bound target without connecting, relaunching, dismissing UI, or choosing an ambient target.
 
 ## Parameters
 
@@ -13,6 +13,7 @@ Passively report the current authority session, Metro client, and CDP target wit
 |------|------|----------|---------|-------------|-------------|
 | `metroPort` | `number` | No |  |  | Diagnostic comparison only; cdp_status never changes the active Metro port |
 | `platform` | `string` | No |  |  | Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups |
+| `waitForTargetMs` | `number` | No |  | min: 1, max: 120_000, integer | Bounded passive wait for the exact authority-bound Hermes target |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -32,7 +32,7 @@ only and cannot establish authority. See
 
 ### No Hermes target
 
-Open the app on the simulator and ensure Hermes is enabled. Check your `app.json` or `metro.config.js` for Hermes configuration.
+Open the bound app, then call `cdp_status({ waitForTargetMs: 120000 })` to wait for its exact Hermes target without connecting or relaunching. A timeout reports only the existing build or Metro authority state; it does not guess whether the app is on a picker or crashed. Once the target is ready, call `cdp_connect` to pin the exact signed runtime.
 
 ### CDP connection rejected (1006)
 
@@ -46,7 +46,7 @@ The bridge auto-reconnects by default and evicts the visual React Native DevTool
 
 This is normal. `cdp_reload` reconnects the authority-bound target within 15
 seconds. If it fails, call `cdp_status` for passive diagnostics, then
-`cdp_connect` to pin the exact signed target again.
+`cdp_status({ waitForTargetMs: 120000 })`, then `cdp_connect` to pin the exact signed target again.
 
 ### MCP server died when Metro was restarted
 

--- a/packages/claude-plugin/commands/check-env.md
+++ b/packages/claude-plugin/commands/check-env.md
@@ -58,7 +58,7 @@ If issues are found, suggest the appropriate fix:
 | Session `state: blocked` | Another session owns this worktree. Report `recoveryRequirement.nextAction` verbatim (plus `startupCleanupBlocked` when present) and stop — do not run setup, do not bind a device, do not pick another booted device. See `using-rn-dev-agent` § "Session ownership recovery" |
 | Session missing or genuinely unbound (not `blocked`) | Run setup, review/apply the integration preview, and bind the intended device and app |
 | Metro not found | Use literal `pnpm ios` or `pnpm android` through the confirmed integration |
-| No Hermes target | Open the bound app, then call `cdp_connect` for the exact signed target |
+| No Hermes target | Open the bound app, wait with `cdp_status({ waitForTargetMs: 120000 })`, then call `cdp_connect` for the exact signed target |
 | CDP code 1006 | Close React Native DevTools, Flipper, Chrome DevTools |
 | `cdp_component_tree` reports RedBox | Run `/rn-dev-agent:debug-screen` |
 | Narrow gated CDP read times out | Check for a blocked JS thread, then use `cdp_reload` |

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -57699,6 +57699,23 @@ init_utils();
 init_maestro_validator();
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
+
+// packages/rn-dev-agent-core/dist/session/session-target.js
+init_discovery();
+function targetMatchesSession(target, filters) {
+  if (!target)
+    return false;
+  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
+    return false;
+  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
+    return false;
+  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
+    return false;
+  }
+  return true;
+}
+
+// packages/rn-dev-agent-core/dist/tools/reload.js
 init_target_device_authority();
 var defaultExecFile = promisify13(execFileCb10);
 var sessionReloadCount = 0;
@@ -70917,26 +70934,249 @@ function createSessionHandler(runtime, dependencies = {}) {
   };
 }
 
-// packages/rn-dev-agent-core/dist/tools/status.js
-function targetMatchesSession(target, filters) {
-  if (!target)
-    return false;
-  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
-    return false;
-  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
-    return false;
-  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
-    return false;
+// packages/rn-dev-agent-core/dist/session/wait-for-exact-session-target.js
+var TARGET_POLL_INTERVAL_MS = 250;
+var TargetWaitDeadlineError = class extends Error {
+};
+function authorityRefusal(status) {
+  if (!status.available) {
+    return {
+      code: status.code,
+      reason: "Waiting for a Hermes target requires an available authority session; inspect rn_session status."
+    };
   }
-  return true;
+  if (status.state === "blocked" || status.state === "handoff_cleanup") {
+    return {
+      code: "SESSION_AUTHORITY_REQUIRED",
+      reason: "The current worker does not own this worktree; inspect rn_session status."
+    };
+  }
+  const terminal = status.bindings.metroTerminal;
+  if (terminal) {
+    return {
+      code: "METRO_AUTHORITY_MISMATCH",
+      reason: typeof terminal.reason === "string" ? terminal.reason : "The authority-bound Metro is no longer live."
+    };
+  }
+  const device = status.bindings.device;
+  if (!device || device.platform !== "ios" && device.platform !== "android" || typeof device.deviceId !== "string" || typeof device.appId !== "string") {
+    return {
+      code: "CDP_TARGET_AUTHORITY_MISMATCH",
+      reason: "Waiting for a Hermes target requires an exact session device and app binding."
+    };
+  }
+  return null;
 }
+function targetBinding(status) {
+  const device = status.bindings.device;
+  const metro = status.bindings.metro;
+  const port = metro?.port;
+  if (!Number.isSafeInteger(port) || metro?.mode !== "managed" && metro?.mode !== "external") {
+    return null;
+  }
+  return {
+    sessionId: status.sessionId,
+    claimEpoch: status.claimEpoch,
+    authorityVersion: status.authorityVersion,
+    platform: device.platform,
+    deviceId: device.deviceId,
+    appId: device.appId,
+    metroMode: metro.mode,
+    metroPort: Number(port)
+  };
+}
+function sameTargetBinding(left, right) {
+  return left.sessionId === right.sessionId && left.claimEpoch === right.claimEpoch && left.authorityVersion === right.authorityVersion && left.platform === right.platform && left.deviceId === right.deviceId && left.appId === right.appId && left.metroMode === right.metroMode && left.metroPort === right.metroPort;
+}
+async function waitForExactSessionTarget(timeoutMs, dependencies) {
+  const now = dependencies.now ?? Date.now;
+  const wait = dependencies.wait ?? ((ms) => new Promise((resolve20) => setTimeout(resolve20, ms)));
+  const setDeadlineTimer = dependencies.setDeadlineTimer ?? ((callback, ms) => setTimeout(callback, ms));
+  const clearDeadlineTimer = dependencies.clearDeadlineTimer ?? ((timer) => clearTimeout(timer));
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  let probes = 0;
+  let lastObservation = null;
+  const elapsedMs = () => Math.max(0, Math.min(timeoutMs, now() - startedAt));
+  const timeoutResult = () => ({
+    outcome: "timeout",
+    requestedMs: timeoutMs,
+    elapsedMs: elapsedMs(),
+    probes,
+    lastObservation
+  });
+  const awaitWithinDeadline = async (operation) => {
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      throw new TargetWaitDeadlineError();
+    let timer;
+    try {
+      const result = await Promise.race([
+        operation(),
+        new Promise((_resolve, reject) => {
+          timer = setDeadlineTimer(() => reject(new TargetWaitDeadlineError()), remainingMs);
+        })
+      ]);
+      if (now() >= deadline)
+        throw new TargetWaitDeadlineError();
+      return result;
+    } finally {
+      if (timer !== void 0)
+        clearDeadlineTimer(timer);
+    }
+  };
+  while (now() < deadline) {
+    const authority = dependencies.readAuthority();
+    const refusal = authorityRefusal(authority);
+    if (refusal) {
+      return {
+        outcome: "refused",
+        requestedMs: timeoutMs,
+        elapsedMs: elapsedMs(),
+        probes,
+        ...refusal,
+        lastObservation
+      };
+    }
+    if (!authority.available)
+      throw new Error("unreachable");
+    const binding = targetBinding(authority);
+    if (!binding) {
+      if (!authority.bindings.pendingBuild) {
+        return {
+          outcome: "refused",
+          requestedMs: timeoutMs,
+          elapsedMs: elapsedMs(),
+          probes,
+          code: "METRO_AUTHORITY_MISMATCH",
+          reason: "Waiting for a Hermes target requires a live authority-bound Metro.",
+          lastObservation
+        };
+      }
+    } else {
+      let exactDeviceProbeStarted = false;
+      try {
+        const listed = await awaitWithinDeadline(() => dependencies.listTargetsExact(binding.metroPort));
+        probes += 1;
+        if (listed.port !== binding.metroPort) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "Target discovery escaped the authority-bound Metro port.",
+            lastObservation
+          };
+        }
+        const sessionTargets = listed.targets.filter((target) => targetMatchesSession(target, {
+          platform: binding.platform,
+          bundleId: binding.appId
+        }));
+        let exactTargets = [];
+        if (sessionTargets.length > 0) {
+          exactDeviceProbeStarted = true;
+          exactTargets = await awaitWithinDeadline(() => dependencies.filterTargetsForExactDevice({
+            platform: binding.platform,
+            deviceId: binding.deviceId,
+            targets: sessionTargets
+          }, awaitWithinDeadline));
+        }
+        lastObservation = {
+          advertisedTargetCount: listed.targets.length,
+          sessionTargetCount: sessionTargets.length,
+          exactTargetCount: exactTargets.length
+        };
+        const refreshedAuthority = dependencies.readAuthority();
+        const refreshedRefusal = authorityRefusal(refreshedAuthority);
+        if (refreshedRefusal) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            ...refreshedRefusal,
+            lastObservation: null
+          };
+        }
+        if (!refreshedAuthority.available)
+          throw new Error("unreachable");
+        const refreshedBinding = targetBinding(refreshedAuthority);
+        if (!refreshedBinding || !sameTargetBinding(binding, refreshedBinding)) {
+          lastObservation = null;
+        } else if (exactTargets.length === 1) {
+          return {
+            outcome: "ready",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            lastObservation,
+            authority: refreshedAuthority
+          };
+        } else if (exactTargets.length > 1) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "More than one target matches the exact session device.",
+            lastObservation
+          };
+        }
+      } catch (error2) {
+        if (error2 instanceof TargetWaitDeadlineError)
+          return timeoutResult();
+        if (exactDeviceProbeStarted) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "The advertised Hermes target cannot be associated with the exact session device.",
+            lastObservation
+          };
+        }
+      }
+    }
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      return timeoutResult();
+    try {
+      await awaitWithinDeadline(() => wait(Math.min(TARGET_POLL_INTERVAL_MS, remainingMs)));
+    } catch (error2) {
+      if (error2 instanceof TargetWaitDeadlineError)
+        return timeoutResult();
+      throw error2;
+    }
+  }
+  return timeoutResult();
+}
+
+// packages/rn-dev-agent-core/dist/tools/status.js
 function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDependencies = {}) {
   return async (args) => {
+    let targetWait;
+    if (args.waitForTargetMs !== void 0) {
+      if (!statusDependencies.listTargetsExact || !statusDependencies.filterTargetsForExactDevice) {
+        return failResult("The passive Hermes target waiter is unavailable in this runtime.", "NOT_IMPLEMENTED");
+      }
+      targetWait = await waitForExactSessionTarget(args.waitForTargetMs, {
+        readAuthority: () => reconcileManagedMetroStatus(authorityRuntime2, statusDependencies),
+        listTargetsExact: statusDependencies.listTargetsExact,
+        filterTargetsForExactDevice: statusDependencies.filterTargetsForExactDevice,
+        ...statusDependencies.now ? { now: statusDependencies.now } : {},
+        ...statusDependencies.wait ? { wait: statusDependencies.wait } : {},
+        ...statusDependencies.setDeadlineTimer ? { setDeadlineTimer: statusDependencies.setDeadlineTimer } : {},
+        ...statusDependencies.clearDeadlineTimer ? { clearDeadlineTimer: statusDependencies.clearDeadlineTimer } : {}
+      });
+    }
     const client2 = getClient2();
     const target = client2.connectedTarget;
-    const authority = reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
+    const authority = targetWait?.outcome === "ready" ? targetWait.authority : reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
     const installIdentity = authority.available ? (statusDependencies.inspectInstallIdentity ?? inspectInstallIdentity)(authority.bindings.install) : null;
-    return okResult({
+    const data = {
       authoritative: false,
       authority: projectPublicAuthorityStatus(authority, { installIdentity }),
       metro: {
@@ -70952,8 +71192,24 @@ function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDepende
         } : null,
         requestedPlatform: args.platform ?? null
       },
-      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port."
-    });
+      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port.",
+      ...targetWait ? {
+        targetWait: {
+          requestedMs: targetWait.requestedMs,
+          elapsedMs: targetWait.elapsedMs,
+          outcome: targetWait.outcome,
+          probes: targetWait.probes,
+          lastObservation: targetWait.lastObservation
+        }
+      } : {}
+    };
+    if (targetWait?.outcome === "timeout") {
+      return failResult(`Timed out after ${targetWait.requestedMs}ms waiting for the exact authority-bound Hermes target.`, "CDP_TARGET_WAIT_TIMEOUT", data);
+    }
+    if (targetWait?.outcome === "refused") {
+      return failResult(targetWait.reason, targetWait.code, data);
+    }
+    return okResult(data);
   };
 }
 
@@ -79449,9 +79705,9 @@ function createMaestroRunHandler(deps = {}) {
         directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
         requireWdaProvenance: passed
       });
-      const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-      if (authorityRefusal) {
-        return failResult(authorityRefusal, "DEVICE_AUTHORITY_MISMATCH", {
+      const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+      if (authorityRefusal2) {
+        return failResult(authorityRefusal2, "DEVICE_AUTHORITY_MISMATCH", {
           flowFile,
           platform,
           runner: dispatch.runner,
@@ -83781,12 +84037,12 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
       directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
       requireWdaProvenance: passed
     });
-    const authorityRefusal = maestroAuthorityRefusal(deviceAuthority, execution.error);
+    const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority, execution.error);
     return {
-      passed: authorityRefusal ? false : passed,
+      passed: authorityRefusal2 ? false : passed,
       output,
       flowFile,
-      ...authorityRefusal ? { error: authorityRefusal } : {},
+      ...authorityRefusal2 ? { error: authorityRefusal2 } : {},
       exitCode: execution.code,
       signal: execution.signal,
       cleanupEscalated: execution.cleanupEscalated,
@@ -89374,13 +89630,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
           requireWdaProvenance: outputPassed
         });
-        const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-        const ok = outputPassed && !authorityRefusal;
+        const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+        const ok = outputPassed && !authorityRefusal2;
         results.push({
           name,
           passed: ok,
           durationMs: now() - start,
-          error: authorityRefusal ?? (ok ? void 0 : output.slice(0, 300)),
+          error: authorityRefusal2 ?? (ok ? void 0 : output.slice(0, 300)),
           deviceAuthority
         });
         if (ok)
@@ -89432,13 +89688,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportDeviceIds: directEvidence.reportDeviceIds,
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength
         }) : null;
-        const authorityRefusal = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
+        const authorityRefusal2 = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
         const preOFailure = platform === "android" && isOlderSdkInstallFailure(capturedOutput) ? olderSdkInstallDiagnosis(flowDispatch.runner) : null;
         results.push({
           name,
           passed: false,
           durationMs: now() - start,
-          error: preOFailure ?? authorityRefusal ?? msg3.slice(0, 300),
+          error: preOFailure ?? authorityRefusal2 ?? msg3.slice(0, 300),
           ...deviceAuthority && !preOFailure ? { deviceAuthority } : {}
         });
         failed++;
@@ -93738,12 +93994,15 @@ trackedTool("rn_session", "Inspect and transition the fenced rn-dev-agent author
   confirmed: external_exports.boolean().describe("Authorizes inline proven-dead device cleanup").optional(),
   force: external_exports.boolean().optional()
 }, sessionHandler);
-trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
+trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target. waitForTargetMs observes only the exact bound target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
   metroPort: external_exports.number().optional().describe("Diagnostic comparison only; cdp_status never changes the active Metro port"),
-  platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups')
+  platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups'),
+  waitForTargetMs: external_exports.number().int().min(1).max(12e4).optional().describe("Bounded passive wait for the exact authority-bound Hermes target")
 }, createPassiveStatusHandler(getClient, authorityRuntime, {
   getSignerCapability: getSessionSignerCapability,
-  onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy()
+  onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy(),
+  listTargetsExact: listTargetsOnExactPort,
+  filterTargetsForExactDevice: (input, awaitWithinBoundary) => filterTargetsForExactDevice(input, { execute: execFileP, awaitWithinBoundary })
 }));
 trackedTool("observe", "Start/stop the read-only observability web UI (watch the agent's live tool-call timeline, device screenshot, and app state). action: start|stop|status.", observeSchema, observeHandler);
 trackedTool("cdp_diagnostic_renderers", 'Diagnostic helper for "fiber root invisibility" bug reports (issue #126 follow-up). Enumerates every registered React renderer and its root count via __REACT_DEVTOOLS_GLOBAL_HOOK__. Returns hook keys, renderer Map keys, per-renderer-id root summaries (top fiber type + first child + testID), and notes when renderers are registered but unscanned. Use this when cdp_component_tree returns empty for a component you know is mounted (modals, portals, sub-apps), or when bug-reporting fiber-walk failures.', {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -69795,6 +69795,26 @@ var init_config = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/session-target.js
+function targetMatchesSession(target, filters) {
+  if (!target)
+    return false;
+  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
+    return false;
+  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
+    return false;
+  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
+    return false;
+  }
+  return true;
+}
+var init_session_target = __esm({
+  "packages/rn-dev-agent-core/dist/session/session-target.js"() {
+    "use strict";
+    init_discovery();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/tools/reload.js
 import { execFile as execFileCb11 } from "node:child_process";
 import { promisify as promisify14 } from "node:util";
@@ -70068,7 +70088,7 @@ var init_reload = __esm({
     "use strict";
     init_utils();
     init_maestro_validator();
-    init_status();
+    init_session_target();
     init_target_device_authority();
     defaultExecFile = promisify14(execFileCb11);
     sessionReloadCount = 0;
@@ -73433,26 +73453,256 @@ var init_session = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/tools/status.js
-function targetMatchesSession(target, filters) {
-  if (!target)
-    return false;
-  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
-    return false;
-  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
-    return false;
-  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
-    return false;
+// packages/rn-dev-agent-core/dist/session/wait-for-exact-session-target.js
+function authorityRefusal(status) {
+  if (!status.available) {
+    return {
+      code: status.code,
+      reason: "Waiting for a Hermes target requires an available authority session; inspect rn_session status."
+    };
   }
-  return true;
+  if (status.state === "blocked" || status.state === "handoff_cleanup") {
+    return {
+      code: "SESSION_AUTHORITY_REQUIRED",
+      reason: "The current worker does not own this worktree; inspect rn_session status."
+    };
+  }
+  const terminal = status.bindings.metroTerminal;
+  if (terminal) {
+    return {
+      code: "METRO_AUTHORITY_MISMATCH",
+      reason: typeof terminal.reason === "string" ? terminal.reason : "The authority-bound Metro is no longer live."
+    };
+  }
+  const device = status.bindings.device;
+  if (!device || device.platform !== "ios" && device.platform !== "android" || typeof device.deviceId !== "string" || typeof device.appId !== "string") {
+    return {
+      code: "CDP_TARGET_AUTHORITY_MISMATCH",
+      reason: "Waiting for a Hermes target requires an exact session device and app binding."
+    };
+  }
+  return null;
 }
+function targetBinding(status) {
+  const device = status.bindings.device;
+  const metro = status.bindings.metro;
+  const port = metro?.port;
+  if (!Number.isSafeInteger(port) || metro?.mode !== "managed" && metro?.mode !== "external") {
+    return null;
+  }
+  return {
+    sessionId: status.sessionId,
+    claimEpoch: status.claimEpoch,
+    authorityVersion: status.authorityVersion,
+    platform: device.platform,
+    deviceId: device.deviceId,
+    appId: device.appId,
+    metroMode: metro.mode,
+    metroPort: Number(port)
+  };
+}
+function sameTargetBinding(left, right) {
+  return left.sessionId === right.sessionId && left.claimEpoch === right.claimEpoch && left.authorityVersion === right.authorityVersion && left.platform === right.platform && left.deviceId === right.deviceId && left.appId === right.appId && left.metroMode === right.metroMode && left.metroPort === right.metroPort;
+}
+async function waitForExactSessionTarget(timeoutMs, dependencies) {
+  const now = dependencies.now ?? Date.now;
+  const wait = dependencies.wait ?? ((ms) => new Promise((resolve21) => setTimeout(resolve21, ms)));
+  const setDeadlineTimer = dependencies.setDeadlineTimer ?? ((callback, ms) => setTimeout(callback, ms));
+  const clearDeadlineTimer = dependencies.clearDeadlineTimer ?? ((timer) => clearTimeout(timer));
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  let probes = 0;
+  let lastObservation = null;
+  const elapsedMs = () => Math.max(0, Math.min(timeoutMs, now() - startedAt));
+  const timeoutResult = () => ({
+    outcome: "timeout",
+    requestedMs: timeoutMs,
+    elapsedMs: elapsedMs(),
+    probes,
+    lastObservation
+  });
+  const awaitWithinDeadline = async (operation) => {
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      throw new TargetWaitDeadlineError();
+    let timer;
+    try {
+      const result = await Promise.race([
+        operation(),
+        new Promise((_resolve, reject) => {
+          timer = setDeadlineTimer(() => reject(new TargetWaitDeadlineError()), remainingMs);
+        })
+      ]);
+      if (now() >= deadline)
+        throw new TargetWaitDeadlineError();
+      return result;
+    } finally {
+      if (timer !== void 0)
+        clearDeadlineTimer(timer);
+    }
+  };
+  while (now() < deadline) {
+    const authority = dependencies.readAuthority();
+    const refusal = authorityRefusal(authority);
+    if (refusal) {
+      return {
+        outcome: "refused",
+        requestedMs: timeoutMs,
+        elapsedMs: elapsedMs(),
+        probes,
+        ...refusal,
+        lastObservation
+      };
+    }
+    if (!authority.available)
+      throw new Error("unreachable");
+    const binding = targetBinding(authority);
+    if (!binding) {
+      if (!authority.bindings.pendingBuild) {
+        return {
+          outcome: "refused",
+          requestedMs: timeoutMs,
+          elapsedMs: elapsedMs(),
+          probes,
+          code: "METRO_AUTHORITY_MISMATCH",
+          reason: "Waiting for a Hermes target requires a live authority-bound Metro.",
+          lastObservation
+        };
+      }
+    } else {
+      let exactDeviceProbeStarted = false;
+      try {
+        const listed = await awaitWithinDeadline(() => dependencies.listTargetsExact(binding.metroPort));
+        probes += 1;
+        if (listed.port !== binding.metroPort) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "Target discovery escaped the authority-bound Metro port.",
+            lastObservation
+          };
+        }
+        const sessionTargets = listed.targets.filter((target) => targetMatchesSession(target, {
+          platform: binding.platform,
+          bundleId: binding.appId
+        }));
+        let exactTargets = [];
+        if (sessionTargets.length > 0) {
+          exactDeviceProbeStarted = true;
+          exactTargets = await awaitWithinDeadline(() => dependencies.filterTargetsForExactDevice({
+            platform: binding.platform,
+            deviceId: binding.deviceId,
+            targets: sessionTargets
+          }, awaitWithinDeadline));
+        }
+        lastObservation = {
+          advertisedTargetCount: listed.targets.length,
+          sessionTargetCount: sessionTargets.length,
+          exactTargetCount: exactTargets.length
+        };
+        const refreshedAuthority = dependencies.readAuthority();
+        const refreshedRefusal = authorityRefusal(refreshedAuthority);
+        if (refreshedRefusal) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            ...refreshedRefusal,
+            lastObservation: null
+          };
+        }
+        if (!refreshedAuthority.available)
+          throw new Error("unreachable");
+        const refreshedBinding = targetBinding(refreshedAuthority);
+        if (!refreshedBinding || !sameTargetBinding(binding, refreshedBinding)) {
+          lastObservation = null;
+        } else if (exactTargets.length === 1) {
+          return {
+            outcome: "ready",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            lastObservation,
+            authority: refreshedAuthority
+          };
+        } else if (exactTargets.length > 1) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "More than one target matches the exact session device.",
+            lastObservation
+          };
+        }
+      } catch (error2) {
+        if (error2 instanceof TargetWaitDeadlineError)
+          return timeoutResult();
+        if (exactDeviceProbeStarted) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "The advertised Hermes target cannot be associated with the exact session device.",
+            lastObservation
+          };
+        }
+      }
+    }
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      return timeoutResult();
+    try {
+      await awaitWithinDeadline(() => wait(Math.min(TARGET_POLL_INTERVAL_MS, remainingMs)));
+    } catch (error2) {
+      if (error2 instanceof TargetWaitDeadlineError)
+        return timeoutResult();
+      throw error2;
+    }
+  }
+  return timeoutResult();
+}
+var TARGET_POLL_INTERVAL_MS, TargetWaitDeadlineError;
+var init_wait_for_exact_session_target = __esm({
+  "packages/rn-dev-agent-core/dist/session/wait-for-exact-session-target.js"() {
+    "use strict";
+    init_session_target();
+    TARGET_POLL_INTERVAL_MS = 250;
+    TargetWaitDeadlineError = class extends Error {
+    };
+  }
+});
+
+// packages/rn-dev-agent-core/dist/tools/status.js
 function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDependencies = {}) {
   return async (args) => {
+    let targetWait;
+    if (args.waitForTargetMs !== void 0) {
+      if (!statusDependencies.listTargetsExact || !statusDependencies.filterTargetsForExactDevice) {
+        return failResult("The passive Hermes target waiter is unavailable in this runtime.", "NOT_IMPLEMENTED");
+      }
+      targetWait = await waitForExactSessionTarget(args.waitForTargetMs, {
+        readAuthority: () => reconcileManagedMetroStatus(authorityRuntime2, statusDependencies),
+        listTargetsExact: statusDependencies.listTargetsExact,
+        filterTargetsForExactDevice: statusDependencies.filterTargetsForExactDevice,
+        ...statusDependencies.now ? { now: statusDependencies.now } : {},
+        ...statusDependencies.wait ? { wait: statusDependencies.wait } : {},
+        ...statusDependencies.setDeadlineTimer ? { setDeadlineTimer: statusDependencies.setDeadlineTimer } : {},
+        ...statusDependencies.clearDeadlineTimer ? { clearDeadlineTimer: statusDependencies.clearDeadlineTimer } : {}
+      });
+    }
     const client2 = getClient2();
     const target = client2.connectedTarget;
-    const authority = reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
+    const authority = targetWait?.outcome === "ready" ? targetWait.authority : reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
     const installIdentity = authority.available ? (statusDependencies.inspectInstallIdentity ?? inspectInstallIdentity)(authority.bindings.install) : null;
-    return okResult({
+    const data = {
       authoritative: false,
       authority: projectPublicAuthorityStatus(authority, { installIdentity }),
       metro: {
@@ -73468,8 +73718,24 @@ function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDepende
         } : null,
         requestedPlatform: args.platform ?? null
       },
-      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port."
-    });
+      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port.",
+      ...targetWait ? {
+        targetWait: {
+          requestedMs: targetWait.requestedMs,
+          elapsedMs: targetWait.elapsedMs,
+          outcome: targetWait.outcome,
+          probes: targetWait.probes,
+          lastObservation: targetWait.lastObservation
+        }
+      } : {}
+    };
+    if (targetWait?.outcome === "timeout") {
+      return failResult(`Timed out after ${targetWait.requestedMs}ms waiting for the exact authority-bound Hermes target.`, "CDP_TARGET_WAIT_TIMEOUT", data);
+    }
+    if (targetWait?.outcome === "refused") {
+      return failResult(targetWait.reason, targetWait.code, data);
+    }
+    return okResult(data);
   };
 }
 var init_status = __esm({
@@ -73495,6 +73761,9 @@ var init_status = __esm({
     init_install_identity_inspection();
     init_public_status();
     init_session();
+    init_session_target();
+    init_wait_for_exact_session_target();
+    init_session_target();
   }
 });
 
@@ -81479,9 +81748,9 @@ function createMaestroRunHandler(deps = {}) {
         directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
         requireWdaProvenance: passed
       });
-      const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-      if (authorityRefusal) {
-        return failResult(authorityRefusal, "DEVICE_AUTHORITY_MISMATCH", {
+      const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+      if (authorityRefusal2) {
+        return failResult(authorityRefusal2, "DEVICE_AUTHORITY_MISMATCH", {
           flowFile,
           platform,
           runner: dispatch.runner,
@@ -84606,7 +84875,7 @@ var SESSION_RUNTIME_ABSENCE_RESAMPLE_MS, IOS_APP_PROBE_TIMEOUT_MS, ANDROID_APP_P
 var init_session_runtime_absence = __esm({
   "packages/rn-dev-agent-core/dist/session/session-runtime-absence.js"() {
     "use strict";
-    init_status();
+    init_session_target();
     init_device_session();
     SESSION_RUNTIME_ABSENCE_RESAMPLE_MS = 1500;
     IOS_APP_PROBE_TIMEOUT_MS = 5e3;
@@ -85967,12 +86236,12 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
       directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
       requireWdaProvenance: passed
     });
-    const authorityRefusal = maestroAuthorityRefusal(deviceAuthority, execution.error);
+    const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority, execution.error);
     return {
-      passed: authorityRefusal ? false : passed,
+      passed: authorityRefusal2 ? false : passed,
       output,
       flowFile,
-      ...authorityRefusal ? { error: authorityRefusal } : {},
+      ...authorityRefusal2 ? { error: authorityRefusal2 } : {},
       exitCode: execution.code,
       signal: execution.signal,
       cleanupEscalated: execution.cleanupEscalated,
@@ -90673,6 +90942,7 @@ var init_connection = __esm({
     init_utils();
     init_agent_device_wrapper();
     init_status();
+    init_session_target();
     init_discovery();
   }
 });
@@ -90878,7 +91148,7 @@ var init_restart = __esm({
     init_recover_detached();
     init_resolve_ios_app_file();
     init_maestro_validator();
-    init_status();
+    init_session_target();
     init_target_device_authority();
     defaultExecFile3 = promisify24(execFileCb18);
     SIMULATOR_UDID_RE = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
@@ -91394,13 +91664,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
           requireWdaProvenance: outputPassed
         });
-        const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-        const ok = outputPassed && !authorityRefusal;
+        const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+        const ok = outputPassed && !authorityRefusal2;
         results.push({
           name,
           passed: ok,
           durationMs: now() - start,
-          error: authorityRefusal ?? (ok ? void 0 : output.slice(0, 300)),
+          error: authorityRefusal2 ?? (ok ? void 0 : output.slice(0, 300)),
           deviceAuthority
         });
         if (ok)
@@ -91452,13 +91722,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportDeviceIds: directEvidence.reportDeviceIds,
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength
         }) : null;
-        const authorityRefusal = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
+        const authorityRefusal2 = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
         const preOFailure = platform === "android" && isOlderSdkInstallFailure(capturedOutput) ? olderSdkInstallDiagnosis(flowDispatch.runner) : null;
         results.push({
           name,
           passed: false,
           durationMs: now() - start,
-          error: preOFailure ?? authorityRefusal ?? msg3.slice(0, 300),
+          error: preOFailure ?? authorityRefusal2 ?? msg3.slice(0, 300),
           ...deviceAuthority && !preOFailure ? { deviceAuthority } : {}
         });
         failed++;
@@ -94931,7 +95201,7 @@ var init_connect_exact_session_target = __esm({
     "use strict";
     init_connect();
     init_discovery();
-    init_status();
+    init_session_target();
     init_target_device_authority();
     IOS_EXACT_TARGET_READINESS_TIMEOUT_MS = 12e4;
     ANDROID_EXACT_TARGET_READINESS_TIMEOUT_MS = 12e4;
@@ -95628,6 +95898,7 @@ var init_index = __esm({
     init_metro_authority();
     init_target_device_authority();
     init_connect_exact_session_target();
+    init_session_target();
     init_source_identity();
     init_managed_metro();
     init_process_cleanup();
@@ -96198,12 +96469,15 @@ var init_index = __esm({
       confirmed: external_exports.boolean().describe("Authorizes inline proven-dead device cleanup").optional(),
       force: external_exports.boolean().optional()
     }, sessionHandler);
-    trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
+    trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target. waitForTargetMs observes only the exact bound target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
       metroPort: external_exports.number().optional().describe("Diagnostic comparison only; cdp_status never changes the active Metro port"),
-      platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups')
+      platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups'),
+      waitForTargetMs: external_exports.number().int().min(1).max(12e4).optional().describe("Bounded passive wait for the exact authority-bound Hermes target")
     }, createPassiveStatusHandler(getClient, authorityRuntime, {
       getSignerCapability: getSessionSignerCapability,
-      onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy()
+      onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy(),
+      listTargetsExact: listTargetsOnExactPort,
+      filterTargetsForExactDevice: (input, awaitWithinBoundary) => filterTargetsForExactDevice(input, { execute: execFileP, awaitWithinBoundary })
     }));
     trackedTool("observe", "Start/stop the read-only observability web UI (watch the agent's live tool-call timeline, device screenshot, and app state). action: start|stop|status.", observeSchema, observeHandler);
     trackedTool("cdp_diagnostic_renderers", 'Diagnostic helper for "fiber root invisibility" bug reports (issue #126 follow-up). Enumerates every registered React renderer and its root count via __REACT_DEVTOOLS_GLOBAL_HOOK__. Returns hook keys, renderer Map keys, per-renderer-id root summaries (top fiber type + first child + testID), and notes when renderers are registered but unscanned. Use this when cdp_component_tree returns empty for a component you know is mounted (modals, portals, sub-apps), or when bug-reporting fiber-walk failures.', {

--- a/packages/codex-plugin/commands/check-env.md
+++ b/packages/codex-plugin/commands/check-env.md
@@ -60,7 +60,7 @@ If issues are found, suggest the appropriate fix:
 | Session `state: blocked` | Another session owns this worktree. Report `recoveryRequirement.nextAction` verbatim (plus `startupCleanupBlocked` when present) and stop — do not run setup, do not bind a device, do not pick another booted device. See the `using-rn-dev-agent` skill section "Session ownership recovery" |
 | Session missing or genuinely unbound (not `blocked`) | Run setup, review/apply the integration preview, and bind the intended device and app |
 | Metro not found | Use literal `pnpm ios` or `pnpm android` through the confirmed integration |
-| No Hermes target | Open the bound app, then call `cdp_connect` for the exact signed target |
+| No Hermes target | Open the bound app, wait with `cdp_status({ waitForTargetMs: 120000 })`, then call `cdp_connect` for the exact signed target |
 | CDP code 1006 | Close React Native DevTools, Flipper, Chrome DevTools |
 | `cdp_component_tree` reports RedBox | Run `$rn-dev-agent:debug-screen` |
 | Narrow gated CDP read times out | Check for a blocked JS thread, then use `cdp_reload` |

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -57699,6 +57699,23 @@ init_utils();
 init_maestro_validator();
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
+
+// packages/rn-dev-agent-core/dist/session/session-target.js
+init_discovery();
+function targetMatchesSession(target, filters) {
+  if (!target)
+    return false;
+  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
+    return false;
+  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
+    return false;
+  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
+    return false;
+  }
+  return true;
+}
+
+// packages/rn-dev-agent-core/dist/tools/reload.js
 init_target_device_authority();
 var defaultExecFile = promisify13(execFileCb10);
 var sessionReloadCount = 0;
@@ -70917,26 +70934,249 @@ function createSessionHandler(runtime, dependencies = {}) {
   };
 }
 
-// packages/rn-dev-agent-core/dist/tools/status.js
-function targetMatchesSession(target, filters) {
-  if (!target)
-    return false;
-  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
-    return false;
-  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
-    return false;
-  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
-    return false;
+// packages/rn-dev-agent-core/dist/session/wait-for-exact-session-target.js
+var TARGET_POLL_INTERVAL_MS = 250;
+var TargetWaitDeadlineError = class extends Error {
+};
+function authorityRefusal(status) {
+  if (!status.available) {
+    return {
+      code: status.code,
+      reason: "Waiting for a Hermes target requires an available authority session; inspect rn_session status."
+    };
   }
-  return true;
+  if (status.state === "blocked" || status.state === "handoff_cleanup") {
+    return {
+      code: "SESSION_AUTHORITY_REQUIRED",
+      reason: "The current worker does not own this worktree; inspect rn_session status."
+    };
+  }
+  const terminal = status.bindings.metroTerminal;
+  if (terminal) {
+    return {
+      code: "METRO_AUTHORITY_MISMATCH",
+      reason: typeof terminal.reason === "string" ? terminal.reason : "The authority-bound Metro is no longer live."
+    };
+  }
+  const device = status.bindings.device;
+  if (!device || device.platform !== "ios" && device.platform !== "android" || typeof device.deviceId !== "string" || typeof device.appId !== "string") {
+    return {
+      code: "CDP_TARGET_AUTHORITY_MISMATCH",
+      reason: "Waiting for a Hermes target requires an exact session device and app binding."
+    };
+  }
+  return null;
 }
+function targetBinding(status) {
+  const device = status.bindings.device;
+  const metro = status.bindings.metro;
+  const port = metro?.port;
+  if (!Number.isSafeInteger(port) || metro?.mode !== "managed" && metro?.mode !== "external") {
+    return null;
+  }
+  return {
+    sessionId: status.sessionId,
+    claimEpoch: status.claimEpoch,
+    authorityVersion: status.authorityVersion,
+    platform: device.platform,
+    deviceId: device.deviceId,
+    appId: device.appId,
+    metroMode: metro.mode,
+    metroPort: Number(port)
+  };
+}
+function sameTargetBinding(left, right) {
+  return left.sessionId === right.sessionId && left.claimEpoch === right.claimEpoch && left.authorityVersion === right.authorityVersion && left.platform === right.platform && left.deviceId === right.deviceId && left.appId === right.appId && left.metroMode === right.metroMode && left.metroPort === right.metroPort;
+}
+async function waitForExactSessionTarget(timeoutMs, dependencies) {
+  const now = dependencies.now ?? Date.now;
+  const wait = dependencies.wait ?? ((ms) => new Promise((resolve20) => setTimeout(resolve20, ms)));
+  const setDeadlineTimer = dependencies.setDeadlineTimer ?? ((callback, ms) => setTimeout(callback, ms));
+  const clearDeadlineTimer = dependencies.clearDeadlineTimer ?? ((timer) => clearTimeout(timer));
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  let probes = 0;
+  let lastObservation = null;
+  const elapsedMs = () => Math.max(0, Math.min(timeoutMs, now() - startedAt));
+  const timeoutResult = () => ({
+    outcome: "timeout",
+    requestedMs: timeoutMs,
+    elapsedMs: elapsedMs(),
+    probes,
+    lastObservation
+  });
+  const awaitWithinDeadline = async (operation) => {
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      throw new TargetWaitDeadlineError();
+    let timer;
+    try {
+      const result = await Promise.race([
+        operation(),
+        new Promise((_resolve, reject) => {
+          timer = setDeadlineTimer(() => reject(new TargetWaitDeadlineError()), remainingMs);
+        })
+      ]);
+      if (now() >= deadline)
+        throw new TargetWaitDeadlineError();
+      return result;
+    } finally {
+      if (timer !== void 0)
+        clearDeadlineTimer(timer);
+    }
+  };
+  while (now() < deadline) {
+    const authority = dependencies.readAuthority();
+    const refusal = authorityRefusal(authority);
+    if (refusal) {
+      return {
+        outcome: "refused",
+        requestedMs: timeoutMs,
+        elapsedMs: elapsedMs(),
+        probes,
+        ...refusal,
+        lastObservation
+      };
+    }
+    if (!authority.available)
+      throw new Error("unreachable");
+    const binding = targetBinding(authority);
+    if (!binding) {
+      if (!authority.bindings.pendingBuild) {
+        return {
+          outcome: "refused",
+          requestedMs: timeoutMs,
+          elapsedMs: elapsedMs(),
+          probes,
+          code: "METRO_AUTHORITY_MISMATCH",
+          reason: "Waiting for a Hermes target requires a live authority-bound Metro.",
+          lastObservation
+        };
+      }
+    } else {
+      let exactDeviceProbeStarted = false;
+      try {
+        const listed = await awaitWithinDeadline(() => dependencies.listTargetsExact(binding.metroPort));
+        probes += 1;
+        if (listed.port !== binding.metroPort) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "Target discovery escaped the authority-bound Metro port.",
+            lastObservation
+          };
+        }
+        const sessionTargets = listed.targets.filter((target) => targetMatchesSession(target, {
+          platform: binding.platform,
+          bundleId: binding.appId
+        }));
+        let exactTargets = [];
+        if (sessionTargets.length > 0) {
+          exactDeviceProbeStarted = true;
+          exactTargets = await awaitWithinDeadline(() => dependencies.filterTargetsForExactDevice({
+            platform: binding.platform,
+            deviceId: binding.deviceId,
+            targets: sessionTargets
+          }, awaitWithinDeadline));
+        }
+        lastObservation = {
+          advertisedTargetCount: listed.targets.length,
+          sessionTargetCount: sessionTargets.length,
+          exactTargetCount: exactTargets.length
+        };
+        const refreshedAuthority = dependencies.readAuthority();
+        const refreshedRefusal = authorityRefusal(refreshedAuthority);
+        if (refreshedRefusal) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            ...refreshedRefusal,
+            lastObservation: null
+          };
+        }
+        if (!refreshedAuthority.available)
+          throw new Error("unreachable");
+        const refreshedBinding = targetBinding(refreshedAuthority);
+        if (!refreshedBinding || !sameTargetBinding(binding, refreshedBinding)) {
+          lastObservation = null;
+        } else if (exactTargets.length === 1) {
+          return {
+            outcome: "ready",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            lastObservation,
+            authority: refreshedAuthority
+          };
+        } else if (exactTargets.length > 1) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "More than one target matches the exact session device.",
+            lastObservation
+          };
+        }
+      } catch (error2) {
+        if (error2 instanceof TargetWaitDeadlineError)
+          return timeoutResult();
+        if (exactDeviceProbeStarted) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "The advertised Hermes target cannot be associated with the exact session device.",
+            lastObservation
+          };
+        }
+      }
+    }
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      return timeoutResult();
+    try {
+      await awaitWithinDeadline(() => wait(Math.min(TARGET_POLL_INTERVAL_MS, remainingMs)));
+    } catch (error2) {
+      if (error2 instanceof TargetWaitDeadlineError)
+        return timeoutResult();
+      throw error2;
+    }
+  }
+  return timeoutResult();
+}
+
+// packages/rn-dev-agent-core/dist/tools/status.js
 function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDependencies = {}) {
   return async (args) => {
+    let targetWait;
+    if (args.waitForTargetMs !== void 0) {
+      if (!statusDependencies.listTargetsExact || !statusDependencies.filterTargetsForExactDevice) {
+        return failResult("The passive Hermes target waiter is unavailable in this runtime.", "NOT_IMPLEMENTED");
+      }
+      targetWait = await waitForExactSessionTarget(args.waitForTargetMs, {
+        readAuthority: () => reconcileManagedMetroStatus(authorityRuntime2, statusDependencies),
+        listTargetsExact: statusDependencies.listTargetsExact,
+        filterTargetsForExactDevice: statusDependencies.filterTargetsForExactDevice,
+        ...statusDependencies.now ? { now: statusDependencies.now } : {},
+        ...statusDependencies.wait ? { wait: statusDependencies.wait } : {},
+        ...statusDependencies.setDeadlineTimer ? { setDeadlineTimer: statusDependencies.setDeadlineTimer } : {},
+        ...statusDependencies.clearDeadlineTimer ? { clearDeadlineTimer: statusDependencies.clearDeadlineTimer } : {}
+      });
+    }
     const client2 = getClient2();
     const target = client2.connectedTarget;
-    const authority = reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
+    const authority = targetWait?.outcome === "ready" ? targetWait.authority : reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
     const installIdentity = authority.available ? (statusDependencies.inspectInstallIdentity ?? inspectInstallIdentity)(authority.bindings.install) : null;
-    return okResult({
+    const data = {
       authoritative: false,
       authority: projectPublicAuthorityStatus(authority, { installIdentity }),
       metro: {
@@ -70952,8 +71192,24 @@ function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDepende
         } : null,
         requestedPlatform: args.platform ?? null
       },
-      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port."
-    });
+      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port.",
+      ...targetWait ? {
+        targetWait: {
+          requestedMs: targetWait.requestedMs,
+          elapsedMs: targetWait.elapsedMs,
+          outcome: targetWait.outcome,
+          probes: targetWait.probes,
+          lastObservation: targetWait.lastObservation
+        }
+      } : {}
+    };
+    if (targetWait?.outcome === "timeout") {
+      return failResult(`Timed out after ${targetWait.requestedMs}ms waiting for the exact authority-bound Hermes target.`, "CDP_TARGET_WAIT_TIMEOUT", data);
+    }
+    if (targetWait?.outcome === "refused") {
+      return failResult(targetWait.reason, targetWait.code, data);
+    }
+    return okResult(data);
   };
 }
 
@@ -79449,9 +79705,9 @@ function createMaestroRunHandler(deps = {}) {
         directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
         requireWdaProvenance: passed
       });
-      const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-      if (authorityRefusal) {
-        return failResult(authorityRefusal, "DEVICE_AUTHORITY_MISMATCH", {
+      const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+      if (authorityRefusal2) {
+        return failResult(authorityRefusal2, "DEVICE_AUTHORITY_MISMATCH", {
           flowFile,
           platform,
           runner: dispatch.runner,
@@ -83781,12 +84037,12 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
       directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
       requireWdaProvenance: passed
     });
-    const authorityRefusal = maestroAuthorityRefusal(deviceAuthority, execution.error);
+    const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority, execution.error);
     return {
-      passed: authorityRefusal ? false : passed,
+      passed: authorityRefusal2 ? false : passed,
       output,
       flowFile,
-      ...authorityRefusal ? { error: authorityRefusal } : {},
+      ...authorityRefusal2 ? { error: authorityRefusal2 } : {},
       exitCode: execution.code,
       signal: execution.signal,
       cleanupEscalated: execution.cleanupEscalated,
@@ -89374,13 +89630,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
           requireWdaProvenance: outputPassed
         });
-        const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-        const ok = outputPassed && !authorityRefusal;
+        const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+        const ok = outputPassed && !authorityRefusal2;
         results.push({
           name,
           passed: ok,
           durationMs: now() - start,
-          error: authorityRefusal ?? (ok ? void 0 : output.slice(0, 300)),
+          error: authorityRefusal2 ?? (ok ? void 0 : output.slice(0, 300)),
           deviceAuthority
         });
         if (ok)
@@ -89432,13 +89688,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportDeviceIds: directEvidence.reportDeviceIds,
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength
         }) : null;
-        const authorityRefusal = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
+        const authorityRefusal2 = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
         const preOFailure = platform === "android" && isOlderSdkInstallFailure(capturedOutput) ? olderSdkInstallDiagnosis(flowDispatch.runner) : null;
         results.push({
           name,
           passed: false,
           durationMs: now() - start,
-          error: preOFailure ?? authorityRefusal ?? msg3.slice(0, 300),
+          error: preOFailure ?? authorityRefusal2 ?? msg3.slice(0, 300),
           ...deviceAuthority && !preOFailure ? { deviceAuthority } : {}
         });
         failed++;
@@ -93738,12 +93994,15 @@ trackedTool("rn_session", "Inspect and transition the fenced rn-dev-agent author
   confirmed: external_exports.boolean().describe("Authorizes inline proven-dead device cleanup").optional(),
   force: external_exports.boolean().optional()
 }, sessionHandler);
-trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
+trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target. waitForTargetMs observes only the exact bound target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
   metroPort: external_exports.number().optional().describe("Diagnostic comparison only; cdp_status never changes the active Metro port"),
-  platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups')
+  platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups'),
+  waitForTargetMs: external_exports.number().int().min(1).max(12e4).optional().describe("Bounded passive wait for the exact authority-bound Hermes target")
 }, createPassiveStatusHandler(getClient, authorityRuntime, {
   getSignerCapability: getSessionSignerCapability,
-  onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy()
+  onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy(),
+  listTargetsExact: listTargetsOnExactPort,
+  filterTargetsForExactDevice: (input, awaitWithinBoundary) => filterTargetsForExactDevice(input, { execute: execFileP, awaitWithinBoundary })
 }));
 trackedTool("observe", "Start/stop the read-only observability web UI (watch the agent's live tool-call timeline, device screenshot, and app state). action: start|stop|status.", observeSchema, observeHandler);
 trackedTool("cdp_diagnostic_renderers", 'Diagnostic helper for "fiber root invisibility" bug reports (issue #126 follow-up). Enumerates every registered React renderer and its root count via __REACT_DEVTOOLS_GLOBAL_HOOK__. Returns hook keys, renderer Map keys, per-renderer-id root summaries (top fiber type + first child + testID), and notes when renderers are registered but unscanned. Use this when cdp_component_tree returns empty for a component you know is mounted (modals, portals, sub-apps), or when bug-reporting fiber-walk failures.', {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -69795,6 +69795,26 @@ var init_config = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/session-target.js
+function targetMatchesSession(target, filters) {
+  if (!target)
+    return false;
+  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
+    return false;
+  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
+    return false;
+  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
+    return false;
+  }
+  return true;
+}
+var init_session_target = __esm({
+  "packages/rn-dev-agent-core/dist/session/session-target.js"() {
+    "use strict";
+    init_discovery();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/tools/reload.js
 import { execFile as execFileCb11 } from "node:child_process";
 import { promisify as promisify14 } from "node:util";
@@ -70068,7 +70088,7 @@ var init_reload = __esm({
     "use strict";
     init_utils();
     init_maestro_validator();
-    init_status();
+    init_session_target();
     init_target_device_authority();
     defaultExecFile = promisify14(execFileCb11);
     sessionReloadCount = 0;
@@ -73433,26 +73453,256 @@ var init_session = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/tools/status.js
-function targetMatchesSession(target, filters) {
-  if (!target)
-    return false;
-  if (filters.platform && (target.platform !== filters.platform || target.platformInference === "defaulted" || target.platformInference === "ambiguous"))
-    return false;
-  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId))
-    return false;
-  if (filters.deviceKind === "physical" && !androidTargetMatchesKind(target.deviceName, filters.deviceKind)) {
-    return false;
+// packages/rn-dev-agent-core/dist/session/wait-for-exact-session-target.js
+function authorityRefusal(status) {
+  if (!status.available) {
+    return {
+      code: status.code,
+      reason: "Waiting for a Hermes target requires an available authority session; inspect rn_session status."
+    };
   }
-  return true;
+  if (status.state === "blocked" || status.state === "handoff_cleanup") {
+    return {
+      code: "SESSION_AUTHORITY_REQUIRED",
+      reason: "The current worker does not own this worktree; inspect rn_session status."
+    };
+  }
+  const terminal = status.bindings.metroTerminal;
+  if (terminal) {
+    return {
+      code: "METRO_AUTHORITY_MISMATCH",
+      reason: typeof terminal.reason === "string" ? terminal.reason : "The authority-bound Metro is no longer live."
+    };
+  }
+  const device = status.bindings.device;
+  if (!device || device.platform !== "ios" && device.platform !== "android" || typeof device.deviceId !== "string" || typeof device.appId !== "string") {
+    return {
+      code: "CDP_TARGET_AUTHORITY_MISMATCH",
+      reason: "Waiting for a Hermes target requires an exact session device and app binding."
+    };
+  }
+  return null;
 }
+function targetBinding(status) {
+  const device = status.bindings.device;
+  const metro = status.bindings.metro;
+  const port = metro?.port;
+  if (!Number.isSafeInteger(port) || metro?.mode !== "managed" && metro?.mode !== "external") {
+    return null;
+  }
+  return {
+    sessionId: status.sessionId,
+    claimEpoch: status.claimEpoch,
+    authorityVersion: status.authorityVersion,
+    platform: device.platform,
+    deviceId: device.deviceId,
+    appId: device.appId,
+    metroMode: metro.mode,
+    metroPort: Number(port)
+  };
+}
+function sameTargetBinding(left, right) {
+  return left.sessionId === right.sessionId && left.claimEpoch === right.claimEpoch && left.authorityVersion === right.authorityVersion && left.platform === right.platform && left.deviceId === right.deviceId && left.appId === right.appId && left.metroMode === right.metroMode && left.metroPort === right.metroPort;
+}
+async function waitForExactSessionTarget(timeoutMs, dependencies) {
+  const now = dependencies.now ?? Date.now;
+  const wait = dependencies.wait ?? ((ms) => new Promise((resolve21) => setTimeout(resolve21, ms)));
+  const setDeadlineTimer = dependencies.setDeadlineTimer ?? ((callback, ms) => setTimeout(callback, ms));
+  const clearDeadlineTimer = dependencies.clearDeadlineTimer ?? ((timer) => clearTimeout(timer));
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  let probes = 0;
+  let lastObservation = null;
+  const elapsedMs = () => Math.max(0, Math.min(timeoutMs, now() - startedAt));
+  const timeoutResult = () => ({
+    outcome: "timeout",
+    requestedMs: timeoutMs,
+    elapsedMs: elapsedMs(),
+    probes,
+    lastObservation
+  });
+  const awaitWithinDeadline = async (operation) => {
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      throw new TargetWaitDeadlineError();
+    let timer;
+    try {
+      const result = await Promise.race([
+        operation(),
+        new Promise((_resolve, reject) => {
+          timer = setDeadlineTimer(() => reject(new TargetWaitDeadlineError()), remainingMs);
+        })
+      ]);
+      if (now() >= deadline)
+        throw new TargetWaitDeadlineError();
+      return result;
+    } finally {
+      if (timer !== void 0)
+        clearDeadlineTimer(timer);
+    }
+  };
+  while (now() < deadline) {
+    const authority = dependencies.readAuthority();
+    const refusal = authorityRefusal(authority);
+    if (refusal) {
+      return {
+        outcome: "refused",
+        requestedMs: timeoutMs,
+        elapsedMs: elapsedMs(),
+        probes,
+        ...refusal,
+        lastObservation
+      };
+    }
+    if (!authority.available)
+      throw new Error("unreachable");
+    const binding = targetBinding(authority);
+    if (!binding) {
+      if (!authority.bindings.pendingBuild) {
+        return {
+          outcome: "refused",
+          requestedMs: timeoutMs,
+          elapsedMs: elapsedMs(),
+          probes,
+          code: "METRO_AUTHORITY_MISMATCH",
+          reason: "Waiting for a Hermes target requires a live authority-bound Metro.",
+          lastObservation
+        };
+      }
+    } else {
+      let exactDeviceProbeStarted = false;
+      try {
+        const listed = await awaitWithinDeadline(() => dependencies.listTargetsExact(binding.metroPort));
+        probes += 1;
+        if (listed.port !== binding.metroPort) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "Target discovery escaped the authority-bound Metro port.",
+            lastObservation
+          };
+        }
+        const sessionTargets = listed.targets.filter((target) => targetMatchesSession(target, {
+          platform: binding.platform,
+          bundleId: binding.appId
+        }));
+        let exactTargets = [];
+        if (sessionTargets.length > 0) {
+          exactDeviceProbeStarted = true;
+          exactTargets = await awaitWithinDeadline(() => dependencies.filterTargetsForExactDevice({
+            platform: binding.platform,
+            deviceId: binding.deviceId,
+            targets: sessionTargets
+          }, awaitWithinDeadline));
+        }
+        lastObservation = {
+          advertisedTargetCount: listed.targets.length,
+          sessionTargetCount: sessionTargets.length,
+          exactTargetCount: exactTargets.length
+        };
+        const refreshedAuthority = dependencies.readAuthority();
+        const refreshedRefusal = authorityRefusal(refreshedAuthority);
+        if (refreshedRefusal) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            ...refreshedRefusal,
+            lastObservation: null
+          };
+        }
+        if (!refreshedAuthority.available)
+          throw new Error("unreachable");
+        const refreshedBinding = targetBinding(refreshedAuthority);
+        if (!refreshedBinding || !sameTargetBinding(binding, refreshedBinding)) {
+          lastObservation = null;
+        } else if (exactTargets.length === 1) {
+          return {
+            outcome: "ready",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            lastObservation,
+            authority: refreshedAuthority
+          };
+        } else if (exactTargets.length > 1) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "More than one target matches the exact session device.",
+            lastObservation
+          };
+        }
+      } catch (error2) {
+        if (error2 instanceof TargetWaitDeadlineError)
+          return timeoutResult();
+        if (exactDeviceProbeStarted) {
+          return {
+            outcome: "refused",
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: "CDP_TARGET_AUTHORITY_MISMATCH",
+            reason: "The advertised Hermes target cannot be associated with the exact session device.",
+            lastObservation
+          };
+        }
+      }
+    }
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0)
+      return timeoutResult();
+    try {
+      await awaitWithinDeadline(() => wait(Math.min(TARGET_POLL_INTERVAL_MS, remainingMs)));
+    } catch (error2) {
+      if (error2 instanceof TargetWaitDeadlineError)
+        return timeoutResult();
+      throw error2;
+    }
+  }
+  return timeoutResult();
+}
+var TARGET_POLL_INTERVAL_MS, TargetWaitDeadlineError;
+var init_wait_for_exact_session_target = __esm({
+  "packages/rn-dev-agent-core/dist/session/wait-for-exact-session-target.js"() {
+    "use strict";
+    init_session_target();
+    TARGET_POLL_INTERVAL_MS = 250;
+    TargetWaitDeadlineError = class extends Error {
+    };
+  }
+});
+
+// packages/rn-dev-agent-core/dist/tools/status.js
 function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDependencies = {}) {
   return async (args) => {
+    let targetWait;
+    if (args.waitForTargetMs !== void 0) {
+      if (!statusDependencies.listTargetsExact || !statusDependencies.filterTargetsForExactDevice) {
+        return failResult("The passive Hermes target waiter is unavailable in this runtime.", "NOT_IMPLEMENTED");
+      }
+      targetWait = await waitForExactSessionTarget(args.waitForTargetMs, {
+        readAuthority: () => reconcileManagedMetroStatus(authorityRuntime2, statusDependencies),
+        listTargetsExact: statusDependencies.listTargetsExact,
+        filterTargetsForExactDevice: statusDependencies.filterTargetsForExactDevice,
+        ...statusDependencies.now ? { now: statusDependencies.now } : {},
+        ...statusDependencies.wait ? { wait: statusDependencies.wait } : {},
+        ...statusDependencies.setDeadlineTimer ? { setDeadlineTimer: statusDependencies.setDeadlineTimer } : {},
+        ...statusDependencies.clearDeadlineTimer ? { clearDeadlineTimer: statusDependencies.clearDeadlineTimer } : {}
+      });
+    }
     const client2 = getClient2();
     const target = client2.connectedTarget;
-    const authority = reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
+    const authority = targetWait?.outcome === "ready" ? targetWait.authority : reconcileManagedMetroStatus(authorityRuntime2, statusDependencies);
     const installIdentity = authority.available ? (statusDependencies.inspectInstallIdentity ?? inspectInstallIdentity)(authority.bindings.install) : null;
-    return okResult({
+    const data = {
       authoritative: false,
       authority: projectPublicAuthorityStatus(authority, { installIdentity }),
       metro: {
@@ -73468,8 +73718,24 @@ function createPassiveStatusHandler(getClient2, authorityRuntime2, statusDepende
         } : null,
         requestedPlatform: args.platform ?? null
       },
-      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port."
-    });
+      nextAction: client2.isConnected ? "Use rn_session status to inspect bindings before authoritative tools." : "Use rn_session bind_metro and cdp_connect with the claimed exact port.",
+      ...targetWait ? {
+        targetWait: {
+          requestedMs: targetWait.requestedMs,
+          elapsedMs: targetWait.elapsedMs,
+          outcome: targetWait.outcome,
+          probes: targetWait.probes,
+          lastObservation: targetWait.lastObservation
+        }
+      } : {}
+    };
+    if (targetWait?.outcome === "timeout") {
+      return failResult(`Timed out after ${targetWait.requestedMs}ms waiting for the exact authority-bound Hermes target.`, "CDP_TARGET_WAIT_TIMEOUT", data);
+    }
+    if (targetWait?.outcome === "refused") {
+      return failResult(targetWait.reason, targetWait.code, data);
+    }
+    return okResult(data);
   };
 }
 var init_status = __esm({
@@ -73495,6 +73761,9 @@ var init_status = __esm({
     init_install_identity_inspection();
     init_public_status();
     init_session();
+    init_session_target();
+    init_wait_for_exact_session_target();
+    init_session_target();
   }
 });
 
@@ -81479,9 +81748,9 @@ function createMaestroRunHandler(deps = {}) {
         directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
         requireWdaProvenance: passed
       });
-      const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-      if (authorityRefusal) {
-        return failResult(authorityRefusal, "DEVICE_AUTHORITY_MISMATCH", {
+      const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+      if (authorityRefusal2) {
+        return failResult(authorityRefusal2, "DEVICE_AUTHORITY_MISMATCH", {
           flowFile,
           platform,
           runner: dispatch.runner,
@@ -84606,7 +84875,7 @@ var SESSION_RUNTIME_ABSENCE_RESAMPLE_MS, IOS_APP_PROBE_TIMEOUT_MS, ANDROID_APP_P
 var init_session_runtime_absence = __esm({
   "packages/rn-dev-agent-core/dist/session/session-runtime-absence.js"() {
     "use strict";
-    init_status();
+    init_session_target();
     init_device_session();
     SESSION_RUNTIME_ABSENCE_RESAMPLE_MS = 1500;
     IOS_APP_PROBE_TIMEOUT_MS = 5e3;
@@ -85967,12 +86236,12 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
       directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
       requireWdaProvenance: passed
     });
-    const authorityRefusal = maestroAuthorityRefusal(deviceAuthority, execution.error);
+    const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority, execution.error);
     return {
-      passed: authorityRefusal ? false : passed,
+      passed: authorityRefusal2 ? false : passed,
       output,
       flowFile,
-      ...authorityRefusal ? { error: authorityRefusal } : {},
+      ...authorityRefusal2 ? { error: authorityRefusal2 } : {},
       exitCode: execution.code,
       signal: execution.signal,
       cleanupEscalated: execution.cleanupEscalated,
@@ -90673,6 +90942,7 @@ var init_connection = __esm({
     init_utils();
     init_agent_device_wrapper();
     init_status();
+    init_session_target();
     init_discovery();
   }
 });
@@ -90878,7 +91148,7 @@ var init_restart = __esm({
     init_recover_detached();
     init_resolve_ios_app_file();
     init_maestro_validator();
-    init_status();
+    init_session_target();
     init_target_device_authority();
     defaultExecFile3 = promisify24(execFileCb18);
     SIMULATOR_UDID_RE = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
@@ -91394,13 +91664,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength,
           requireWdaProvenance: outputPassed
         });
-        const authorityRefusal = maestroAuthorityRefusal(deviceAuthority);
-        const ok = outputPassed && !authorityRefusal;
+        const authorityRefusal2 = maestroAuthorityRefusal(deviceAuthority);
+        const ok = outputPassed && !authorityRefusal2;
         results.push({
           name,
           passed: ok,
           durationMs: now() - start,
-          error: authorityRefusal ?? (ok ? void 0 : output.slice(0, 300)),
+          error: authorityRefusal2 ?? (ok ? void 0 : output.slice(0, 300)),
           deviceAuthority
         });
         if (ok)
@@ -91452,13 +91722,13 @@ function createMaestroTestAllHandler(deps = {}) {
           directReportDeviceIds: directEvidence.reportDeviceIds,
           directReportIdentityStrength: directEvidence.reportDeviceIdStrength
         }) : null;
-        const authorityRefusal = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
+        const authorityRefusal2 = deviceAuthority ? maestroAuthorityRefusal(deviceAuthority, msg3.slice(0, 300)) : null;
         const preOFailure = platform === "android" && isOlderSdkInstallFailure(capturedOutput) ? olderSdkInstallDiagnosis(flowDispatch.runner) : null;
         results.push({
           name,
           passed: false,
           durationMs: now() - start,
-          error: preOFailure ?? authorityRefusal ?? msg3.slice(0, 300),
+          error: preOFailure ?? authorityRefusal2 ?? msg3.slice(0, 300),
           ...deviceAuthority && !preOFailure ? { deviceAuthority } : {}
         });
         failed++;
@@ -94931,7 +95201,7 @@ var init_connect_exact_session_target = __esm({
     "use strict";
     init_connect();
     init_discovery();
-    init_status();
+    init_session_target();
     init_target_device_authority();
     IOS_EXACT_TARGET_READINESS_TIMEOUT_MS = 12e4;
     ANDROID_EXACT_TARGET_READINESS_TIMEOUT_MS = 12e4;
@@ -95628,6 +95898,7 @@ var init_index = __esm({
     init_metro_authority();
     init_target_device_authority();
     init_connect_exact_session_target();
+    init_session_target();
     init_source_identity();
     init_managed_metro();
     init_process_cleanup();
@@ -96198,12 +96469,15 @@ var init_index = __esm({
       confirmed: external_exports.boolean().describe("Authorizes inline proven-dead device cleanup").optional(),
       force: external_exports.boolean().optional()
     }, sessionHandler);
-    trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
+    trackedTool("cdp_status", "Passively report the current authority session, Metro client, and CDP target. waitForTargetMs observes only the exact bound target without connecting, relaunching, dismissing UI, or choosing an ambient target.", {
       metroPort: external_exports.number().optional().describe("Diagnostic comparison only; cdp_status never changes the active Metro port"),
-      platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups')
+      platform: external_exports.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups'),
+      waitForTargetMs: external_exports.number().int().min(1).max(12e4).optional().describe("Bounded passive wait for the exact authority-bound Hermes target")
     }, createPassiveStatusHandler(getClient, authorityRuntime, {
       getSignerCapability: getSessionSignerCapability,
-      onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy()
+      onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy(),
+      listTargetsExact: listTargetsOnExactPort,
+      filterTargetsForExactDevice: (input, awaitWithinBoundary) => filterTargetsForExactDevice(input, { execute: execFileP, awaitWithinBoundary })
     }));
     trackedTool("observe", "Start/stop the read-only observability web UI (watch the agent's live tool-call timeline, device screenshot, and app state). action: start|stop|status.", observeSchema, observeHandler);
     trackedTool("cdp_diagnostic_renderers", 'Diagnostic helper for "fiber root invisibility" bug reports (issue #126 follow-up). Enumerates every registered React renderer and its root count via __REACT_DEVTOOLS_GLOBAL_HOOK__. Returns hook keys, renderer Map keys, per-renderer-id root summaries (top fiber type + first child + testID), and notes when renderers are registered but unscanned. Use this when cdp_component_tree returns empty for a component you know is mounted (modals, portals, sub-apps), or when bug-reporting fiber-walk failures.', {

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -17,7 +17,7 @@ import { okResult, failResult, withConnection } from './utils.js';
 import { annotateMutationAbsence } from './verification/mutation-absence.js';
 import { loadVerificationConfig, getCachedProjectRoot } from './verification/config.js';
 import { logger } from './logger.js';
-import { createPassiveStatusHandler, targetMatchesSession } from './tools/status.js';
+import { createPassiveStatusHandler } from './tools/status.js';
 import { createEvaluateHandler } from './tools/evaluate.js';
 import { createReloadHandler } from './tools/reload.js';
 import { createComponentTreeHandler } from './tools/component-tree.js';
@@ -233,6 +233,7 @@ import { createForeignMetroOriginScanner } from './session/metro-origin.js';
 import {
   DISCOVERY_TIMEOUT_MS,
   discoverAllMetroPorts,
+  listTargetsOnExactPort,
   resolveDefaultPorts,
   mapRegistryDeviceBinding,
   setRegistryDeviceBindingProvider,
@@ -261,6 +262,7 @@ import {
   exactSessionTargetReadinessTimeoutMs,
   type ExactSessionTargetConnection,
 } from './session/connect-exact-session-target.js';
+import { targetMatchesSession } from './session/session-target.js';
 import type { SessionStatus } from './session/registry.js';
 import { strictProofSourceIdentity, type SourceIdentity } from './session/source-identity.js';
 import { verifyManagedMetroManagementProof } from './session/managed-metro.js';
@@ -1613,7 +1615,7 @@ trackedTool(
 
 trackedTool(
   'cdp_status',
-  'Passively report the current authority session, Metro client, and CDP target without connecting, relaunching, dismissing UI, or choosing an ambient target.',
+  'Passively report the current authority session, Metro client, and CDP target. waitForTargetMs observes only the exact bound target without connecting, relaunching, dismissing UI, or choosing an ambient target.',
   {
     metroPort: z
       .number()
@@ -1625,10 +1627,20 @@ trackedTool(
       .describe(
         'Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups',
       ),
+    waitForTargetMs: z
+      .number()
+      .int()
+      .min(1)
+      .max(120_000)
+      .optional()
+      .describe('Bounded passive wait for the exact authority-bound Hermes target'),
   },
   createPassiveStatusHandler(getClient, authorityRuntime, {
     getSignerCapability: getSessionSignerCapability,
     onBundleInvalidated: () => getClient().clearAuthoritativeSessionPolicy(),
+    listTargetsExact: listTargetsOnExactPort,
+    filterTargetsForExactDevice: (input, awaitWithinBoundary) =>
+      filterTargetsForExactDevice(input, { execute: execFileP, awaitWithinBoundary }),
   }),
 );
 

--- a/packages/rn-dev-agent-core/src/session/connect-exact-session-target.ts
+++ b/packages/rn-dev-agent-core/src/session/connect-exact-session-target.ts
@@ -1,7 +1,7 @@
 import type { CDPClient } from '../cdp-client.js';
 import { CDPProbeTimeoutError } from '../cdp/connect.js';
 import { describeTarget, targetMatchesBundleId } from '../cdp/discovery.js';
-import { targetMatchesSession } from '../tools/status.js';
+import { targetMatchesSession } from './session-target.js';
 import type { HermesTarget } from '../types.js';
 import {
   filterTargetsForExactDevice,

--- a/packages/rn-dev-agent-core/src/session/session-runtime-absence.ts
+++ b/packages/rn-dev-agent-core/src/session/session-runtime-absence.ts
@@ -1,5 +1,5 @@
 import type { HermesTarget } from '../types.js';
-import { targetMatchesSession } from '../tools/status.js';
+import { targetMatchesSession } from './session-target.js';
 import { buildAndroidPidofArgs, buildIosAppRunningArgs } from '../tools/device-session.js';
 
 export interface SessionRuntimeBinding {

--- a/packages/rn-dev-agent-core/src/session/session-target.ts
+++ b/packages/rn-dev-agent-core/src/session/session-target.ts
@@ -1,0 +1,25 @@
+import type { ConnectFilters } from '../cdp/connect.js';
+import { androidTargetMatchesKind, targetMatchesBundleId } from '../cdp/discovery.js';
+import type { HermesTarget } from '../types.js';
+
+export function targetMatchesSession(
+  target: HermesTarget | null,
+  filters: ConnectFilters,
+): boolean {
+  if (!target) return false;
+  if (
+    filters.platform &&
+    (target.platform !== filters.platform ||
+      target.platformInference === 'defaulted' ||
+      target.platformInference === 'ambiguous')
+  )
+    return false;
+  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId)) return false;
+  if (
+    filters.deviceKind === 'physical' &&
+    !androidTargetMatchesKind(target.deviceName, filters.deviceKind)
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/packages/rn-dev-agent-core/src/session/wait-for-exact-session-target.ts
+++ b/packages/rn-dev-agent-core/src/session/wait-for-exact-session-target.ts
@@ -1,0 +1,322 @@
+import type { AwaitWithinBoundary } from '../cdp-client.js';
+import type { ToolErrorCode, HermesTarget } from '../types.js';
+import type { WorkerAuthorityStatus } from './runtime.js';
+import { targetMatchesSession } from './session-target.js';
+
+const TARGET_POLL_INTERVAL_MS = 250;
+
+interface ExactDeviceTargetInput {
+  platform: 'ios' | 'android';
+  deviceId: string;
+  targets: readonly HermesTarget[];
+}
+
+export interface ExactSessionTargetWaitDependencies {
+  readAuthority(): WorkerAuthorityStatus;
+  listTargetsExact(port: number): Promise<{ port: number; targets: HermesTarget[] }>;
+  filterTargetsForExactDevice(
+    input: ExactDeviceTargetInput,
+    awaitWithinBoundary: AwaitWithinBoundary,
+  ): Promise<HermesTarget[]>;
+  now?(): number;
+  wait?(ms: number): Promise<void>;
+  setDeadlineTimer?(callback: () => void, ms: number): unknown;
+  clearDeadlineTimer?(timer: unknown): void;
+}
+
+export interface ExactSessionTargetWaitObservation {
+  advertisedTargetCount: number;
+  sessionTargetCount: number;
+  exactTargetCount: number;
+}
+
+export type ExactSessionTargetWaitResult =
+  | {
+      outcome: 'ready';
+      requestedMs: number;
+      elapsedMs: number;
+      probes: number;
+      lastObservation: ExactSessionTargetWaitObservation;
+      authority: Extract<WorkerAuthorityStatus, { available: true }>;
+    }
+  | {
+      outcome: 'timeout';
+      requestedMs: number;
+      elapsedMs: number;
+      probes: number;
+      lastObservation: ExactSessionTargetWaitObservation | null;
+    }
+  | {
+      outcome: 'refused';
+      requestedMs: number;
+      elapsedMs: number;
+      probes: number;
+      code: ToolErrorCode;
+      reason: string;
+      lastObservation: ExactSessionTargetWaitObservation | null;
+    };
+
+class TargetWaitDeadlineError extends Error {}
+
+function authorityRefusal(
+  status: WorkerAuthorityStatus,
+): { code: ToolErrorCode; reason: string } | null {
+  if (!status.available) {
+    return {
+      code: status.code as ToolErrorCode,
+      reason:
+        'Waiting for a Hermes target requires an available authority session; inspect rn_session status.',
+    };
+  }
+  if (status.state === 'blocked' || status.state === 'handoff_cleanup') {
+    return {
+      code: 'SESSION_AUTHORITY_REQUIRED',
+      reason: 'The current worker does not own this worktree; inspect rn_session status.',
+    };
+  }
+  const terminal = status.bindings.metroTerminal as
+    | { code?: unknown; reason?: unknown }
+    | undefined;
+  if (terminal) {
+    return {
+      code: 'METRO_AUTHORITY_MISMATCH',
+      reason:
+        typeof terminal.reason === 'string'
+          ? terminal.reason
+          : 'The authority-bound Metro is no longer live.',
+    };
+  }
+  const device = status.bindings.device as
+    | { platform?: unknown; deviceId?: unknown; appId?: unknown }
+    | undefined;
+  if (
+    !device ||
+    (device.platform !== 'ios' && device.platform !== 'android') ||
+    typeof device.deviceId !== 'string' ||
+    typeof device.appId !== 'string'
+  ) {
+    return {
+      code: 'CDP_TARGET_AUTHORITY_MISMATCH',
+      reason: 'Waiting for a Hermes target requires an exact session device and app binding.',
+    };
+  }
+  return null;
+}
+
+function targetBinding(status: Extract<WorkerAuthorityStatus, { available: true }>) {
+  const device = status.bindings.device as {
+    platform: 'ios' | 'android';
+    deviceId: string;
+    appId: string;
+  };
+  const metro = status.bindings.metro as { port?: unknown; mode?: unknown } | undefined;
+  const port = metro?.port;
+  if (!Number.isSafeInteger(port) || (metro?.mode !== 'managed' && metro?.mode !== 'external')) {
+    return null;
+  }
+  return {
+    sessionId: status.sessionId,
+    claimEpoch: status.claimEpoch,
+    authorityVersion: status.authorityVersion,
+    platform: device.platform,
+    deviceId: device.deviceId,
+    appId: device.appId,
+    metroMode: metro.mode,
+    metroPort: Number(port),
+  };
+}
+
+function sameTargetBinding(
+  left: NonNullable<ReturnType<typeof targetBinding>>,
+  right: NonNullable<ReturnType<typeof targetBinding>>,
+): boolean {
+  return (
+    left.sessionId === right.sessionId &&
+    left.claimEpoch === right.claimEpoch &&
+    left.authorityVersion === right.authorityVersion &&
+    left.platform === right.platform &&
+    left.deviceId === right.deviceId &&
+    left.appId === right.appId &&
+    left.metroMode === right.metroMode &&
+    left.metroPort === right.metroPort
+  );
+}
+
+export async function waitForExactSessionTarget(
+  timeoutMs: number,
+  dependencies: ExactSessionTargetWaitDependencies,
+): Promise<ExactSessionTargetWaitResult> {
+  const now = dependencies.now ?? Date.now;
+  const wait =
+    dependencies.wait ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const setDeadlineTimer =
+    dependencies.setDeadlineTimer ??
+    ((callback: () => void, ms: number) => setTimeout(callback, ms));
+  const clearDeadlineTimer =
+    dependencies.clearDeadlineTimer ?? ((timer: unknown) => clearTimeout(timer as NodeJS.Timeout));
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  let probes = 0;
+  let lastObservation: ExactSessionTargetWaitObservation | null = null;
+
+  const elapsedMs = () => Math.max(0, Math.min(timeoutMs, now() - startedAt));
+  const timeoutResult = (): ExactSessionTargetWaitResult => ({
+    outcome: 'timeout',
+    requestedMs: timeoutMs,
+    elapsedMs: elapsedMs(),
+    probes,
+    lastObservation,
+  });
+  const awaitWithinDeadline: AwaitWithinBoundary = async <T>(operation: () => Promise<T>) => {
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) throw new TargetWaitDeadlineError();
+    let timer: unknown;
+    try {
+      const result = await Promise.race([
+        operation(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setDeadlineTimer(() => reject(new TargetWaitDeadlineError()), remainingMs);
+        }),
+      ]);
+      if (now() >= deadline) throw new TargetWaitDeadlineError();
+      return result;
+    } finally {
+      if (timer !== undefined) clearDeadlineTimer(timer);
+    }
+  };
+
+  while (now() < deadline) {
+    const authority = dependencies.readAuthority();
+    const refusal = authorityRefusal(authority);
+    if (refusal) {
+      return {
+        outcome: 'refused',
+        requestedMs: timeoutMs,
+        elapsedMs: elapsedMs(),
+        probes,
+        ...refusal,
+        lastObservation,
+      };
+    }
+    if (!authority.available) throw new Error('unreachable');
+    const binding = targetBinding(authority);
+    if (!binding) {
+      if (!authority.bindings.pendingBuild) {
+        return {
+          outcome: 'refused',
+          requestedMs: timeoutMs,
+          elapsedMs: elapsedMs(),
+          probes,
+          code: 'METRO_AUTHORITY_MISMATCH',
+          reason: 'Waiting for a Hermes target requires a live authority-bound Metro.',
+          lastObservation,
+        };
+      }
+    } else {
+      let exactDeviceProbeStarted = false;
+      try {
+        const listed = await awaitWithinDeadline(() =>
+          dependencies.listTargetsExact(binding.metroPort),
+        );
+        probes += 1;
+        if (listed.port !== binding.metroPort) {
+          return {
+            outcome: 'refused',
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: 'CDP_TARGET_AUTHORITY_MISMATCH',
+            reason: 'Target discovery escaped the authority-bound Metro port.',
+            lastObservation,
+          };
+        }
+        const sessionTargets = listed.targets.filter((target) =>
+          targetMatchesSession(target, {
+            platform: binding.platform,
+            bundleId: binding.appId,
+          }),
+        );
+        let exactTargets: HermesTarget[] = [];
+        if (sessionTargets.length > 0) {
+          exactDeviceProbeStarted = true;
+          exactTargets = await awaitWithinDeadline(() =>
+            dependencies.filterTargetsForExactDevice(
+              {
+                platform: binding.platform,
+                deviceId: binding.deviceId,
+                targets: sessionTargets,
+              },
+              awaitWithinDeadline,
+            ),
+          );
+        }
+        lastObservation = {
+          advertisedTargetCount: listed.targets.length,
+          sessionTargetCount: sessionTargets.length,
+          exactTargetCount: exactTargets.length,
+        };
+        const refreshedAuthority = dependencies.readAuthority();
+        const refreshedRefusal = authorityRefusal(refreshedAuthority);
+        if (refreshedRefusal) {
+          return {
+            outcome: 'refused',
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            ...refreshedRefusal,
+            lastObservation: null,
+          };
+        }
+        if (!refreshedAuthority.available) throw new Error('unreachable');
+        const refreshedBinding = targetBinding(refreshedAuthority);
+        if (!refreshedBinding || !sameTargetBinding(binding, refreshedBinding)) {
+          lastObservation = null;
+        } else if (exactTargets.length === 1) {
+          return {
+            outcome: 'ready',
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            lastObservation,
+            authority: refreshedAuthority,
+          };
+        } else if (exactTargets.length > 1) {
+          return {
+            outcome: 'refused',
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: 'CDP_TARGET_AUTHORITY_MISMATCH',
+            reason: 'More than one target matches the exact session device.',
+            lastObservation,
+          };
+        }
+      } catch (error) {
+        if (error instanceof TargetWaitDeadlineError) return timeoutResult();
+        if (exactDeviceProbeStarted) {
+          return {
+            outcome: 'refused',
+            requestedMs: timeoutMs,
+            elapsedMs: elapsedMs(),
+            probes,
+            code: 'CDP_TARGET_AUTHORITY_MISMATCH',
+            reason:
+              'The advertised Hermes target cannot be associated with the exact session device.',
+            lastObservation,
+          };
+        }
+      }
+    }
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) return timeoutResult();
+    try {
+      await awaitWithinDeadline(() => wait(Math.min(TARGET_POLL_INTERVAL_MS, remainingMs)));
+    } catch (error) {
+      if (error instanceof TargetWaitDeadlineError) return timeoutResult();
+      throw error;
+    }
+  }
+
+  return timeoutResult();
+}

--- a/packages/rn-dev-agent-core/src/tools/connection.ts
+++ b/packages/rn-dev-agent-core/src/tools/connection.ts
@@ -2,7 +2,8 @@ import type { CDPClient } from '../cdp-client.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
-import { sessionConnectFilters, targetMatchesSession } from './status.js';
+import { sessionConnectFilters } from './status.js';
+import { targetMatchesSession } from '../session/session-target.js';
 import { TargetSelectionError } from '../cdp/discovery.js';
 import type { ConnectFilters } from '../cdp/connect.js';
 

--- a/packages/rn-dev-agent-core/src/tools/reload.ts
+++ b/packages/rn-dev-agent-core/src/tools/reload.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 import type { CDPClient } from '../cdp-client.js';
 import { okResult, failResult, warnResult, withConnection } from '../utils.js';
 import { isValidBundleId } from '../domain/maestro-validator.js';
-import { targetMatchesSession } from './status.js';
+import { targetMatchesSession } from '../session/session-target.js';
 import { filterTargetsForExactDevice } from '../session/target-device-authority.js';
 
 const defaultExecFile = promisify(execFileCb);

--- a/packages/rn-dev-agent-core/src/tools/restart.ts
+++ b/packages/rn-dev-agent-core/src/tools/restart.ts
@@ -9,7 +9,7 @@ import type { SnapshotHint } from '../cdp/app-installed-probe.js';
 import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 import { isValidBundleId } from '../domain/maestro-validator.js';
-import { targetMatchesSession } from './status.js';
+import { targetMatchesSession } from '../session/session-target.js';
 import { filterTargetsForExactDevice } from '../session/target-device-authority.js';
 import type { ToolResult } from '../utils.js';
 

--- a/packages/rn-dev-agent-core/src/tools/status.ts
+++ b/packages/rn-dev-agent-core/src/tools/status.ts
@@ -14,11 +14,9 @@ import {
   AppDetachedError,
   MetroNotFoundError,
   TargetSelectionError,
-  androidTargetMatchesKind,
   anyMetroRunning,
   enumerateMetroCandidates,
   targetBundleIdentity,
-  targetMatchesBundleId,
 } from '../cdp/discovery.js';
 import { resolveBridgeProjectRoot, pathMatchesRoot } from '../cdp/metro-cwd.js';
 import { getDeviceSessionHealth } from './device-session-health.js';
@@ -28,11 +26,18 @@ import { storeMode } from '../domain/action-state-store.js';
 import { getEngineStatus } from '../domain/engine-pin.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import type { ConnectFilters } from '../cdp/connect.js';
-import type { HermesTarget } from '../types.js';
 import type { WorkerAuthorityRuntime } from '../session/runtime.js';
 import { inspectInstallIdentity } from '../session/install-identity-inspection.js';
 import { projectPublicAuthorityStatus } from '../session/public-status.js';
 import { reconcileManagedMetroStatus, type ManagedMetroStatusDependencies } from './session.js';
+import { targetMatchesSession } from '../session/session-target.js';
+import {
+  waitForExactSessionTarget,
+  type ExactSessionTargetWaitDependencies,
+  type ExactSessionTargetWaitResult,
+} from '../session/wait-for-exact-session-target.js';
+
+export { targetMatchesSession } from '../session/session-target.js';
 
 export function sessionConnectFilters(
   session: ReturnType<typeof getActiveSession>,
@@ -47,43 +52,47 @@ export function sessionConnectFilters(
   };
 }
 
-export function targetMatchesSession(
-  target: HermesTarget | null,
-  filters: ConnectFilters,
-): boolean {
-  if (!target) return false;
-  if (
-    filters.platform &&
-    (target.platform !== filters.platform ||
-      target.platformInference === 'defaulted' ||
-      target.platformInference === 'ambiguous')
-  )
-    return false;
-  if (filters.bundleId && !targetMatchesBundleId(target, filters.bundleId)) return false;
-  if (
-    filters.deviceKind === 'physical' &&
-    !androidTargetMatchesKind(target.deviceName, filters.deviceKind)
-  ) {
-    return false;
-  }
-  return true;
-}
-
 export function createPassiveStatusHandler(
   getClient: () => CDPClient,
   authorityRuntime: WorkerAuthorityRuntime,
-  statusDependencies: ManagedMetroStatusDependencies = {},
+  statusDependencies: ManagedMetroStatusDependencies &
+    Partial<Omit<ExactSessionTargetWaitDependencies, 'readAuthority'>> = {},
 ) {
-  return async (args: { metroPort?: number; platform?: string }) => {
+  return async (args: { metroPort?: number; platform?: string; waitForTargetMs?: number }) => {
+    let targetWait: ExactSessionTargetWaitResult | undefined;
+    if (args.waitForTargetMs !== undefined) {
+      if (!statusDependencies.listTargetsExact || !statusDependencies.filterTargetsForExactDevice) {
+        return failResult(
+          'The passive Hermes target waiter is unavailable in this runtime.',
+          'NOT_IMPLEMENTED',
+        );
+      }
+      targetWait = await waitForExactSessionTarget(args.waitForTargetMs, {
+        readAuthority: () => reconcileManagedMetroStatus(authorityRuntime, statusDependencies),
+        listTargetsExact: statusDependencies.listTargetsExact,
+        filterTargetsForExactDevice: statusDependencies.filterTargetsForExactDevice,
+        ...(statusDependencies.now ? { now: statusDependencies.now } : {}),
+        ...(statusDependencies.wait ? { wait: statusDependencies.wait } : {}),
+        ...(statusDependencies.setDeadlineTimer
+          ? { setDeadlineTimer: statusDependencies.setDeadlineTimer }
+          : {}),
+        ...(statusDependencies.clearDeadlineTimer
+          ? { clearDeadlineTimer: statusDependencies.clearDeadlineTimer }
+          : {}),
+      });
+    }
     const client = getClient();
     const target = client.connectedTarget;
-    const authority = reconcileManagedMetroStatus(authorityRuntime, statusDependencies);
+    const authority =
+      targetWait?.outcome === 'ready'
+        ? targetWait.authority
+        : reconcileManagedMetroStatus(authorityRuntime, statusDependencies);
     const installIdentity = authority.available
       ? (statusDependencies.inspectInstallIdentity ?? inspectInstallIdentity)(
           authority.bindings.install as Record<string, unknown> | null | undefined,
         )
       : null;
-    return okResult({
+    const data = {
       authoritative: false,
       authority: projectPublicAuthorityStatus(authority, { installIdentity }),
       metro: {
@@ -104,7 +113,29 @@ export function createPassiveStatusHandler(
       nextAction: client.isConnected
         ? 'Use rn_session status to inspect bindings before authoritative tools.'
         : 'Use rn_session bind_metro and cdp_connect with the claimed exact port.',
-    });
+      ...(targetWait
+        ? {
+            targetWait: {
+              requestedMs: targetWait.requestedMs,
+              elapsedMs: targetWait.elapsedMs,
+              outcome: targetWait.outcome,
+              probes: targetWait.probes,
+              lastObservation: targetWait.lastObservation,
+            },
+          }
+        : {}),
+    };
+    if (targetWait?.outcome === 'timeout') {
+      return failResult(
+        `Timed out after ${targetWait.requestedMs}ms waiting for the exact authority-bound Hermes target.`,
+        'CDP_TARGET_WAIT_TIMEOUT',
+        data,
+      );
+    }
+    if (targetWait?.outcome === 'refused') {
+      return failResult(targetWait.reason, targetWait.code, data);
+    }
+    return okResult(data);
   };
 }
 

--- a/packages/rn-dev-agent-core/src/types.ts
+++ b/packages/rn-dev-agent-core/src/types.ts
@@ -271,6 +271,7 @@ export type ToolErrorCode =
   | 'HELPERS_STALE'
   | 'DEV_MENU_HIDE_FAILED'
   | 'RECONNECT_TIMEOUT'
+  | 'CDP_TARGET_WAIT_TIMEOUT'
   | 'CONNECT_IN_FLIGHT' // GH #616: a reconnect/connect is in flight; force=true supersedes it
   | 'APP_DETACHED' // GH #208 (RC2/RC3): Metro up but 0 Hermes targets (app detached)
   | 'DEV_MENU_HIDE_UNVERIFIED'

--- a/packages/rn-dev-agent-core/test/unit/session/cdp-status-wait-for-target.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/cdp-status-wait-for-target.test.ts
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createPassiveStatusHandler } from '../../../dist/tools/status.js';
+
+const METRO_PORT = 8193;
+
+function authorityStatus() {
+  return {
+    available: true as const,
+    sessionId: 'session-secret',
+    sourceKey: 'source-secret',
+    worktreeKey: 'worktree-secret',
+    appRootKey: 'app-root-secret',
+    state: 'device_bound',
+    claimEpoch: 2,
+    authorityVersion: 9,
+    leaseUntilMs: 100,
+    source: { kind: 'git' },
+    bindings: {
+      metroPort: METRO_PORT,
+      metro: { mode: 'external', port: METRO_PORT },
+      device: {
+        platform: 'ios',
+        deviceId: 'device-id-secret',
+        appId: 'com.example.secret',
+      },
+    } as Record<string, unknown>,
+    claims: [],
+    worker: { instanceId: 'worker-secret', pid: 1, birthAvailable: true },
+  };
+}
+
+function client() {
+  return {
+    isConnected: false,
+    metroPort: METRO_PORT,
+    connectedTarget: null,
+  } as never;
+}
+
+const exactTarget = {
+  id: 'target-id-secret',
+  title: 'target-title-secret',
+  appId: 'com.example.secret',
+  deviceName: 'iPhone Secret',
+  platform: 'ios' as const,
+  platformInference: 'probed' as const,
+  webSocketDebuggerUrl: `ws://127.0.0.1:${METRO_PORT}/secret`,
+};
+
+test('cdp_status waits passively for the exact target and omission performs zero probes', async () => {
+  let now = 0;
+  let listCalls = 0;
+  let exactDeviceCalls = 0;
+  const handler = createPassiveStatusHandler(client, { status: authorityStatus } as never, {
+    now: () => now,
+    wait: async (ms) => {
+      now += ms;
+    },
+    listTargetsExact: async () => {
+      listCalls += 1;
+      return {
+        port: METRO_PORT,
+        targets: listCalls === 1 ? [] : [exactTarget],
+      };
+    },
+    filterTargetsForExactDevice: async ({ targets }) => {
+      exactDeviceCalls += 1;
+      return [...targets];
+    },
+  });
+
+  const immediate = await handler({});
+  assert.equal(immediate.isError, undefined);
+  assert.equal(listCalls, 0);
+  assert.equal(exactDeviceCalls, 0);
+
+  const waited = await handler({ waitForTargetMs: 1_000 });
+  const envelope = JSON.parse(waited.content[0]!.text);
+  assert.equal(waited.isError, undefined, waited.content[0]!.text);
+  assert.equal(envelope.data.targetWait.outcome, 'ready');
+  assert.equal(envelope.data.targetWait.probes, 2);
+  assert.equal(listCalls, 2);
+  assert.equal(exactDeviceCalls, 1);
+  for (const secret of [
+    'session-secret',
+    'device-id-secret',
+    'com.example.secret',
+    'target-id-secret',
+    'target-title-secret',
+    'iPhone Secret',
+  ]) {
+    assert.equal(waited.content[0]!.text.includes(secret), false);
+  }
+});
+
+test('cdp_status rejects foreign targets until its explicit wait deadline', async () => {
+  let now = 0;
+  let listCalls = 0;
+  let exactDeviceCalls = 0;
+  const handler = createPassiveStatusHandler(client, { status: authorityStatus } as never, {
+    now: () => now,
+    wait: async (ms) => {
+      now += ms;
+    },
+    listTargetsExact: async () => {
+      listCalls += 1;
+      return {
+        port: METRO_PORT,
+        targets: [exactTarget],
+      };
+    },
+    filterTargetsForExactDevice: async () => {
+      exactDeviceCalls += 1;
+      return [];
+    },
+  });
+
+  const result = await handler({ waitForTargetMs: 500 });
+  const envelope = JSON.parse(result.content[0]!.text);
+  assert.equal(result.isError, true);
+  assert.equal(envelope.code, 'CDP_TARGET_WAIT_TIMEOUT');
+  assert.equal(envelope.meta.targetWait.outcome, 'timeout');
+  assert.deepEqual(envelope.meta.targetWait.lastObservation, {
+    advertisedTargetCount: 1,
+    sessionTargetCount: 1,
+    exactTargetCount: 0,
+  });
+  assert.equal(envelope.meta.targetWait.elapsedMs, 500);
+  assert.equal(listCalls, 2);
+  assert.equal(exactDeviceCalls, 2);
+});
+
+test('cdp_status preserves exact-device authority refusal without leaking probe details', async () => {
+  const handler = createPassiveStatusHandler(client, { status: authorityStatus } as never, {
+    listTargetsExact: async () => ({ port: METRO_PORT, targets: [exactTarget] }),
+    filterTargetsForExactDevice: async () => {
+      throw new Error(
+        'CDP_TARGET_AUTHORITY_MISMATCH: foreign device /private/secret/device-id-secret',
+      );
+    },
+  });
+
+  const result = await handler({ waitForTargetMs: 1_000 });
+  const envelope = JSON.parse(result.content[0]!.text);
+  assert.equal(result.isError, true);
+  assert.equal(envelope.code, 'CDP_TARGET_AUTHORITY_MISMATCH');
+  assert.equal(envelope.error.includes('/private/secret'), false);
+  assert.equal(result.content[0]!.text.includes('device-id-secret'), false);
+});
+
+test('cdp_status refuses when exact-device association cannot be measured', async () => {
+  const handler = createPassiveStatusHandler(client, { status: authorityStatus } as never, {
+    listTargetsExact: async () => ({ port: METRO_PORT, targets: [exactTarget] }),
+    filterTargetsForExactDevice: async () => {
+      throw new Error('xcrun inventory failed at /private/secret/inventory');
+    },
+  });
+
+  const result = await handler({ waitForTargetMs: 1_000 });
+  const envelope = JSON.parse(result.content[0]!.text);
+  assert.equal(result.isError, true);
+  assert.equal(envelope.code, 'CDP_TARGET_AUTHORITY_MISMATCH');
+  assert.equal(result.content[0]!.text.includes('/private/secret'), false);
+});
+
+test('cdp_status wait redacts an unavailable authority reason', async () => {
+  let listCalls = 0;
+  const handler = createPassiveStatusHandler(
+    client,
+    {
+      status: () => ({
+        available: false,
+        code: 'SESSION_NOT_INITIALIZED',
+        reason: 'registry failed at /private/secret/session-source',
+      }),
+    } as never,
+    {
+      listTargetsExact: async () => {
+        listCalls += 1;
+        return { port: METRO_PORT, targets: [] };
+      },
+      filterTargetsForExactDevice: async ({ targets }) => [...targets],
+    },
+  );
+
+  const result = await handler({ waitForTargetMs: 1_000 });
+  const envelope = JSON.parse(result.content[0]!.text);
+  assert.equal(result.isError, true);
+  assert.equal(envelope.code, 'SESSION_NOT_INITIALIZED');
+  assert.equal(result.content[0]!.text.includes('/private/secret'), false);
+  assert.equal(listCalls, 0);
+});
+
+test('cdp_status does not report ready after the exact authority binding changes', async () => {
+  let now = 0;
+  let statusCalls = 0;
+  const changedAuthority = {
+    ...authorityStatus(),
+    authorityVersion: 10,
+    bindings: {
+      ...authorityStatus().bindings,
+      device: {
+        platform: 'ios',
+        deviceId: 'replacement-device',
+        appId: 'com.example.replacement',
+      },
+    },
+  };
+  const handler = createPassiveStatusHandler(
+    client,
+    {
+      status: () => {
+        statusCalls += 1;
+        return statusCalls === 1 ? authorityStatus() : changedAuthority;
+      },
+    } as never,
+    {
+      now: () => now,
+      wait: async (ms) => {
+        now += ms;
+      },
+      listTargetsExact: async () => ({ port: METRO_PORT, targets: [exactTarget] }),
+      filterTargetsForExactDevice: async ({ targets }) => [...targets],
+    },
+  );
+
+  const result = await handler({ waitForTargetMs: 500 });
+  const envelope = JSON.parse(result.content[0]!.text);
+  assert.equal(result.isError, true);
+  assert.equal(envelope.code, 'CDP_TARGET_WAIT_TIMEOUT');
+  assert.equal(envelope.meta.targetWait.outcome, 'timeout');
+});
+
+test('cdp_status ready response uses the authority snapshot that proved the target', async () => {
+  let statusCalls = 0;
+  const changedAuthority = {
+    ...authorityStatus(),
+    authorityVersion: 10,
+    bindings: {
+      ...authorityStatus().bindings,
+      device: {
+        platform: 'android',
+        deviceId: 'replacement-device',
+        appId: 'com.example.replacement',
+      },
+    },
+  };
+  const handler = createPassiveStatusHandler(
+    client,
+    {
+      status: () => {
+        statusCalls += 1;
+        return statusCalls <= 2 ? authorityStatus() : changedAuthority;
+      },
+    } as never,
+    {
+      listTargetsExact: async () => ({ port: METRO_PORT, targets: [exactTarget] }),
+      filterTargetsForExactDevice: async ({ targets }) => [...targets],
+    },
+  );
+
+  const result = await handler({ waitForTargetMs: 1_000 });
+  const envelope = JSON.parse(result.content[0]!.text);
+  assert.equal(result.isError, undefined, result.content[0]!.text);
+  assert.equal(envelope.data.targetWait.outcome, 'ready');
+  assert.equal(envelope.data.authority.platform, 'ios');
+  assert.equal(statusCalls, 2);
+});
+
+test('cdp_status rejects target proof that resolves after the absolute deadline', async () => {
+  let now = 0;
+  const handler = createPassiveStatusHandler(client, { status: authorityStatus } as never, {
+    now: () => now,
+    listTargetsExact: async () => ({ port: METRO_PORT, targets: [exactTarget] }),
+    filterTargetsForExactDevice: async ({ targets }) => {
+      now = 1_001;
+      return [...targets];
+    },
+  });
+
+  const result = await handler({ waitForTargetMs: 1_000 });
+  const envelope = JSON.parse(result.content[0]!.text);
+  assert.equal(result.isError, true);
+  assert.equal(envelope.code, 'CDP_TARGET_WAIT_TIMEOUT');
+  assert.equal(envelope.meta.targetWait.outcome, 'timeout');
+});
+
+test('cdp_status absolute deadline bounds a stalled exact-port probe', async () => {
+  const handler = createPassiveStatusHandler(client, { status: authorityStatus } as never, {
+    listTargetsExact: () => new Promise(() => {}),
+    filterTargetsForExactDevice: async ({ targets }) => [...targets],
+  });
+  const startedAt = Date.now();
+  const result = await handler({ waitForTargetMs: 20 });
+  const elapsedMs = Date.now() - startedAt;
+  const envelope = JSON.parse(result.content[0]!.text);
+
+  assert.equal(result.isError, true);
+  assert.equal(envelope.code, 'CDP_TARGET_WAIT_TIMEOUT');
+  assert.ok(elapsedMs < 250, `absolute target wait took ${elapsedMs}ms`);
+});

--- a/packages/shared-agent-knowledge/commands/check-env.md
+++ b/packages/shared-agent-knowledge/commands/check-env.md
@@ -58,7 +58,7 @@ If issues are found, suggest the appropriate fix:
 | Session `state: blocked` | Another session owns this worktree. Report `recoveryRequirement.nextAction` verbatim (plus `startupCleanupBlocked` when present) and stop — do not run setup, do not bind a device, do not pick another booted device. See `using-rn-dev-agent` § "Session ownership recovery" |
 | Session missing or genuinely unbound (not `blocked`) | Run setup, review/apply the integration preview, and bind the intended device and app |
 | Metro not found | Use literal `pnpm ios` or `pnpm android` through the confirmed integration |
-| No Hermes target | Open the bound app, then call `cdp_connect` for the exact signed target |
+| No Hermes target | Open the bound app, wait with `cdp_status({ waitForTargetMs: 120000 })`, then call `cdp_connect` for the exact signed target |
 | CDP code 1006 | Close React Native DevTools, Flipper, Chrome DevTools |
 | `cdp_component_tree` reports RedBox | Run `/rn-dev-agent:debug-screen` |
 | Narrow gated CDP read times out | Check for a blocked JS thread, then use `cdp_reload` |


### PR DESCRIPTION
## Summary

- add an optional bounded `cdp_status` wait for the exact authority-bound Hermes target
- preserve immediate passive status behavior when the option is omitted
- return typed, redacted timeout and authority refusals without connecting, relaunching, or selecting ambient targets

## Validation

- focused waiter and status-redaction regressions pass
- lint, formatting, generated runtime freshness, package sync, and TypeScript-only gates pass
- strict proof capture pending; this draft exists solely to bind the proof receipt to an exact PR head

Closes #524