### PR TITLE
fix(claude-plugin): keep SessionStart runner verification offline

### DIFF
--- a/.changeset/spotty-donkeys-refuse.md
+++ b/.changeset/spotty-donkeys-refuse.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+SessionStart no longer downloads the maestro-runner: it verifies the pin-cache offline and prints the explicit pinned install command instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,13 @@ sibling workspace only when explicitly requested.
   `observe-*.png`, simulator screenshots, temporary logs, or proof captures.
 - Do not add or restore `BUGS.md`. Bugs are tracked in GitHub Issues.
 - The SessionStart hook (`packages/claude-plugin/hooks/detect-rn-project.sh`)
-  must never fetch or execute network content. It verifies the runner with
+  must never download the maestro-runner. It verifies the runner with
   `ensure-maestro-runner.sh --print-bin`, the no-download mode also used by
   `ensure-android-ready.sh`, and prints the explicit install command; the hook
   itself stays exit 0 so that guidance reaches the agent.
-  `scripts/test/session-start-bounded.test.sh` pins both (GH #773).
+  `scripts/test/session-start-bounded.test.sh` pins both (GH #773). Other
+  SessionStart installers (`ensure-cdp-deps.sh` via npm and `ensure-ffmpeg.sh`
+  via brew) remain network-capable and are tracked separately.
 - Do not create compatibility symlinks for legacy root paths. Host package
   outputs must be real directories/files, not symlinks.
 - Do not hand-edit generated host runtime or packaged native-runner copies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@ sibling workspace only when explicitly requested.
 - Do not commit generated local artifacts: `.playwright-mcp/`, root
   `observe-*.png`, simulator screenshots, temporary logs, or proof captures.
 - Do not add or restore `BUGS.md`. Bugs are tracked in GitHub Issues.
+- The SessionStart hook (`packages/claude-plugin/hooks/detect-rn-project.sh`)
+  must never fetch or execute network content. It verifies the runner with
+  `ensure-maestro-runner.sh --print-bin`, the no-download mode also used by
+  `ensure-android-ready.sh`, and prints the explicit install command; the hook
+  itself stays exit 0 so that guidance reaches the agent.
+  `scripts/test/session-start-bounded.test.sh` pins both (GH #773).
 - Do not create compatibility symlinks for legacy root paths. Host package
   outputs must be real directories/files, not symlinks.
 - Do not hand-edit generated host runtime or packaged native-runner copies.

--- a/apps/docs-site/src/content/docs/getting-started.mdx
+++ b/apps/docs-site/src/content/docs/getting-started.mdx
@@ -15,7 +15,7 @@ import { Steps } from '@astrojs/starlight/components';
 | iOS Simulator or Android Emulator | At least one platform |
 | Session-bound Metro | Setup previews the project integration; literal `pnpm ios` or `pnpm android` starts or validates the allocated Metro |
 
-**maestro-runner `>= 1.1.24`** is installed into rn-dev-agent's versioned pin-cache as attested `1.1.24` on first plugin load in Claude Code (via its SessionStart hook). In Codex, invoke `$rn-dev-agent:setup`; after its read-only diagnosis, setup converges and verifies that attested runner before previewing project changes for consent. Replay never resolves from PATH, `~/.maestro-runner`, or brew Maestro. Device control ships in-tree through the iOS/Android runners. Use the matching host setup workflow for guided remediation.
+**maestro-runner `>= 1.1.24`** is installed into rn-dev-agent's versioned pin-cache as attested `1.1.24` by the host setup workflow. Claude's SessionStart hook only verifies the pin-cache offline and prints the explicit pinned install command when remediation is needed. In Codex, invoke `$rn-dev-agent:setup`; after its read-only diagnosis, setup converges and verifies that attested runner before previewing project changes for consent. Replay never resolves from PATH, `~/.maestro-runner`, or brew Maestro. Device control ships in-tree through the iOS/Android runners. Use the matching host setup workflow for guided remediation.
 
 ## Installation
 

--- a/packages/claude-plugin/hooks/detect-rn-project.sh
+++ b/packages/claude-plugin/hooks/detect-rn-project.sh
@@ -86,9 +86,11 @@ if [ "$has_rn_config" = true ]; then
     INSTALL_WARNINGS+=("WARNING: CDP bridge deps failed. Run: cd ${CORE_ROOT} && npm install")
   fi
 
-  # Ensure maestro-runner is installed (stderr visible for diagnostics)
-  if ! bash "$SCRIPT_ROOT/ensure-maestro-runner.sh" 2>&1; then
-    INSTALL_WARNINGS+=("WARNING: attested maestro-runner 1.1.24 is missing from the pin-cache (floor >= 1.1.24). Re-run: bash ${SCRIPT_ROOT}/ensure-maestro-runner.sh")
+  # GH #773: verify the maestro-runner pin-cache WITHOUT touching the network.
+  # --print-bin is the no-download verify mode (same call shape as
+  # ensure-android-ready.sh); downloading is an explicit user-run command.
+  if ! bash "$SCRIPT_ROOT/ensure-maestro-runner.sh" --print-bin >/dev/null; then
+    INSTALL_WARNINGS+=("WARNING: attested maestro-runner 1.1.24 is missing from the pin-cache (floor >= 1.1.24). Install it explicitly (SessionStart never downloads): bash ${SCRIPT_ROOT}/ensure-maestro-runner.sh")
   fi
 
   # GH #59 #3: surface (and optionally auto-install) idb-companion when a

--- a/packages/claude-plugin/hooks/detect-rn-project.sh
+++ b/packages/claude-plugin/hooks/detect-rn-project.sh
@@ -86,9 +86,7 @@ if [ "$has_rn_config" = true ]; then
     INSTALL_WARNINGS+=("WARNING: CDP bridge deps failed. Run: cd ${CORE_ROOT} && npm install")
   fi
 
-  # GH #773: verify the maestro-runner pin-cache WITHOUT touching the network.
-  # --print-bin is the no-download verify mode (same call shape as
-  # ensure-android-ready.sh); downloading is an explicit user-run command.
+  # Verify offline so SessionStart can surface the explicit install command (GH #773).
   if ! bash "$SCRIPT_ROOT/ensure-maestro-runner.sh" --print-bin >/dev/null; then
     INSTALL_WARNINGS+=("WARNING: attested maestro-runner 1.1.24 is missing from the pin-cache (floor >= 1.1.24). Install it explicitly (SessionStart never downloads): bash ${SCRIPT_ROOT}/ensure-maestro-runner.sh")
   fi

--- a/packages/claude-plugin/scripts/ensure-maestro-runner.sh
+++ b/packages/claude-plugin/scripts/ensure-maestro-runner.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # ensure-maestro-runner.sh — Install or converge the session pin-cache to
 # the attested maestro-runner (floor >= the tested pin). Never uses PATH,
-# ~/.maestro-runner, or the Maestro CLI. Downloading is an explicit user action
-# (/rn-dev-agent:setup); SessionStart only verifies, via the no-network
-# --print-bin mode (GH #773).
+# ~/.maestro-runner, or the Maestro CLI. Setup downloads explicitly;
+# SessionStart only verifies with --print-bin (GH #773).
 #
 # Exit codes:
 #   0 — pin-cache binary is the attested tested pin (already or just installed)

--- a/packages/claude-plugin/scripts/ensure-maestro-runner.sh
+++ b/packages/claude-plugin/scripts/ensure-maestro-runner.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # ensure-maestro-runner.sh — Install or converge the session pin-cache to
 # the attested maestro-runner (floor >= the tested pin). Never uses PATH,
-# ~/.maestro-runner, or the Maestro CLI. SessionStart and /rn-dev-agent:setup
-# invoke this.
+# ~/.maestro-runner, or the Maestro CLI. Downloading is an explicit user action
+# (/rn-dev-agent:setup); SessionStart only verifies, via the no-network
+# --print-bin mode (GH #773).
 #
 # Exit codes:
 #   0 — pin-cache binary is the attested tested pin (already or just installed)

--- a/packages/codex-plugin/scripts/ensure-maestro-runner.sh
+++ b/packages/codex-plugin/scripts/ensure-maestro-runner.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # ensure-maestro-runner.sh — Install or converge the session pin-cache to
 # the attested maestro-runner (floor >= the tested pin). Never uses PATH,
-# ~/.maestro-runner, or the Maestro CLI. Downloading is an explicit user action
-# (/rn-dev-agent:setup); SessionStart only verifies, via the no-network
-# --print-bin mode (GH #773).
+# ~/.maestro-runner, or the Maestro CLI. Setup downloads explicitly;
+# SessionStart only verifies with --print-bin (GH #773).
 #
 # Exit codes:
 #   0 — pin-cache binary is the attested tested pin (already or just installed)

--- a/packages/codex-plugin/scripts/ensure-maestro-runner.sh
+++ b/packages/codex-plugin/scripts/ensure-maestro-runner.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # ensure-maestro-runner.sh — Install or converge the session pin-cache to
 # the attested maestro-runner (floor >= the tested pin). Never uses PATH,
-# ~/.maestro-runner, or the Maestro CLI. SessionStart and /rn-dev-agent:setup
-# invoke this.
+# ~/.maestro-runner, or the Maestro CLI. Downloading is an explicit user action
+# (/rn-dev-agent:setup); SessionStart only verifies, via the no-network
+# --print-bin mode (GH #773).
 #
 # Exit codes:
 #   0 — pin-cache binary is the attested tested pin (already or just installed)

--- a/packages/rn-dev-agent-core/test/unit/ensure-maestro-runner-pin.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ensure-maestro-runner-pin.test.ts
@@ -263,6 +263,56 @@ test('installer verifies the complete archive before replacing the live pin-cach
   assert.equal(existsSync(outsideStageMarker), false);
 });
 
+// GH #773 negative control: a tampered artifact must never reach execution.
+test('a tampered artifact fails the pin and its payload never executes', () => {
+  const fixture = createInstallerFixture('mr-tampered-exec-');
+  const root = dirname(fixture.archive);
+  const marker = join(root, 'tampered-payload-executed');
+  // A marker path the payload's shell could mangle would make this control
+  // pass even if the payload ran, so refuse it outright.
+  assert.doesNotMatch(marker, /["$`\\\s]/);
+  // A drifted pin-cache forces a real install attempt instead of the fast path,
+  // so the probe below always has a real executable to run.
+  const pinnedBin = join(fixture.pinDir, 'bin', 'maestro-runner');
+  mkdirSync(dirname(pinnedBin), { recursive: true });
+  writeFileSync(pinnedBin, '#!/bin/sh\necho drifted\n', 'utf8');
+  chmodSync(pinnedBin, 0o755);
+  const tamperedPayload = join(root, 'tampered', 'maestro-runner');
+  const tamperedArchive = join(root, 'tampered.tar.gz');
+  mkdirSync(join(tamperedPayload, 'bin'), { recursive: true });
+  const tamperedRunner = join(tamperedPayload, 'bin', 'maestro-runner');
+  writeFileSync(tamperedRunner, `#!/bin/sh\nprintf executed > ${JSON.stringify(marker)}\n`, 'utf8');
+  chmodSync(tamperedRunner, 0o755);
+  const packed = spawnSync('tar', [
+    '-czf',
+    tamperedArchive,
+    '-C',
+    join(root, 'tampered'),
+    'maestro-runner',
+  ]);
+  assert.equal(packed.status, 0, String(packed.stderr));
+
+  const env = {
+    ...fixture.env,
+    RN_DEV_AGENT_MAESTRO_DOWNLOAD_URL: pathToFileURL(tamperedArchive).href,
+  };
+  const result = spawnSync('bash', [fixture.copiedScript], { encoding: 'utf8', env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}${result.stderr}`, /archive checksum/);
+  // The session is never handed a runner path it could execute.
+  const printed = spawnSync('bash', [fixture.copiedScript, '--print-bin'], {
+    encoding: 'utf8',
+    env,
+  });
+  assert.notEqual(printed.status, 0);
+  // Falsifiable: the pin path is executable, so had the tampered payload been
+  // published over it this would run it and leave the marker behind.
+  const probe = spawnSync(pinnedBin, [], { encoding: 'utf8' });
+  assert.equal(probe.stdout, 'drifted\n');
+  assert.equal(existsSync(marker), false);
+});
+
 test('installed fast path refuses a payload changed after verified installation', () => {
   const root = mkdtempSync(join(tmpdir(), 'mr-live-payload-'));
   const scriptDir = join(root, 'scripts');

--- a/scripts/ensure-maestro-runner.sh
+++ b/scripts/ensure-maestro-runner.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # ensure-maestro-runner.sh — Install or converge the session pin-cache to
 # the attested maestro-runner (floor >= the tested pin). Never uses PATH,
-# ~/.maestro-runner, or the Maestro CLI. Downloading is an explicit user action
-# (/rn-dev-agent:setup); SessionStart only verifies, via the no-network
-# --print-bin mode (GH #773).
+# ~/.maestro-runner, or the Maestro CLI. Setup downloads explicitly;
+# SessionStart only verifies with --print-bin (GH #773).
 #
 # Exit codes:
 #   0 — pin-cache binary is the attested tested pin (already or just installed)

--- a/scripts/ensure-maestro-runner.sh
+++ b/scripts/ensure-maestro-runner.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # ensure-maestro-runner.sh — Install or converge the session pin-cache to
 # the attested maestro-runner (floor >= the tested pin). Never uses PATH,
-# ~/.maestro-runner, or the Maestro CLI. SessionStart and /rn-dev-agent:setup
-# invoke this.
+# ~/.maestro-runner, or the Maestro CLI. Downloading is an explicit user action
+# (/rn-dev-agent:setup); SessionStart only verifies, via the no-network
+# --print-bin mode (GH #773).
 #
 # Exit codes:
 #   0 — pin-cache binary is the attested tested pin (already or just installed)

--- a/scripts/test/session-start-bounded.test.sh
+++ b/scripts/test/session-start-bounded.test.sh
@@ -109,6 +109,13 @@ exit 1
 EOF
   chmod +x "$TEST_DIR/bin/$tool"
 done
+for tool in idb idb_companion; do
+  cat > "$TEST_DIR/bin/$tool" << 'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$TEST_DIR/bin/$tool"
+done
 
 NET_LOG="$TEST_DIR/session-start-net.log"
 PKG_LOG="$TEST_DIR/session-start-pkg.log"

--- a/scripts/test/session-start-bounded.test.sh
+++ b/scripts/test/session-start-bounded.test.sh
@@ -116,10 +116,20 @@ exit 0
 EOF
   chmod +x "$TEST_DIR/bin/$tool"
 done
+cat > "$TEST_DIR/bin/adb" << 'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "devices" ]; then
+  printf 'List of devices attached\n\n'
+fi
+exit 0
+EOF
+chmod +x "$TEST_DIR/bin/adb"
 
 NET_LOG="$TEST_DIR/session-start-net.log"
 PKG_LOG="$TEST_DIR/session-start-pkg.log"
 IDB_STATE="$TEST_DIR/idb-state"
+SESSION_TMP="$TEST_DIR/session-tmp"
+mkdir -p "$SESSION_TMP"
 PIN_VERSION="$(node -e 'process.stdout.write(require(process.argv[1]).version)' \
   "$REPO_ROOT/packages/rn-dev-agent-core/src/domain/maestro-runner-pin.json")"
 EXPECTED_CMD="bash $REPO_ROOT/packages/claude-plugin/scripts/ensure-maestro-runner.sh"
@@ -133,6 +143,7 @@ run_session_start() {
       PATH="$TEST_DIR/bin:$PATH" \
       NET_LOG="$NET_LOG" \
       PKG_LOG="$PKG_LOG" \
+      TMPDIR="$SESSION_TMP" \
       RN_DEV_AGENT_RUNNER_CACHE="$1" \
       RN_AGENT_IDB_STATE_DIR="$IDB_STATE" \
       RN_AGENT_IDB_DRY_SPAWN=1 \

--- a/scripts/test/session-start-bounded.test.sh
+++ b/scripts/test/session-start-bounded.test.sh
@@ -155,9 +155,9 @@ run_session_start() {
 assert_session_start_offline() {
   local label="$1" out="$2"
   if [ -s "$NET_LOG" ]; then
-    bad "SessionStart fetched over the network ($label): $(tr '\n' '; ' < "$NET_LOG")"
+    bad "SessionStart downloaded the maestro-runner ($label): $(tr '\n' '; ' < "$NET_LOG")"
   else
-    ok "SessionStart makes no network calls ($label)"
+    ok "SessionStart does not download the maestro-runner ($label)"
   fi
   # Exit 0 matters: the hook's own contract makes a non-zero exit "logged,
   # non-blocking", which would hide the install command from the agent.
@@ -209,9 +209,9 @@ else
 fi
 
 if [ -s "$IDB_STATE/spawn.log" ]; then
-  bad "SessionStart spawned a background installer: $(tr '\n' '; ' < "$IDB_STATE/spawn.log")"
+  bad "SessionStart spawned the idb background installer: $(tr '\n' '; ' < "$IDB_STATE/spawn.log")"
 else
-  ok "SessionStart spawns no background installer"
+  ok "SessionStart spawns no idb background installer"
 fi
 if [ -s "$PKG_LOG" ]; then
   echo "note: SessionStart package-manager calls (pre-existing, outside GH#773): $(tr '\n' '; ' < "$PKG_LOG")"

--- a/scripts/test/session-start-bounded.test.sh
+++ b/scripts/test/session-start-bounded.test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Regression test for GH#252/B196 — SessionStart must be bounded. The hook runs
-# installers (npm install, curl | bash) on fresh machines; without an explicit
-# hook timeout and curl time limits, a stalled CDN blocks every session start
-# and the install is silently re-attempted each session.
+# Regression test for SessionStart safety.
+# GH#252/B196 — SessionStart must be bounded: without an explicit hook timeout
+# and curl time limits, a stalled CDN blocks every session start.
+# GH#773 — SessionStart must not fetch the runner over the network at all; the
+# explicit install is a user-run command.
 #
 # Run: bash scripts/test/session-start-bounded.test.sh
 
@@ -79,6 +80,123 @@ then
   ok "ensure-maestro-runner.sh: download uses positive connect and total timeouts"
 else
   bad "ensure-maestro-runner.sh: download is not bounded by positive connect and total timeouts"
+fi
+
+# 3. GH#773 — SessionStart must not fetch the runner over the network. The hook
+# verifies the pin-cache; downloading is an explicit user-run command.
+PROJECT="$TEST_DIR/rn-project"
+mkdir -p "$PROJECT"
+echo '{"name":"fixture","dependencies":{"expo":"51.0.0","react-native":"0.74.0"}}' > "$PROJECT/package.json"
+echo '{"expo":{"name":"fixture"}}' > "$PROJECT/app.json"
+
+# curl/wget are the fetchers the runner installer uses; any call fails the test.
+for tool in curl wget; do
+  cat > "$TEST_DIR/bin/$tool" << 'EOF'
+#!/usr/bin/env bash
+printf '%s %s\n' "$(basename "$0")" "$*" >> "$NET_LOG"
+exit 28
+EOF
+  chmod +x "$TEST_DIR/bin/$tool"
+done
+# npm/brew get their own log rather than a silent stub: SessionStart already
+# runs them for CDP deps and ffmpeg, so they must stay visible here without
+# failing this runner-scoped assertion.
+for tool in npm brew; do
+  cat > "$TEST_DIR/bin/$tool" << 'EOF'
+#!/usr/bin/env bash
+printf '%s %s\n' "$(basename "$0")" "$*" >> "$PKG_LOG"
+exit 1
+EOF
+  chmod +x "$TEST_DIR/bin/$tool"
+done
+
+NET_LOG="$TEST_DIR/session-start-net.log"
+PKG_LOG="$TEST_DIR/session-start-pkg.log"
+IDB_STATE="$TEST_DIR/idb-state"
+PIN_VERSION="$(node -e 'process.stdout.write(require(process.argv[1]).version)' \
+  "$REPO_ROOT/packages/rn-dev-agent-core/src/domain/maestro-runner-pin.json")"
+EXPECTED_CMD="bash $REPO_ROOT/packages/claude-plugin/scripts/ensure-maestro-runner.sh"
+
+# RN_AGENT_IDB_* keep ensure-idb.sh off the real $HOME and stop it detaching a
+# worker just because this test put a `brew` on PATH.
+run_session_start() {
+  rm -f "$NET_LOG"
+  (
+    cd "$PROJECT" &&
+      PATH="$TEST_DIR/bin:$PATH" \
+      NET_LOG="$NET_LOG" \
+      PKG_LOG="$PKG_LOG" \
+      RN_DEV_AGENT_RUNNER_CACHE="$1" \
+      RN_AGENT_IDB_STATE_DIR="$IDB_STATE" \
+      RN_AGENT_IDB_DRY_SPAWN=1 \
+      bash "$REPO_ROOT/packages/claude-plugin/hooks/detect-rn-project.sh"
+  ) > "$2" 2>&1
+  HOOK_STATUS=$?
+}
+
+assert_session_start_offline() {
+  local label="$1" out="$2"
+  if [ -s "$NET_LOG" ]; then
+    bad "SessionStart fetched over the network ($label): $(tr '\n' '; ' < "$NET_LOG")"
+  else
+    ok "SessionStart makes no network calls ($label)"
+  fi
+  # Exit 0 matters: the hook's own contract makes a non-zero exit "logged,
+  # non-blocking", which would hide the install command from the agent.
+  if [ "$HOOK_STATUS" -eq 0 ]; then
+    ok "SessionStart hook exits 0 so its guidance is shown ($label)"
+  else
+    bad "SessionStart hook exited $HOOK_STATUS ($label)"
+  fi
+  if grep -qF "$EXPECTED_CMD" "$out"; then
+    ok "SessionStart prints the explicit pinned install command ($label)"
+  else
+    bad "SessionStart does not print '$EXPECTED_CMD' ($label)"
+  fi
+}
+
+# The hook's guidance is only correct if the verify mode itself refuses offline,
+# so pin that contract directly rather than inferring it from hook output.
+assert_verify_mode_refuses_offline() {
+  local label="$1" cache="$2" status=0
+  rm -f "$NET_LOG"
+  PATH="$TEST_DIR/bin:$PATH" NET_LOG="$NET_LOG" RN_DEV_AGENT_RUNNER_CACHE="$cache" \
+    bash "$REPO_ROOT/scripts/ensure-maestro-runner.sh" --print-bin > /dev/null 2>&1 || status=$?
+  if [ "$status" -ne 0 ] && [ ! -s "$NET_LOG" ]; then
+    ok "--print-bin refuses without downloading ($label)"
+  else
+    bad "--print-bin returned $status and logged '$(tr '\n' '; ' < "$NET_LOG")' ($label)"
+  fi
+}
+
+MISSING_OUT="$TEST_DIR/session-start-missing.out"
+run_session_start "$TEST_DIR/cache-missing" "$MISSING_OUT"
+assert_session_start_offline "runner absent" "$MISSING_OUT"
+assert_verify_mode_refuses_offline "runner absent" "$TEST_DIR/cache-missing"
+
+# A mismatched cached runner must not be "converged" over the network either.
+MISMATCH_CACHE="$TEST_DIR/cache-mismatch"
+MISMATCH_BIN="$MISMATCH_CACHE/maestro-runner/$PIN_VERSION/bin/maestro-runner"
+mkdir -p "$(dirname "$MISMATCH_BIN")"
+printf '#!/bin/sh\necho not-the-pinned-runner\n' > "$MISMATCH_BIN"
+chmod +x "$MISMATCH_BIN"
+MISMATCH_OUT="$TEST_DIR/session-start-mismatch.out"
+run_session_start "$MISMATCH_CACHE" "$MISMATCH_OUT"
+assert_session_start_offline "runner checksum mismatch" "$MISMATCH_OUT"
+assert_verify_mode_refuses_offline "runner checksum mismatch" "$MISMATCH_CACHE"
+if [ "$(cat "$MISMATCH_BIN")" = "$(printf '#!/bin/sh\necho not-the-pinned-runner\n')" ]; then
+  ok "SessionStart leaves a mismatched pin-cache byte-identical"
+else
+  bad "SessionStart rewrote the mismatched pin-cache binary"
+fi
+
+if [ -s "$IDB_STATE/spawn.log" ]; then
+  bad "SessionStart spawned a background installer: $(tr '\n' '; ' < "$IDB_STATE/spawn.log")"
+else
+  ok "SessionStart spawns no background installer"
+fi
+if [ -s "$PKG_LOG" ]; then
+  echo "note: SessionStart package-manager calls (pre-existing, outside GH#773): $(tr '\n' '; ' < "$PKG_LOG")"
 fi
 
 exit $fail


### PR DESCRIPTION
## Intent

Fix GitHub issue 773 in Lykhoyda/rn-dev-agent: SessionStart must never execute unverified network content.

Required behavior:
- A fresh SessionStart in a React Native project without maestro-runner performs no network execution and prints the explicit pinned installation command instead.
- The explicit installation path fetches a versioned release artifact to a temporary file, verifies a committed SHA-256 pin for every supported platform before anything executes, and refuses a mismatch or unknown platform.
- If the publisher offered no usable versioned artifact or checksum for a supported platform, pin the installer script bytes themselves; SessionStart still must not execute network-fetched content.
- Update both authoritative copies together: scripts/ensure-maestro-runner.sh and the shipped plugin hook/install surface.
- Add one tampered-artifact negative control proving mismatch prevents execution, plus the smallest test that would fail if SessionStart regained a network-execution path.
- Reuse existing shell/download/hash helpers and dependencies; add no framework or speculative installer abstraction.

Scope constraints: keep the change strictly within Issue 773. Do not touch session authority, managed Metro, process attestation, or the frozen authority surfaces.

Investigation findings that explain the diff:
- The curl-pipe-bash quoted in the issue body was already removed by earlier PRs (#811/#830), which introduced the versioned artifact URL and the per-platform pin manifest. The remaining vector was the unattended fetch itself.
- Root cause: packages/claude-plugin/hooks/detect-rn-project.sh:90 was the single call site invoking ensure-maestro-runner.sh in full install mode. Masking condition: the pin-cache fast path (bin_matches_pin) short-circuits before the download, so a developer who already had the runner never observed it. Reproduced with a curl test double: curl fired unattended on an empty pin-cache.
- scripts/ensure-android-ready.sh:55, the other SessionStart verifier, already called the installer as `--print-bin >/dev/null`, an existing zero-network verify mode. Deliberate decision: reuse that established idiom at the one outlier call site rather than add a new --verify-only flag or installer abstraction. Discarding stdout via >/dev/null is intentional and matches the sibling caller.
- Deliberate decision: the hook keeps exit 0 on a missing/mismatched runner. Its own contract (detect-rn-project.sh:4) makes a non-zero hook exit "logged, non-blocking", which would hide the install command from the agent. The non-zero exit belongs to the script, and --print-bin does exit 1. A codex-pair HIGH suggesting the hook exit non-zero was verified against source and rejected for this reason.
- The install path already satisfied the versioned-artifact and per-platform checksum requirements (hash verified at :421-429 before tar extraction at :438; all four supported platforms pinned; unsupported platform fails closed), so it is unchanged apart from a stale header comment. The installer-script-byte-pinning fallback was therefore not needed.

Tests added:
- scripts/test/session-start-bounded.test.sh gains runner-absent and checksum-mismatch cases asserting no network call, hook exit 0, the printed install command, an untouched mismatched pin-cache, no detached background installer, and that --print-bin itself refuses offline. Proven falsifiable: fails on the pre-fix hook in both cache states.
- packages/rn-dev-agent-core/test/unit/ensure-maestro-runner-pin.test.ts gains a tampered-artifact negative control proving mismatched bytes never execute. Proven falsifiable against an injected early-publication regression.
- The test uses RN_AGENT_IDB_STATE_DIR and RN_AGENT_IDB_DRY_SPAWN so it cannot mutate the real $HOME or spawn a detached idb installer (an accepted codex-pair HIGH).
- Deliberate decision: npm and brew doubles log rather than fail the assertion. SessionStart already runs npm (ensure-cdp-deps.sh) and brew (ensure-ffmpeg.sh); those are pre-existing paths outside Issue 773, and asserting on them would fail on main too.

Deliberately not fixed, reported instead as out of scope for Issue 773:
- scripts/ensure-ffmpeg.sh:11 runs `brew install ffmpeg` unattended at SessionStart when ffmpeg is absent and brew is present (same bug class, lower severity since Homebrew verifies its own downloads).
- scripts/ensure-maestro-runner.sh:503 enforces the install deadline after atomic publication, so a boundary-timing install reports failure despite having published. Pre-existing; this change only touches that file's header comment.

Other notes:
- A changeset bumping rn-dev-agent-plugin is included because the shipped SessionStart hook behavior changes for marketplace installs, even though scripts/require-changeset.sh reports one is not required (no core src changes).
- AGENTS.md records the durable invariant so a future session does not restore the install call.
- Two pre-existing full-suite failures are unrelated to this change (it contains no rn-dev-agent-core/src changes, so dist is identical to base): save-as-action overwrite is the documented macOS $TMPDIR /var -> /private/var case and reproduces identically at base commit a3ffeb70; proof-recorder-stream-contract is timing-flaky under full-suite load and passes 11/11 on 3/3 standalone runs.

## What Changed

- Change Claude SessionStart to verify the cached maestro-runner offline and print the explicit pinned installation command when it is missing or mismatched.
- Add regression coverage for no-network SessionStart behavior and ensure tampered runner archives are rejected before their payload can execute.
- Update installation guidance and publish the behavior change as a plugin patch.

## Risk Assessment

✅ Low: The change is narrowly scoped and closes the unattended runner download through the existing offline verification boundary without weakening the pinned explicit-install path.

## Testing

After restoring the isolated worktree’s Yarn prerequisites, the focused SessionStart integration test and four installer safety controls passed: SessionStart remained offline and showed explicit guidance, verified installs succeeded, tampered or unsupported artifacts failed before execution, evidence transcripts were captured, and generated setup artifacts were removed.

<details>
<summary>Evidence: SessionStart offline transcript</summary>

`SessionStart performs no runner download for absent or mismatched caches, exits 0, prints the explicit install command, and preserves mismatched bytes.`

```text
ok: hooks.json: SessionStart entries declare a timeout
ok: ensure-maestro-runner.sh: download uses positive connect and total timeouts
ok: SessionStart does not download the maestro-runner (runner absent)
ok: SessionStart hook exits 0 so its guidance is shown (runner absent)
ok: SessionStart prints the explicit pinned install command (runner absent)
ok: --print-bin refuses without downloading (runner absent)
ok: SessionStart does not download the maestro-runner (runner checksum mismatch)
ok: SessionStart hook exits 0 so its guidance is shown (runner checksum mismatch)
ok: SessionStart prints the explicit pinned install command (runner checksum mismatch)
ok: --print-bin refuses without downloading (runner checksum mismatch)
ok: SessionStart leaves a mismatched pin-cache byte-identical
ok: SessionStart spawns no idb background installer
```
</details>
<details>
<summary>Evidence: Runner pin safety controls</summary>

`Verified archive installation passed; tampered artifacts and unsupported platforms failed closed without payload execution; all supported platforms have checksum pins.`

```text
✔ unsupported platform fails closed and does not download (1051.348334ms)
✔ installer verifies the complete archive before replacing the live pin-cache (1703.91875ms)
✔ a tampered artifact fails the pin and its payload never executes (3354.322208ms)
✔ pin manifest owns checksums for every supported release archive (4.789084ms)
ℹ tests 4
ℹ suites 0
ℹ pass 4
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 6316.989916
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"50fa4edb2254b56da77d6802ffe15b7d701ffce7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `scripts/test/session-start-bounded.test.sh:193` - Make this assertion independent of the host&#39;s idb installation. On a fresh macOS host with Homebrew but without idb/idb_companion, the unchanged ensure-idb path sees the test&#39;s brew double and RN_AGENT_IDB_DRY_SPAWN=1 writes spawn.log, causing this runner-specific test to fail despite no maestro-runner network call. Set RN_AGENT_IDB_UNAME=Linux or provide healthy idb doubles in run_session_start.

🔧 Fix: Stabilize SessionStart test with healthy idb doubles
1 warning still open:

- ⚠️ `scripts/test/session-start-bounded.test.sh:133` - Isolate the hook test from the developer&#39;s real SessionStart state and Android device. `run_session_start` inherits `TMPDIR` and the real `adb`; with a connected device, `ensure-android-ready.sh` can remove the live `tcp:7001` forwarding and overwrite the Android serial file, while the hook also overwrites the shared upgrade marker. Set a fixture `TMPDIR` and provide an `adb` double that reports no devices.

🔧 Fix: Isolate SessionStart test from host Android state
1 warning still open:

- ⚠️ `AGENTS.md:47` - Scope this invariant to the maestro-runner check. The hook still intentionally invokes npm/brew-capable dependency installers, while the regression test intercepts only the runner&#39;s curl/wget fetchers and explicitly exempts npm/brew. As written, this claims a global SessionStart guarantee that neither the implementation nor test provides; narrow the wording here and in the test result messages to the maestro-runner path.

🔧 Fix: Scope SessionStart invariant to maestro-runner downloads
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`test -f packages/rn-dev-agent-core/dist/domain/engine-pin.js` (setup probe found generated output absent)</code>
- `bash scripts/test/session-start-bounded.test.sh`
- <code>`corepack yarn workspace rn-dev-agent-core build` (initial setup attempt identified missing Yarn install state)</code>
- `corepack yarn install --immutable`
- `corepack yarn workspace rn-dev-agent-core build`
- `node --test --test-name-pattern='^(unsupported platform fails closed and does not download|installer verifies the complete archive before replacing the live pin-cache|a tampered artifact fails the pin and its payload never executes|pin manifest owns checksums for every supported release archive)$' packages/rn-dev-agent-core/test/unit/ensure-maestro-runner-pin.test.ts`
- <code>Reviewed both saved evidence transcripts and confirmed `git status --short` was clean after cleanup</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
