### PR TITLE
fix(core): complete id-based iOS waits across partitioned replay

### DIFF
--- a/.changeset/modal-alternate-frontmost.md
+++ b/.changeset/modal-alternate-frontmost.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Recognize a modal-hosted testID as frontmost when its React return chain threads through the modal host fiber's alternate, instead of refusing it as behind the active modal.

--- a/.changeset/partitioned-native-handoff.md
+++ b/.changeset/partitioned-native-handoff.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Re-prove the exact CDP session target before completing a partitioned native segment's deferred origin, so a passing native prefix survives the runner park/resume handoff into the React-tree suffix instead of failing with an empty before-first-step envelope.

--- a/.changeset/quiet-otps-wait.md
+++ b/.changeset/quiet-otps-wait.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Resume id-based iOS action waits through the React tree with Maestro-compatible timed visibility semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,8 +214,10 @@ alive for such callers.
   (`connectExactSessionTarget`, which waits for the target to re-register)
   reliably survives a WDA-driven segment, so the deferred-completion guard in
   `src/tools/maestro-run.ts` admits a caller-supplied reprove even in the
-  nested `replayDeps: undefined` handler. Park/resume handoff regressions are
-  pinned in `test/unit/partitioned-replay-authority.test.ts`.
+  nested `replayDeps: undefined` handler. Forward the parent flow's remaining
+  readiness budget and cancellation signal through that reproof and its
+  subsequent origin completion. Park/resume handoff regressions are pinned in
+  `test/unit/partitioned-replay-authority.test.ts`.
 - Trailing-verification classification (GH #623) has exactly one owner: the
   canonical per-attempt ledger built inside `maestro_run` from per-stage
   producer artifacts (`src/domain/maestro-run-ledger.ts`, artifact reader in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,14 @@ alive for such callers.
   allowlist: a real actions directory, or the approved `.rn-agent/actions`
   symlink to the same-repo primary corpus. `isDirectNode` still refuses
   per-file action symlinks.
+- Exact-ID visibility in CDP/JS replay has exactly one owner: the injected
+  `isTestIdFrontmost` oracle (`src/injected-helpers.ts`), consumed through
+  `frontmostFor` — it scans fibers exactly and fail-closes on renderer
+  coverage and scan budget before any absence claim (`matchCount: 0` is
+  complete readable absence; refusals carry no matchCount). `replayTreeData`
+  (`src/tools/cdp-replay-dispatch.ts`) is a readability gate only (transport,
+  redbox, truncation); `getTree(filter)` matches substrings, so never
+  reintroduce exact-ID presence/absence inference from its output.
 - Trailing-verification classification (GH #623) has exactly one owner: the
   canonical per-attempt ledger built inside `maestro_run` from per-stage
   producer artifacts (`src/domain/maestro-run-ledger.ts`, artifact reader in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,13 @@ alive for such callers.
   `corepack yarn gate:otp-omitted-timeout` (needs `OTP_FIXTURE_ROOT` and
   `OTP_FIXTURE_DEVICE_ID`; not run in hosted CI), with the causal modal-
   alternate regressions in `test/unit/ios-proof-domain-routing.test.ts`.
+- The partitioned iOS native leg must re-prove the exact CDP target before
+  completing its deferred origin: only `reproveManagedOrigin`
+  (`connectExactSessionTarget`, which waits for the target to re-register)
+  reliably survives a WDA-driven segment, so the deferred-completion guard in
+  `src/tools/maestro-run.ts` admits a caller-supplied reprove even in the
+  nested `replayDeps: undefined` handler. Park/resume handoff regressions are
+  pinned in `test/unit/partitioned-replay-authority.test.ts`.
 - Trailing-verification classification (GH #623) has exactly one owner: the
   canonical per-attempt ledger built inside `maestro_run` from per-stage
   producer artifacts (`src/domain/maestro-run-ledger.ts`, artifact reader in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,12 @@ alive for such callers.
   complete readable absence; refusals carry no matchCount). `replayTreeData`
   (`src/tools/cdp-replay-dispatch.ts`) is a readability gate only (transport,
   redbox, truncation); `getTree(filter)` matches substrings, so never
-  reintroduce exact-ID presence/absence inference from its output.
+  reintroduce exact-ID presence/absence inference from its output. Fibers are
+  compared modulo `fiber.alternate` (React's double buffer) in `containsFiber`;
+  the end-to-end OTP login-resume smoke is device-bound and owned by
+  `corepack yarn gate:otp-omitted-timeout` (needs `OTP_FIXTURE_ROOT` and
+  `OTP_FIXTURE_DEVICE_ID`; not run in hosted CI), with the causal modal-
+  alternate regressions in `test/unit/ios-proof-domain-routing.test.ts`.
 - Trailing-verification classification (GH #623) has exactly one owner: the
   canonical per-attempt ledger built inside `maestro_run` from per-stage
   producer artifacts (`src/domain/maestro-run-ledger.ts`, artifact reader in

--- a/apps/docs-site/src/content/docs/changelog.md
+++ b/apps/docs-site/src/content/docs/changelog.md
@@ -5,6 +5,15 @@ description: "Release history for rn-dev-agent"
 
 ## Claude plugin
 
+### 0.77.7
+
+#### Patch Changes
+
+- b39903b: SessionStart no longer downloads the maestro-runner: it verifies the pin-cache offline and prints the explicit pinned install command instead.
+- 18b95ca: maestro_run now emits a canonical per-attempt run ledger and attaches a ledger-derived `trailingVerification` qualifier block (`trailingVerificationOnly: true`, existing failureKind unchanged) to a still-failed flow whose mutating commands all provably completed while only a trailing wait/assert timed out, and cdp_run_action consumes it to refuse selector auto-repair and swap the simulator-reboot advice for verify-first guidance (final goal state stays unproven; genuine wedges keep the existing reboot hint).
+- Updated dependencies [18b95ca]
+  - rn-dev-agent-core@0.72.7
+
 ### 0.77.6
 
 #### Patch Changes
@@ -1634,6 +1643,12 @@ identifier, hittable? }`, with a `fullNodeCount`. Far fewer tokens; `@ref`s for
   #188 shipped these to `main` with no version bump, leaving them undeliverable to marketplace installs; this patch publishes them.
 
 ## Core MCP server
+
+### 0.72.7
+
+#### Patch Changes
+
+- 18b95ca: maestro_run now emits a canonical per-attempt run ledger and attaches a ledger-derived `trailingVerification` qualifier block (`trailingVerificationOnly: true`, existing failureKind unchanged) to a still-failed flow whose mutating commands all provably completed while only a trailing wait/assert timed out, and cdp_run_action consumes it to refuse selector auto-repair and swap the simulator-reboot advice for verify-first guidance (final goal state stays unproven; genuine wedges keep the existing reboot hint).
 
 ### 0.72.6
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "prepare": "husky",
-    "gate:slice-a": "yarn build:core && node packages/rn-dev-agent-core/test/smoke/slice-a-visibility-gate.ts"
+    "gate:slice-a": "yarn build:core && node packages/rn-dev-agent-core/test/smoke/slice-a-visibility-gate.ts",
+    "gate:otp-omitted-timeout": "yarn build:host-runtimes && node packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -94058,7 +94058,7 @@ var makeReplayDeps = (_args, signal) => {
       })).content[0].text);
       let env = await fetchTree(false);
       const d = env.data;
-      if (d && typeof d === "object" && "__agent_truncated" in d) {
+      if (d && typeof d === "object" && ("__agent_truncated" in d || d.truncated === true)) {
         env = await fetchTree(true);
       }
       const data = replayTreeData(env);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79311,12 +79311,13 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
-  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
+  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
+  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
   const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51588,11 +51588,7 @@ var INJECTED_HELPERS = `
     '_LogBoxInspectorContainer'
   ];
 
-  // Reset by every root-iteration pass; only valid when read synchronously
-  // after the pass that produced the tree (many helpers share the iterators).
-  // finished is true only when the renderer-ID loop finished without the
-  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
-  // (GH #789).
+  // Synchronous scan result; finished stays false after the GH #789 empty-streak exit.
   var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
   function rootScanCoverage() {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -78732,6 +78732,8 @@ var ReplayDispatchError = class extends Error {
 var interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)(?:\s*\?\?\s*(['"])(.*?)\2)?\}/g, (match, key, _quote, fallback) => p[key] ?? fallback ?? match);
 var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
+var VISIBILITY_POLL_INTERVAL_MS = 200;
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -78786,7 +78788,11 @@ function normalizeSteps(body, params) {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
           throw new UnsupportedStepError("assertVisible (missing string id)");
-        out.push({ t: "assert", id: interp(id, params) });
+        out.push({
+          t: "waitVisible",
+          id: interp(id, params),
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+        });
         break;
       }
       case "extendedWaitUntil": {
@@ -78796,10 +78802,10 @@ function normalizeSteps(body, params) {
           refuseUnsupportedKeys(v.visible, ["id"], "extendedWaitUntil.visible");
         }
         const id = isObj(v) && isObj(v.visible) ? asString(v.visible.id) : null;
-        const timeoutMs = isObj(v) ? v.timeout : void 0;
-        if (!id || !Number.isSafeInteger(timeoutMs) || Number(timeoutMs) < 0)
-          throw new UnsupportedStepError("extendedWaitUntil (need visible.id + non-negative integer timeout)");
-        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs: Number(timeoutMs) });
+        const timeoutMs = isObj(v) && "timeout" in v ? v.timeout : DEFAULT_VISIBILITY_TIMEOUT_MS;
+        if (!id || typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs < 0)
+          throw new UnsupportedStepError("extendedWaitUntil (need visible.id; timeout must be finite and non-negative when present)");
+        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs });
         break;
       }
       case "waitForAnimationToEnd": {
@@ -78902,39 +78908,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         }
-        case "assert": {
-          const verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          trace.push({
-            sourceIndex: sourceIndex(i),
-            t: s.t,
-            target: s.id,
-            ok: verdict.visible,
-            durationMs: Date.now() - startedAt
-          });
-          if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `assertVisible: "${s.id}" is not frontmost`, verdict.code ?? "ASSERTION_FAILED", verdict.meta);
-          break;
-        }
         case "waitVisible": {
-          const deadline = Date.now() + s.timeoutMs;
-          let verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          while (!verdict.visible && Date.now() < deadline) {
-            requireNotAborted();
-            await new Promise((resolve21) => setTimeout(resolve21, 100));
+          const deadline = startedAt + s.timeoutMs;
+          let verdict;
+          for (; ; ) {
             verdict = await dispatch.visibility(s.id);
             requireNotAborted();
+            if (verdict.visible)
+              break;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0)
+              break;
+            await new Promise((resolve21) => setTimeout(resolve21, Math.min(VISIBILITY_POLL_INTERVAL_MS, remainingMs)));
           }
+          const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
             ok: verdict.visible,
-            durationMs: Date.now() - startedAt
+            durationMs: waitedMs
           });
           if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `extendedWaitUntil: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", verdict.meta);
+            return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
         }
         case "wait":
@@ -78984,14 +78980,16 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
       }
     } catch (e) {
+      const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
         t: s.t,
         target: "id" in s ? s.id : void 0,
         ok: false,
-        durationMs: Date.now() - startedAt
+        durationMs: waitedMs
       });
-      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, e instanceof ReplayDispatchError ? e.meta : void 0);
+      const dispatchMeta = e instanceof ReplayDispatchError ? e.meta : void 0;
+      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, s.t === "waitVisible" ? { ...dispatchMeta, failedSelector: s.id, waitedMs } : dispatchMeta);
     }
   }
   if (opts.signal?.aborted) {
@@ -79254,14 +79252,17 @@ function unwrapTree(data) {
 function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
-  if (envelope.ok === true && !redbox)
-    return envelope.data;
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const message = redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const truncated = data !== null && data.__agent_truncated === true;
+  if (envelope.ok === true && !redbox && !truncated)
+    return envelope.data;
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...truncated ? { truncated: true } : {},
+      ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
       ...warning ? { warning } : {},
@@ -93942,12 +93943,11 @@ var makeReplayDeps = (_args, signal) => {
         ...interactiveOnly ? { interactiveOnly: true } : {}
       })).content[0].text);
       let env = await fetchTree(false);
-      let data = replayTreeData(env);
-      const d = data;
+      const d = env.data;
       if (d && typeof d === "object" && "__agent_truncated" in d) {
         env = await fetchTree(true);
-        data = replayTreeData(env);
       }
+      const data = replayTreeData(env);
       return unwrapTree(data);
     },
     frontmostFor: async (id) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -55301,8 +55301,7 @@ var INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
-      // A fiber and its work-in-progress alternate are the same logical node;
-      // committed .return chains may thread through either half of the pair.
+      // React return chains may thread through either half of a fiber/alternate pair.
       var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79351,53 +79351,25 @@ function loginPostconditionId(commands) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
-function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
-  if (!node || typeof node !== "object")
-    return acc;
-  const n = node;
-  if (typeof n.testID === "string")
-    acc.add(n.testID);
-  if (typeof n.nativeID === "string")
-    acc.add(n.nativeID);
-  if (n.tree)
-    collectTestIds(n.tree, acc);
-  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
-  if (Array.isArray(kids))
-    for (const c of kids)
-      collectTestIds(c, acc);
-  return acc;
-}
-function isExactPresent(treeJson, selector) {
-  return collectTestIds(treeJson).has(selector);
-}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope, selector) {
+function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
-  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
-  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
-  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
-  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
-  if (envelope.ok === true && !redbox && !truncated && !incomplete)
+  if (envelope.ok === true && !redbox && !truncated)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
-      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -79406,37 +79378,6 @@ function replayTreeData(envelope, selector) {
       ...envelope.meta ? { meta: envelope.meta } : {}
     }
   });
-}
-function countExactMatches(treeJson, id) {
-  let matches = 0;
-  const root = treeJson && typeof treeJson === "object" && "tree" in treeJson ? treeJson.tree : treeJson;
-  const stack = [root];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node || typeof node !== "object")
-      continue;
-    const record2 = node;
-    if (record2.testID === id || record2.nativeID === id)
-      matches++;
-    const children = record2.children ?? record2.nodes ?? record2.matches;
-    if (Array.isArray(children))
-      stack.push(...children);
-  }
-  return matches;
-}
-function countVisibilityMatches(treeJson, id) {
-  const treeMatches = countExactMatches(treeJson, id);
-  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
-    return treeMatches;
-  const interactive = treeJson.interactive;
-  if (!Array.isArray(interactive))
-    return 0;
-  return interactive.filter((node) => {
-    if (!node || typeof node !== "object")
-      return false;
-    const record2 = node;
-    return record2.testID === id || record2.nativeID === id;
-  }).length;
 }
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
@@ -79516,17 +79457,16 @@ function buildCdpDispatch(deps, signal) {
   const assertExactInteractable = async (id) => {
     const tree = await deps.treeFor(id);
     requireNotAborted();
-    const treeMatches = countExactMatches(tree, id);
-    if (treeMatches === 0)
+    const frontmost = await deps.frontmostFor(id);
+    requireNotAborted();
+    if (frontmost.matchCount === 0)
       throw new ReplayDispatchError("TESTID_NOT_FOUND", `testID "${id}" not present`, {
         failedSelector: id
       });
-    const frontmost = await deps.frontmostFor?.(id);
-    requireNotAborted();
-    const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+    const matches = frontmost.matchCount ?? 1;
     if (matches > 1)
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
-    if (frontmost && !frontmost.visible)
+    if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
     if (isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
@@ -79546,24 +79486,23 @@ function buildCdpDispatch(deps, signal) {
       await deps.typeByTestId(id, text);
     },
     async visibility(id) {
-      const tree = await deps.treeFor(id);
-      const treeMatches = countVisibilityMatches(tree, id);
-      if (treeMatches === 0)
+      await deps.treeFor(id);
+      const frontmost = await deps.frontmostFor(id);
+      if (frontmost.matchCount === 0)
         return {
           visible: false,
           code: "TESTID_NOT_FOUND",
           reason: `testID "${id}" not present in the React tree`,
           meta: { failedSelector: id }
         };
-      const frontmost = await deps.frontmostFor?.(id);
-      const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+      const matches = frontmost.matchCount ?? 1;
       if (matches > 1)
         return {
           visible: false,
           code: "AMBIGUOUS_TESTID",
           reason: `testID "${id}" resolves to ${matches} mounted elements`
         };
-      if (frontmost && !frontmost.visible)
+      if (!frontmost.visible)
         return {
           visible: false,
           code: frontmost.code ?? "ASSERTION_FAILED",
@@ -94097,7 +94036,7 @@ var makeReplayDeps = (_args, signal) => {
       if (d && typeof d === "object" && "__agent_truncated" in d) {
         env = await fetchTree(true);
       }
-      const data = replayTreeData(env, id);
+      const data = replayTreeData(env);
       return unwrapTree(data);
     },
     frontmostFor: async (id) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -78734,12 +78734,14 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+var MAX_TIMER_DELAY_MS = 2147483647;
 async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve21, reject) => {
     let settled = false;
+    let timer;
     const finish = (value) => {
       if (settled)
         return;
@@ -78747,7 +78749,11 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
       clearTimeout(timer);
       resolve21(Date.now() <= deadline ? value : null);
     };
-    const timer = setTimeout(() => finish(null), remainingMs);
+    const armDeadline = () => {
+      const nextRemainingMs = deadline - Date.now();
+      timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
+    };
+    armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
@@ -79344,6 +79350,20 @@ function countExactMatches(treeJson, id) {
   }
   return matches;
 }
+function countVisibilityMatches(treeJson, id) {
+  const treeMatches = countExactMatches(treeJson, id);
+  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
+    return treeMatches;
+  const interactive = treeJson.interactive;
+  if (!Array.isArray(interactive))
+    return 0;
+  return interactive.filter((node) => {
+    if (!node || typeof node !== "object")
+      return false;
+    const record2 = node;
+    return record2.testID === id || record2.nativeID === id;
+  }).length;
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -79453,7 +79473,7 @@ function buildCdpDispatch(deps, signal) {
     },
     async visibility(id) {
       const tree = await deps.treeFor(id);
-      const treeMatches = countExactMatches(tree, id);
+      const treeMatches = countVisibilityMatches(tree, id);
       if (treeMatches === 0)
         return {
           visible: false,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -78820,7 +78820,8 @@ function normalizeSteps(body, params) {
         out.push({
           t: "waitVisible",
           id: interp(id, params),
-          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+          evidenceType: "assert"
         });
         break;
       }
@@ -78897,6 +78898,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
+    const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
     try {
       requireNotAborted();
@@ -78939,11 +78941,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict = {
-            visible: false,
-            code: "TESTID_NOT_FOUND",
-            reason: `testID "${s.id}" not present before the visibility deadline`
-          };
+          let verdict = null;
           for (; ; ) {
             const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
@@ -78960,11 +78958,13 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
-            t: s.t,
+            t: evidenceType,
             target: s.id,
-            ok: verdict.visible,
+            ok: verdict?.visible === true,
             durationMs: waitedMs
           });
+          if (!verdict)
+            return fail3(i, `waitVisible: no readable visibility observation completed for "${s.id}" before the deadline`, "RUNNER_TIMEOUT", { failedSelector: s.id, waitedMs });
           if (!verdict.visible)
             return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
@@ -79019,7 +79019,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
       const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
-        t: s.t,
+        t: evidenceType,
         target: "id" in s ? s.id : void 0,
         ok: false,
         durationMs: waitedMs
@@ -79311,8 +79311,10 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0;
-  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
+  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
+  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
   const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
   const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 47;
+var HELPERS_VERSION = 48;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -51590,21 +51590,77 @@ var INJECTED_HELPERS = `
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  // complete is true only when the renderer-ID loop finished without the
+  // finished is true only when the renderer-ID loop finished without the
   // empty-streak early-exit \u2014 empty roots are mounting evidence only then
   // (GH #789).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+  var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
-  function computeUnscannedRendererIds() {
-    try {
-      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
-      var out = [];
-      hook.renderers.forEach(function(_v, id) {
-        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
-      });
-      return out;
-    } catch (_) { return []; }
+  function rootScanCoverage() {
+    var reasons = [];
+    var registryIds = [];
+    var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    var renderers = hook && hook.renderers;
+    if (renderers) {
+      if (typeof renderers.keys !== 'function' || typeof renderers.forEach !== 'function') {
+        registryIds = null;
+      } else {
+        try {
+          var iterator = renderers.keys();
+          if (!iterator || typeof iterator.next !== 'function') {
+            registryIds = null;
+          } else {
+            var step;
+            var iterations = 0;
+            while (registryIds !== null) {
+              step = iterator.next();
+              if (!step || typeof step !== 'object' || typeof step.done !== 'boolean') {
+                registryIds = null;
+                break;
+              }
+              if (step.done) break;
+              if (++iterations > MAX_REGISTERED_RENDERER_IDS || typeof step.value !== 'number') {
+                registryIds = null;
+                break;
+              }
+              if (registryIds.indexOf(step.value) === -1) registryIds.push(step.value);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            }
+          }
+        } catch (_) {
+          registryIds = null;
+        }
+        if (registryIds !== null) {
+          try {
+            var forEachIterations = 0;
+            renderers.forEach(function(_v, id) {
+              if (registryIds === null) return;
+              if (++forEachIterations > MAX_REGISTERED_RENDERER_IDS || typeof id !== 'number') {
+                registryIds = null;
+                return;
+              }
+              if (registryIds.indexOf(id) === -1) registryIds.push(id);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            });
+          } catch (_) {
+            registryIds = null;
+          }
+        }
+      }
+    }
+    var addReason = function(reason) {
+      if (reasons.indexOf(reason) === -1) reasons.push(reason);
+    };
+    if (lastRootScan.rendererErrors > 0 || registryIds === null) addReason('renderer-error');
+    if (!lastRootScan.finished) addReason('root-enumeration-incomplete');
+    var unscannedRendererIds = [];
+    if (registryIds !== null) {
+      for (var i = 0; i < registryIds.length; i++) {
+        var id = registryIds[i];
+        if (!lastRootScan.visited[id]) unscannedRendererIds.push(id);
+      }
+      if (unscannedRendererIds.length > 0) addReason('renderers-unscanned');
+    }
+    return { reasons: reasons, unscannedRendererIds: unscannedRendererIds };
   }
 
   // Read the renderer IDs React DevTools actually registered. A malformed or
@@ -51631,7 +51687,7 @@ var INJECTED_HELPERS = `
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -51642,7 +51698,7 @@ var INJECTED_HELPERS = `
     var emptyStreak = 0;
     for (var rii = 0; rii < rendererIds.length; rii++) {
       var ri = rendererIds[rii];
-      if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+      lastRootScan.visited[ri] = true;
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size > 0) {
@@ -51657,7 +51713,7 @@ var INJECTED_HELPERS = `
         lastRootScan.rendererErrors++;
       }
     }
-    lastRootScan.complete = true;
+    lastRootScan.finished = true;
     return null;
   }
 
@@ -51674,7 +51730,7 @@ var INJECTED_HELPERS = `
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -51686,7 +51742,7 @@ var INJECTED_HELPERS = `
       var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
-        if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+        lastRootScan.visited[ri] = true;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -51711,7 +51767,7 @@ var INJECTED_HELPERS = `
           lastRootScan.rendererErrors++;
         }
       }
-      lastRootScan.complete = !abortedEarly;
+      if (!abortedEarly) lastRootScan.finished = true;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -51947,10 +52003,12 @@ var INJECTED_HELPERS = `
       o = o || {};
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
-      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
-      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
-      var unscanned = computeUnscannedRendererIds();
-      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      var coverage = rootScanCoverage();
+      for (var coverageIndex = 0; coverageIndex < coverage.reasons.length; coverageIndex++) {
+        if (reasons.indexOf(coverage.reasons[coverageIndex]) === -1) {
+          reasons.push(coverage.reasons[coverageIndex]);
+        }
+      }
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
       if (o.outputTruncated) reasons.push('output-truncated');
       var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
@@ -51963,8 +52021,8 @@ var INJECTED_HELPERS = `
         effectiveDepth: maxDepth,
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
-        rendererErrors: lastRootScan.rendererErrors,
-        unscannedRendererIds: unscanned
+        complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
 
@@ -52428,7 +52486,8 @@ var INJECTED_HELPERS = `
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
       // Only a complete, clean scan is mounting evidence.
-      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
+      var mountCoverage = rootScanCoverage();
+      var mountScanClean = mountHookUsable && mountCoverage.reasons.length === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
@@ -52436,7 +52495,7 @@ var INJECTED_HELPERS = `
           retryInMs: 2000
         });
       }
-      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+      if (mountHookUsable && mountCoverage.reasons.indexOf('root-enumeration-incomplete') !== -1 && mountRoots.length === 0) {
         return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
@@ -55236,12 +55295,8 @@ var INJECTED_HELPERS = `
         truncated: true
       });
     }
-    var unscannedRendererIds = computeUnscannedRendererIds();
-    if (
-      lastRootScan.rendererErrors > 0 ||
-      !lastRootScan.complete ||
-      unscannedRendererIds.length > 0
-    ) {
+    var coverage = rootScanCoverage();
+    if (coverage.reasons.length > 0) {
       return JSON.stringify({
         visible: false,
         code: 'ASSERTION_FAILED',
@@ -78770,6 +78825,10 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
+      if (Date.now() > deadline) {
+        finish(null);
+        return;
+      }
       settled = true;
       clearTimeout(timer);
       reject(error2);
@@ -79322,9 +79381,8 @@ function replayTreeData(envelope, selector) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
-  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
   const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 48;
+var HELPERS_VERSION = 49;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -55300,10 +55300,13 @@ var INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
+      // A fiber and its work-in-progress alternate are the same logical node;
+      // committed .return chains may thread through either half of the pair.
+      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor) return true;
+        if (current === ancestor || current === ancestorAlternate) return true;
         current = current.return;
       }
       return false;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -81306,7 +81306,7 @@ function createRunActionHandler(deps = {}) {
         params: args.params,
         attempt: { attemptId: initialAttemptId, ordinal: 1, maxAttempts, kind: "initial" },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
@@ -81622,7 +81622,7 @@ function createRunActionHandler(deps = {}) {
           parentAttemptId: initialAttemptId
         },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -78734,6 +78734,29 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs < 0)
+    return null;
+  return new Promise((resolve21, reject) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      resolve21(Date.now() <= deadline ? value : null);
+    };
+    const timer = setTimeout(() => finish(null), remainingMs);
+    Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error2);
+    });
+  });
+}
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -78910,10 +78933,17 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict;
+          let verdict = {
+            visible: false,
+            code: "TESTID_NOT_FOUND",
+            reason: `testID "${s.id}" not present before the visibility deadline`
+          };
           for (; ; ) {
-            verdict = await dispatch.visibility(s.id);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
+            if (!observed)
+              break;
+            verdict = observed;
             if (verdict.visible)
               break;
             const remainingMs = deadline - Date.now();
@@ -79243,25 +79273,51 @@ function loginPostconditionId(commands) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
+function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
+  if (!node || typeof node !== "object")
+    return acc;
+  const n = node;
+  if (typeof n.testID === "string")
+    acc.add(n.testID);
+  if (typeof n.nativeID === "string")
+    acc.add(n.nativeID);
+  if (n.tree)
+    collectTestIds(n.tree, acc);
+  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
+  if (Array.isArray(kids))
+    for (const c of kids)
+      collectTestIds(c, acc);
+  return acc;
+}
+function isExactPresent(treeJson, selector) {
+  return collectTestIds(treeJson).has(selector);
+}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope) {
+function replayTreeData(envelope, selector) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const truncated = data !== null && data.__agent_truncated === true;
-  if (envelope.ok === true && !redbox && !truncated)
+  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
+  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
+  const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
+  const complete = verdict?.state === "ok" && reasons.length === 0;
+  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
+      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -93947,7 +94003,7 @@ var makeReplayDeps = (_args, signal) => {
       if (d && typeof d === "object" && "__agent_truncated" in d) {
         env = await fetchTree(true);
       }
-      const data = replayTreeData(env);
+      const data = replayTreeData(env, id);
       return unwrapTree(data);
     },
     frontmostFor: async (id) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -80468,7 +80468,7 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin();
+          await reproveManagedOrigin({ signal: flowAbort.signal });
         }
         await completeOrigin(true);
         nativeOriginPreclaimed = false;
@@ -81305,7 +81305,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));
@@ -81621,7 +81621,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79733,7 +79733,7 @@ function remapNativeSteps(steps, sourceIndices) {
     return mapped ? [mapped] : [];
   });
 }
-function partialNativeFailureMessage(meta) {
+function partialNativeFailureMessage(meta, nestedError) {
   const failedStep = remapNativeStep(meta.failedStep, 0, []);
   const lastStep = remapNativeStep(meta.lastStep, 0, []);
   const terminal = isRecord(meta.terminal) ? meta.terminal : null;
@@ -79742,7 +79742,12 @@ function partialNativeFailureMessage(meta) {
     kind: failureKind,
     selector: typeof terminal?.failureSelector === "string" ? terminal.failureSelector : null
   } : null;
-  const headline = formatFailureHeadline({ steps: [], failedStep, lastStep, reason }, { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true }, "Native replay segment failed.");
+  const headline = formatFailureHeadline(
+    { steps: [], failedStep, lastStep, reason },
+    { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true },
+    // Keep the nested envelope's own cause when no structured evidence exists.
+    nestedError?.replace(/^Maestro flow failed: /, "") || "Native replay segment failed."
+  );
   const runtimeDegradation = runtimeDegradationFromMetadata(meta.runtimeDegraded);
   return runtimeDegradation ? `${headline} \u2014 ${formatRuntimeDegradedHint(runtimeDegradation)}` : headline;
 }
@@ -79981,7 +79986,7 @@ function createMaestroRunHandler(deps = {}) {
               if (!nativeSegmentCoversAttempt) {
                 delete nestedMeta.trailingVerification;
                 delete nestedMeta.ledger;
-                nestedError = partialNativeFailureMessage(nestedMeta);
+                nestedError = partialNativeFailureMessage(nestedMeta, env.error);
               }
               combinedSteps.push(...remapNativeSteps(nestedMeta.steps, segment.sourceIndices));
               const uniqueProofDomains = [...new Set(proofDomains)];
@@ -80462,7 +80467,7 @@ function createMaestroRunHandler(deps = {}) {
         signal: flowAbort.signal
       });
       if (deferredNativeOriginTarget) {
-        if (nativeOriginPreclaimed && replayFactory && (args.reproveManagedOrigin || deps.reproveManagedOrigin || hasManagedNativeOriginAuthority(args))) {
+        if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
           await reproveManagedOrigin();
         }
         await completeOrigin(true);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 49;
+var HELPERS_VERSION = 50;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -52018,6 +52018,7 @@ var INJECTED_HELPERS = `
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
         complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        rendererErrors: lastRootScan.rendererErrors,
         unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
@@ -55335,6 +55336,9 @@ var INJECTED_HELPERS = `
       });
     }
     var target = logicalMatches[0];
+    var targetProps = target.memoizedProps || {};
+    var targetAccessibilityState = targetProps.accessibilityState || {};
+    var targetDisabled = targetProps.disabled === true || targetAccessibilityState.disabled === true;
     if (__hidden(target)) {
       return JSON.stringify({
         visible: false,
@@ -55343,7 +55347,7 @@ var INJECTED_HELPERS = `
       });
     }
 
-    var targetPointerEvents = (target.memoizedProps || {}).pointerEvents;
+    var targetPointerEvents = targetProps.pointerEvents;
     if (targetPointerEvents === 'none' || targetPointerEvents === 'box-none') {
       return JSON.stringify({
         visible: false,
@@ -55509,7 +55513,8 @@ var INJECTED_HELPERS = `
       route: routeOwner,
       activeRoute: activeRoute,
       modalCount: modals.length,
-      matchCount: 1
+      matchCount: 1,
+      disabled: targetDisabled
     });
   }
 
@@ -78802,24 +78807,44 @@ var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
 var MAX_TIMER_DELAY_MS = 2147483647;
-async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+async function readVisibilityBeforeDeadline(dispatch, id, deadline, signal) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve21, reject) => {
     let settled = false;
     let timer;
+    const cleanup = () => {
+      if (timer !== void 0)
+        clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
     const finish = (value) => {
       if (settled)
         return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve21(Date.now() <= deadline ? value : null);
+    };
+    const fail3 = (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      cleanup();
+      reject(error2);
+    };
+    const onAbort = () => {
+      fail3(new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline"));
     };
     const armDeadline = () => {
       const nextRemainingMs = deadline - Date.now();
       timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
     };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
@@ -78828,9 +78853,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
         finish(null);
         return;
       }
-      settled = true;
-      clearTimeout(timer);
-      reject(error2);
+      fail3(error2);
     });
   });
 }
@@ -79014,7 +79037,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const deadline = startedAt + s.timeoutMs;
           let verdict = null;
           for (; ; ) {
-            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline, opts.signal);
             requireNotAborted();
             if (!observed)
               break;
@@ -79470,7 +79493,7 @@ function buildCdpDispatch(deps, signal) {
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
     if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
-    if (isDisabled(nodeProps(tree, id)))
+    if (frontmost.disabled === true || isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
     const pointerEventsError = pointerEventsBlock(tree, id);
     if (pointerEventsError)
@@ -94054,6 +94077,7 @@ var makeReplayDeps = (_args, signal) => {
         const parsed = JSON.parse(result.value);
         return {
           visible: parsed.visible === true,
+          ...typeof parsed.disabled === "boolean" ? { disabled: parsed.disabled } : {},
           ...parsed.reason ? { reason: parsed.reason } : {},
           ...typeof parsed.matchCount === "number" ? { matchCount: parsed.matchCount } : {},
           ...parsed.code ? { code: parsed.code } : {}

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79362,13 +79362,16 @@ function replayTreeData(envelope) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  if (envelope.ok === true && !redbox && !truncated)
+  const agentError = typeof data?.__agent_error === "string" ? data.__agent_error.slice(0, 1e3) : void 0;
+  const serializationFailed = agentError !== void 0;
+  if (envelope.ok === true && !redbox && !truncated && !serializationFailed)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
-  const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
+  const message = serializationFailed ? agentError || "Component tree serialization failed" : truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const code = serializationFailed ? "EVAL_FAILED" : redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...serializationFailed ? { agentError } : {},
       ...truncated ? { truncated: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -80468,9 +80468,12 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin({ signal: flowAbort.signal });
+          await reproveManagedOrigin({
+            signal: flowAbort.signal,
+            readinessTimeoutMs: Math.max(1, flowDeadline - now())
+          });
         }
-        await completeOrigin(true);
+        await completeOrigin(true, flowAbort.signal);
         nativeOriginPreclaimed = false;
       }
       await commitReinstalledInstall();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51948,6 +51948,7 @@ var INJECTED_HELPERS = `
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
       if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
       var unscanned = computeUnscannedRendererIds();
       if (unscanned.length > 0) reasons.push('renderers-unscanned');
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
@@ -55233,6 +55234,18 @@ var INJECTED_HELPERS = `
         reason: 'frontmost testID scan exceeded its bounded React-tree budget',
         code: 'ASSERTION_FAILED',
         truncated: true
+      });
+    }
+    var unscannedRendererIds = computeUnscannedRendererIds();
+    if (
+      lastRootScan.rendererErrors > 0 ||
+      !lastRootScan.complete ||
+      unscannedRendererIds.length > 0
+    ) {
+      return JSON.stringify({
+        visible: false,
+        code: 'ASSERTION_FAILED',
+        reason: 'frontmost proof cannot cover every mounted renderer'
       });
     }
     function containsFiber(ancestor, candidate) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15136,6 +15136,8 @@ var ReplayDispatchError = class extends Error {
 var interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)(?:\s*\?\?\s*(['"])(.*?)\2)?\}/g, (match, key, _quote, fallback) => p[key] ?? fallback ?? match);
 var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
+var VISIBILITY_POLL_INTERVAL_MS = 200;
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -15190,7 +15192,11 @@ function normalizeSteps(body, params) {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
           throw new UnsupportedStepError("assertVisible (missing string id)");
-        out.push({ t: "assert", id: interp(id, params) });
+        out.push({
+          t: "waitVisible",
+          id: interp(id, params),
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+        });
         break;
       }
       case "extendedWaitUntil": {
@@ -15200,10 +15206,10 @@ function normalizeSteps(body, params) {
           refuseUnsupportedKeys(v.visible, ["id"], "extendedWaitUntil.visible");
         }
         const id = isObj(v) && isObj(v.visible) ? asString(v.visible.id) : null;
-        const timeoutMs = isObj(v) ? v.timeout : void 0;
-        if (!id || !Number.isSafeInteger(timeoutMs) || Number(timeoutMs) < 0)
-          throw new UnsupportedStepError("extendedWaitUntil (need visible.id + non-negative integer timeout)");
-        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs: Number(timeoutMs) });
+        const timeoutMs = isObj(v) && "timeout" in v ? v.timeout : DEFAULT_VISIBILITY_TIMEOUT_MS;
+        if (!id || typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs < 0)
+          throw new UnsupportedStepError("extendedWaitUntil (need visible.id; timeout must be finite and non-negative when present)");
+        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs });
         break;
       }
       case "waitForAnimationToEnd": {
@@ -15306,39 +15312,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         }
-        case "assert": {
-          const verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          trace.push({
-            sourceIndex: sourceIndex(i),
-            t: s.t,
-            target: s.id,
-            ok: verdict.visible,
-            durationMs: Date.now() - startedAt
-          });
-          if (!verdict.visible)
-            return fail(i, verdict.reason ?? `assertVisible: "${s.id}" is not frontmost`, verdict.code ?? "ASSERTION_FAILED", verdict.meta);
-          break;
-        }
         case "waitVisible": {
-          const deadline = Date.now() + s.timeoutMs;
-          let verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          while (!verdict.visible && Date.now() < deadline) {
-            requireNotAborted();
-            await new Promise((resolve9) => setTimeout(resolve9, 100));
+          const deadline = startedAt + s.timeoutMs;
+          let verdict;
+          for (; ; ) {
             verdict = await dispatch.visibility(s.id);
             requireNotAborted();
+            if (verdict.visible)
+              break;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0)
+              break;
+            await new Promise((resolve9) => setTimeout(resolve9, Math.min(VISIBILITY_POLL_INTERVAL_MS, remainingMs)));
           }
+          const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
             ok: verdict.visible,
-            durationMs: Date.now() - startedAt
+            durationMs: waitedMs
           });
           if (!verdict.visible)
-            return fail(i, verdict.reason ?? `extendedWaitUntil: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", verdict.meta);
+            return fail(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
         }
         case "wait":
@@ -15388,14 +15384,16 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
       }
     } catch (e) {
+      const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
         t: s.t,
         target: "id" in s ? s.id : void 0,
         ok: false,
-        durationMs: Date.now() - startedAt
+        durationMs: waitedMs
       });
-      return fail(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, e instanceof ReplayDispatchError ? e.meta : void 0);
+      const dispatchMeta = e instanceof ReplayDispatchError ? e.meta : void 0;
+      return fail(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, s.t === "waitVisible" ? { ...dispatchMeta, failedSelector: s.id, waitedMs } : dispatchMeta);
     }
   }
   if (opts.signal?.aborted) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15138,12 +15138,14 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+var MAX_TIMER_DELAY_MS = 2147483647;
 async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve9, reject) => {
     let settled = false;
+    let timer;
     const finish = (value) => {
       if (settled)
         return;
@@ -15151,7 +15153,11 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
       clearTimeout(timer);
       resolve9(Date.now() <= deadline ? value : null);
     };
-    const timer = setTimeout(() => finish(null), remainingMs);
+    const armDeadline = () => {
+      const nextRemainingMs = deadline - Date.now();
+      timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
+    };
+    armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
       if (settled)
         return;
@@ -15691,6 +15697,20 @@ function countExactMatches(treeJson, id) {
   }
   return matches;
 }
+function countVisibilityMatches(treeJson, id) {
+  const treeMatches = countExactMatches(treeJson, id);
+  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
+    return treeMatches;
+  const interactive = treeJson.interactive;
+  if (!Array.isArray(interactive))
+    return 0;
+  return interactive.filter((node) => {
+    if (!node || typeof node !== "object")
+      return false;
+    const record = node;
+    return record.testID === id || record.nativeID === id;
+  }).length;
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -15800,7 +15820,7 @@ function buildCdpDispatch(deps, signal) {
     },
     async visibility(id) {
       const tree = await deps.treeFor(id);
-      const treeMatches = countExactMatches(tree, id);
+      const treeMatches = countVisibilityMatches(tree, id);
       if (treeMatches === 0)
         return {
           visible: false,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -16767,9 +16767,12 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin({ signal: flowAbort.signal });
+          await reproveManagedOrigin({
+            signal: flowAbort.signal,
+            readinessTimeoutMs: Math.max(1, flowDeadline - now())
+          });
         }
-        await completeOrigin(true);
+        await completeOrigin(true, flowAbort.signal);
         nativeOriginPreclaimed = false;
       }
       await commitReinstalledInstall();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15161,6 +15161,10 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
       if (settled)
         return;
+      if (Date.now() > deadline) {
+        finish(null);
+        return;
+      }
       settled = true;
       clearTimeout(timer);
       reject(error);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -16767,7 +16767,7 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin();
+          await reproveManagedOrigin({ signal: flowAbort.signal });
         }
         await completeOrigin(true);
         nativeOriginPreclaimed = false;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -16032,7 +16032,7 @@ function remapNativeSteps(steps, sourceIndices) {
     return mapped ? [mapped] : [];
   });
 }
-function partialNativeFailureMessage(meta) {
+function partialNativeFailureMessage(meta, nestedError) {
   const failedStep = remapNativeStep(meta.failedStep, 0, []);
   const lastStep = remapNativeStep(meta.lastStep, 0, []);
   const terminal = isRecord(meta.terminal) ? meta.terminal : null;
@@ -16041,7 +16041,12 @@ function partialNativeFailureMessage(meta) {
     kind: failureKind,
     selector: typeof terminal?.failureSelector === "string" ? terminal.failureSelector : null
   } : null;
-  const headline = formatFailureHeadline({ steps: [], failedStep, lastStep, reason }, { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true }, "Native replay segment failed.");
+  const headline = formatFailureHeadline(
+    { steps: [], failedStep, lastStep, reason },
+    { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true },
+    // Keep the nested envelope's own cause when no structured evidence exists.
+    nestedError?.replace(/^Maestro flow failed: /, "") || "Native replay segment failed."
+  );
   const runtimeDegradation = runtimeDegradationFromMetadata(meta.runtimeDegraded);
   return runtimeDegradation ? `${headline} \u2014 ${formatRuntimeDegradedHint(runtimeDegradation)}` : headline;
 }
@@ -16280,7 +16285,7 @@ function createMaestroRunHandler(deps = {}) {
               if (!nativeSegmentCoversAttempt) {
                 delete nestedMeta.trailingVerification;
                 delete nestedMeta.ledger;
-                nestedError = partialNativeFailureMessage(nestedMeta);
+                nestedError = partialNativeFailureMessage(nestedMeta, env.error);
               }
               combinedSteps.push(...remapNativeSteps(nestedMeta.steps, segment.sourceIndices));
               const uniqueProofDomains = [...new Set(proofDomains)];
@@ -16761,7 +16766,7 @@ function createMaestroRunHandler(deps = {}) {
         signal: flowAbort.signal
       });
       if (deferredNativeOriginTarget) {
-        if (nativeOriginPreclaimed && replayFactory && (args.reproveManagedOrigin || deps.reproveManagedOrigin || hasManagedNativeOriginAuthority(args))) {
+        if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
           await reproveManagedOrigin();
         }
         await completeOrigin(true);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15138,6 +15138,29 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs < 0)
+    return null;
+  return new Promise((resolve9, reject) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      resolve9(Date.now() <= deadline ? value : null);
+    };
+    const timer = setTimeout(() => finish(null), remainingMs);
+    Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -15314,10 +15337,17 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict;
+          let verdict = {
+            visible: false,
+            code: "TESTID_NOT_FOUND",
+            reason: `testID "${s.id}" not present before the visibility deadline`
+          };
           for (; ; ) {
-            verdict = await dispatch.visibility(s.id);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
+            if (!observed)
+              break;
+            verdict = observed;
             if (verdict.visible)
               break;
             const remainingMs = deadline - Date.now();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15139,24 +15139,44 @@ var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
 var MAX_TIMER_DELAY_MS = 2147483647;
-async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+async function readVisibilityBeforeDeadline(dispatch, id, deadline, signal) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve9, reject) => {
     let settled = false;
     let timer;
+    const cleanup = () => {
+      if (timer !== void 0)
+        clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
     const finish = (value) => {
       if (settled)
         return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve9(Date.now() <= deadline ? value : null);
+    };
+    const fail = (error) => {
+      if (settled)
+        return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = () => {
+      fail(new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline"));
     };
     const armDeadline = () => {
       const nextRemainingMs = deadline - Date.now();
       timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
     };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
       if (settled)
@@ -15165,9 +15185,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
         finish(null);
         return;
       }
-      settled = true;
-      clearTimeout(timer);
-      reject(error);
+      fail(error);
     });
   });
 }
@@ -15351,7 +15369,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const deadline = startedAt + s.timeoutMs;
           let verdict = null;
           for (; ; ) {
-            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline, opts.signal);
             requireNotAborted();
             if (!observed)
               break;
@@ -15773,7 +15791,7 @@ function buildCdpDispatch(deps, signal) {
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
     if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
-    if (isDisabled(nodeProps(tree, id)))
+    if (frontmost.disabled === true || isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
     const pointerEventsError = pointerEventsBlock(tree, id);
     if (pointerEventsError)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15684,37 +15684,6 @@ function loginPostconditionId(commands) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
-function countExactMatches(treeJson, id) {
-  let matches = 0;
-  const root2 = treeJson && typeof treeJson === "object" && "tree" in treeJson ? treeJson.tree : treeJson;
-  const stack = [root2];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node || typeof node !== "object")
-      continue;
-    const record = node;
-    if (record.testID === id || record.nativeID === id)
-      matches++;
-    const children = record.children ?? record.nodes ?? record.matches;
-    if (Array.isArray(children))
-      stack.push(...children);
-  }
-  return matches;
-}
-function countVisibilityMatches(treeJson, id) {
-  const treeMatches = countExactMatches(treeJson, id);
-  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
-    return treeMatches;
-  const interactive = treeJson.interactive;
-  if (!Array.isArray(interactive))
-    return 0;
-  return interactive.filter((node) => {
-    if (!node || typeof node !== "object")
-      return false;
-    const record = node;
-    return record.testID === id || record.nativeID === id;
-  }).length;
-}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -15793,17 +15762,16 @@ function buildCdpDispatch(deps, signal) {
   const assertExactInteractable = async (id) => {
     const tree = await deps.treeFor(id);
     requireNotAborted();
-    const treeMatches = countExactMatches(tree, id);
-    if (treeMatches === 0)
+    const frontmost = await deps.frontmostFor(id);
+    requireNotAborted();
+    if (frontmost.matchCount === 0)
       throw new ReplayDispatchError("TESTID_NOT_FOUND", `testID "${id}" not present`, {
         failedSelector: id
       });
-    const frontmost = await deps.frontmostFor?.(id);
-    requireNotAborted();
-    const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+    const matches = frontmost.matchCount ?? 1;
     if (matches > 1)
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
-    if (frontmost && !frontmost.visible)
+    if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
     if (isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
@@ -15823,24 +15791,23 @@ function buildCdpDispatch(deps, signal) {
       await deps.typeByTestId(id, text);
     },
     async visibility(id) {
-      const tree = await deps.treeFor(id);
-      const treeMatches = countVisibilityMatches(tree, id);
-      if (treeMatches === 0)
+      await deps.treeFor(id);
+      const frontmost = await deps.frontmostFor(id);
+      if (frontmost.matchCount === 0)
         return {
           visible: false,
           code: "TESTID_NOT_FOUND",
           reason: `testID "${id}" not present in the React tree`,
           meta: { failedSelector: id }
         };
-      const frontmost = await deps.frontmostFor?.(id);
-      const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+      const matches = frontmost.matchCount ?? 1;
       if (matches > 1)
         return {
           visible: false,
           code: "AMBIGUOUS_TESTID",
           reason: `testID "${id}" resolves to ${matches} mounted elements`
         };
-      if (frontmost && !frontmost.visible)
+      if (!frontmost.visible)
         return {
           visible: false,
           code: frontmost.code ?? "ASSERTION_FAILED",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15224,7 +15224,8 @@ function normalizeSteps(body, params) {
         out.push({
           t: "waitVisible",
           id: interp(id, params),
-          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+          evidenceType: "assert"
         });
         break;
       }
@@ -15301,6 +15302,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
+    const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
     try {
       requireNotAborted();
@@ -15343,11 +15345,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict = {
-            visible: false,
-            code: "TESTID_NOT_FOUND",
-            reason: `testID "${s.id}" not present before the visibility deadline`
-          };
+          let verdict = null;
           for (; ; ) {
             const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
@@ -15364,11 +15362,13 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
-            t: s.t,
+            t: evidenceType,
             target: s.id,
-            ok: verdict.visible,
+            ok: verdict?.visible === true,
             durationMs: waitedMs
           });
+          if (!verdict)
+            return fail(i, `waitVisible: no readable visibility observation completed for "${s.id}" before the deadline`, "RUNNER_TIMEOUT", { failedSelector: s.id, waitedMs });
           if (!verdict.visible)
             return fail(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
@@ -15423,7 +15423,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
       const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
-        t: s.t,
+        t: evidenceType,
         target: "id" in s ? s.id : void 0,
         ok: false,
         durationMs: waitedMs

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82512,7 +82512,7 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin();
+          await reproveManagedOrigin({ signal: flowAbort.signal });
         }
         await completeOrigin(true);
         nativeOriginPreclaimed = false;
@@ -83411,7 +83411,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));
@@ -83727,7 +83727,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67675,8 +67675,7 @@ var init_injected_helpers = __esm({
       });
     }
     function containsFiber(ancestor, candidate) {
-      // A fiber and its work-in-progress alternate are the same logical node;
-      // committed .return chains may thread through either half of the pair.
+      // React return chains may thread through either half of a fiber/alternate pair.
       var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81788,7 +81788,7 @@ function remapNativeSteps(steps, sourceIndices) {
     return mapped ? [mapped] : [];
   });
 }
-function partialNativeFailureMessage(meta) {
+function partialNativeFailureMessage(meta, nestedError) {
   const failedStep = remapNativeStep(meta.failedStep, 0, []);
   const lastStep = remapNativeStep(meta.lastStep, 0, []);
   const terminal = isRecord(meta.terminal) ? meta.terminal : null;
@@ -81797,7 +81797,12 @@ function partialNativeFailureMessage(meta) {
     kind: failureKind,
     selector: typeof terminal?.failureSelector === "string" ? terminal.failureSelector : null
   } : null;
-  const headline = formatFailureHeadline({ steps: [], failedStep, lastStep, reason }, { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true }, "Native replay segment failed.");
+  const headline = formatFailureHeadline(
+    { steps: [], failedStep, lastStep, reason },
+    { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true },
+    // Keep the nested envelope's own cause when no structured evidence exists.
+    nestedError?.replace(/^Maestro flow failed: /, "") || "Native replay segment failed."
+  );
   const runtimeDegradation = runtimeDegradationFromMetadata(meta.runtimeDegraded);
   return runtimeDegradation ? `${headline} \u2014 ${formatRuntimeDegradedHint(runtimeDegradation)}` : headline;
 }
@@ -82025,7 +82030,7 @@ function createMaestroRunHandler(deps = {}) {
               if (!nativeSegmentCoversAttempt) {
                 delete nestedMeta.trailingVerification;
                 delete nestedMeta.ledger;
-                nestedError = partialNativeFailureMessage(nestedMeta);
+                nestedError = partialNativeFailureMessage(nestedMeta, env.error);
               }
               combinedSteps.push(...remapNativeSteps(nestedMeta.steps, segment.sourceIndices));
               const uniqueProofDomains = [...new Set(proofDomains)];
@@ -82506,7 +82511,7 @@ function createMaestroRunHandler(deps = {}) {
         signal: flowAbort.signal
       });
       if (deferredNativeOriginTarget) {
-        if (nativeOriginPreclaimed && replayFactory && (args.reproveManagedOrigin || deps.reproveManagedOrigin || hasManagedNativeOriginAuthority(args))) {
+        if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
           await reproveManagedOrigin();
         }
         await completeOrigin(true);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80841,7 +80841,8 @@ function normalizeSteps(body, params) {
         out.push({
           t: "waitVisible",
           id: interp(id, params),
-          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+          evidenceType: "assert"
         });
         break;
       }
@@ -80918,6 +80919,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
+    const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
     try {
       requireNotAborted();
@@ -80960,11 +80962,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict = {
-            visible: false,
-            code: "TESTID_NOT_FOUND",
-            reason: `testID "${s.id}" not present before the visibility deadline`
-          };
+          let verdict = null;
           for (; ; ) {
             const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
@@ -80981,11 +80979,13 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
-            t: s.t,
+            t: evidenceType,
             target: s.id,
-            ok: verdict.visible,
+            ok: verdict?.visible === true,
             durationMs: waitedMs
           });
+          if (!verdict)
+            return fail3(i, `waitVisible: no readable visibility observation completed for "${s.id}" before the deadline`, "RUNNER_TIMEOUT", { failedSelector: s.id, waitedMs });
           if (!verdict.visible)
             return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
@@ -81040,7 +81040,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
       const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
-        t: s.t,
+        t: evidenceType,
         target: "id" in s ? s.id : void 0,
         ok: false,
         durationMs: waitedMs
@@ -81369,8 +81369,10 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0;
-  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
+  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
+  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
   const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
   const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81369,12 +81369,13 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
-  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
+  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
+  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
   const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -96897,7 +96897,7 @@ var init_index = __esm({
           })).content[0].text);
           let env = await fetchTree(false);
           const d = env.data;
-          if (d && typeof d === "object" && "__agent_truncated" in d) {
+          if (d && typeof d === "object" && ("__agent_truncated" in d || d.truncated === true)) {
             env = await fetchTree(true);
           }
           const data = replayTreeData(env);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 48;
+    HELPERS_VERSION = 49;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -67674,10 +67674,13 @@ var init_injected_helpers = __esm({
       });
     }
     function containsFiber(ancestor, candidate) {
+      // A fiber and its work-in-progress alternate are the same logical node;
+      // committed .return chains may thread through either half of the pair.
+      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor) return true;
+        if (current === ancestor || current === ancestorAlternate) return true;
         current = current.return;
       }
       return false;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63962,11 +63962,7 @@ var init_injected_helpers = __esm({
     '_LogBoxInspectorContainer'
   ];
 
-  // Reset by every root-iteration pass; only valid when read synchronously
-  // after the pass that produced the tree (many helpers share the iterators).
-  // finished is true only when the renderer-ID loop finished without the
-  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
-  // (GH #789).
+  // Synchronous scan result; finished stays false after the GH #789 empty-streak exit.
   var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
   function rootScanCoverage() {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80762,6 +80762,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     return null;
   return new Promise((resolve22, reject) => {
     let settled = false;
+    let timer;
     const finish = (value) => {
       if (settled)
         return;
@@ -80769,7 +80770,11 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
       clearTimeout(timer);
       resolve22(Date.now() <= deadline ? value : null);
     };
-    const timer = setTimeout(() => finish(null), remainingMs);
+    const armDeadline = () => {
+      const nextRemainingMs = deadline - Date.now();
+      timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
+    };
+    armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
@@ -81049,7 +81054,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
-var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj, DEFAULT_VISIBILITY_TIMEOUT_MS, VISIBILITY_POLL_INTERVAL_MS;
+var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj, DEFAULT_VISIBILITY_TIMEOUT_MS, VISIBILITY_POLL_INTERVAL_MS, MAX_TIMER_DELAY_MS;
 var init_cdp_flow_replay = __esm({
   "packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js"() {
     "use strict";
@@ -81076,6 +81081,7 @@ var init_cdp_flow_replay = __esm({
     isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
     DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
     VISIBILITY_POLL_INTERVAL_MS = 200;
+    MAX_TIMER_DELAY_MS = 2147483647;
   }
 });
 
@@ -81402,6 +81408,20 @@ function countExactMatches(treeJson, id) {
   }
   return matches;
 }
+function countVisibilityMatches(treeJson, id) {
+  const treeMatches = countExactMatches(treeJson, id);
+  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
+    return treeMatches;
+  const interactive = treeJson.interactive;
+  if (!Array.isArray(interactive))
+    return 0;
+  return interactive.filter((node) => {
+    if (!node || typeof node !== "object")
+      return false;
+    const record2 = node;
+    return record2.testID === id || record2.nativeID === id;
+  }).length;
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -81511,7 +81531,7 @@ function buildCdpDispatch(deps, signal) {
     },
     async visibility(id) {
       const tree = await deps.treeFor(id);
-      const treeMatches = countExactMatches(tree, id);
+      const treeMatches = countVisibilityMatches(tree, id);
       if (treeMatches === 0)
         return {
           visible: false,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -64322,6 +64322,7 @@ var init_injected_helpers = __esm({
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
       if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
       var unscanned = computeUnscannedRendererIds();
       if (unscanned.length > 0) reasons.push('renderers-unscanned');
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
@@ -67607,6 +67608,18 @@ var init_injected_helpers = __esm({
         reason: 'frontmost testID scan exceeded its bounded React-tree budget',
         code: 'ASSERTION_FAILED',
         truncated: true
+      });
+    }
+    var unscannedRendererIds = computeUnscannedRendererIds();
+    if (
+      lastRootScan.rendererErrors > 0 ||
+      !lastRootScan.complete ||
+      unscannedRendererIds.length > 0
+    ) {
+      return JSON.stringify({
+        visible: false,
+        code: 'ASSERTION_FAILED',
+        reason: 'frontmost proof cannot cover every mounted renderer'
       });
     }
     function containsFiber(ancestor, candidate) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80810,7 +80810,11 @@ function normalizeSteps(body, params) {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
           throw new UnsupportedStepError("assertVisible (missing string id)");
-        out.push({ t: "assert", id: interp(id, params) });
+        out.push({
+          t: "waitVisible",
+          id: interp(id, params),
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+        });
         break;
       }
       case "extendedWaitUntil": {
@@ -80820,10 +80824,10 @@ function normalizeSteps(body, params) {
           refuseUnsupportedKeys(v.visible, ["id"], "extendedWaitUntil.visible");
         }
         const id = isObj(v) && isObj(v.visible) ? asString(v.visible.id) : null;
-        const timeoutMs = isObj(v) ? v.timeout : void 0;
-        if (!id || !Number.isSafeInteger(timeoutMs) || Number(timeoutMs) < 0)
-          throw new UnsupportedStepError("extendedWaitUntil (need visible.id + non-negative integer timeout)");
-        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs: Number(timeoutMs) });
+        const timeoutMs = isObj(v) && "timeout" in v ? v.timeout : DEFAULT_VISIBILITY_TIMEOUT_MS;
+        if (!id || typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs < 0)
+          throw new UnsupportedStepError("extendedWaitUntil (need visible.id; timeout must be finite and non-negative when present)");
+        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs });
         break;
       }
       case "waitForAnimationToEnd": {
@@ -80926,39 +80930,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         }
-        case "assert": {
-          const verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          trace.push({
-            sourceIndex: sourceIndex(i),
-            t: s.t,
-            target: s.id,
-            ok: verdict.visible,
-            durationMs: Date.now() - startedAt
-          });
-          if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `assertVisible: "${s.id}" is not frontmost`, verdict.code ?? "ASSERTION_FAILED", verdict.meta);
-          break;
-        }
         case "waitVisible": {
-          const deadline = Date.now() + s.timeoutMs;
-          let verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          while (!verdict.visible && Date.now() < deadline) {
-            requireNotAborted();
-            await new Promise((resolve22) => setTimeout(resolve22, 100));
+          const deadline = startedAt + s.timeoutMs;
+          let verdict;
+          for (; ; ) {
             verdict = await dispatch.visibility(s.id);
             requireNotAborted();
+            if (verdict.visible)
+              break;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0)
+              break;
+            await new Promise((resolve22) => setTimeout(resolve22, Math.min(VISIBILITY_POLL_INTERVAL_MS, remainingMs)));
           }
+          const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
             ok: verdict.visible,
-            durationMs: Date.now() - startedAt
+            durationMs: waitedMs
           });
           if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `extendedWaitUntil: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", verdict.meta);
+            return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
         }
         case "wait":
@@ -81008,14 +81002,16 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
       }
     } catch (e) {
+      const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
         t: s.t,
         target: "id" in s ? s.id : void 0,
         ok: false,
-        durationMs: Date.now() - startedAt
+        durationMs: waitedMs
       });
-      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, e instanceof ReplayDispatchError ? e.meta : void 0);
+      const dispatchMeta = e instanceof ReplayDispatchError ? e.meta : void 0;
+      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, s.t === "waitVisible" ? { ...dispatchMeta, failedSelector: s.id, waitedMs } : dispatchMeta);
     }
   }
   if (opts.signal?.aborted) {
@@ -81023,7 +81019,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
-var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj;
+var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj, DEFAULT_VISIBILITY_TIMEOUT_MS, VISIBILITY_POLL_INTERVAL_MS;
 var init_cdp_flow_replay = __esm({
   "packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js"() {
     "use strict";
@@ -81048,6 +81044,8 @@ var init_cdp_flow_replay = __esm({
     interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)(?:\s*\?\?\s*(['"])(.*?)\2)?\}/g, (match, key, _quote, fallback) => p[key] ?? fallback ?? match);
     asString = (x) => typeof x === "string" ? x : null;
     isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+    DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
+    VISIBILITY_POLL_INTERVAL_MS = 200;
   }
 });
 
@@ -81312,14 +81310,17 @@ function unwrapTree(data) {
 function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
-  if (envelope.ok === true && !redbox)
-    return envelope.data;
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const message = redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const truncated = data !== null && data.__agent_truncated === true;
+  if (envelope.ok === true && !redbox && !truncated)
+    return envelope.data;
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...truncated ? { truncated: true } : {},
+      ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
       ...warning ? { warning } : {},
@@ -96781,12 +96782,11 @@ var init_index = __esm({
             ...interactiveOnly ? { interactiveOnly: true } : {}
           })).content[0].text);
           let env = await fetchTree(false);
-          let data = replayTreeData(env);
-          const d = data;
+          const d = env.data;
           if (d && typeof d === "object" && "__agent_truncated" in d) {
             env = await fetchTree(true);
-            data = replayTreeData(env);
           }
+          const data = replayTreeData(env);
           return unwrapTree(data);
         },
         frontmostFor: async (id) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 49;
+    HELPERS_VERSION = 50;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -64392,6 +64392,7 @@ var init_injected_helpers = __esm({
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
         complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        rendererErrors: lastRootScan.rendererErrors,
         unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
@@ -67709,6 +67710,9 @@ var init_injected_helpers = __esm({
       });
     }
     var target = logicalMatches[0];
+    var targetProps = target.memoizedProps || {};
+    var targetAccessibilityState = targetProps.accessibilityState || {};
+    var targetDisabled = targetProps.disabled === true || targetAccessibilityState.disabled === true;
     if (__hidden(target)) {
       return JSON.stringify({
         visible: false,
@@ -67717,7 +67721,7 @@ var init_injected_helpers = __esm({
       });
     }
 
-    var targetPointerEvents = (target.memoizedProps || {}).pointerEvents;
+    var targetPointerEvents = targetProps.pointerEvents;
     if (targetPointerEvents === 'none' || targetPointerEvents === 'box-none') {
       return JSON.stringify({
         visible: false,
@@ -67883,7 +67887,8 @@ var init_injected_helpers = __esm({
       route: routeOwner,
       activeRoute: activeRoute,
       modalCount: modals.length,
-      matchCount: 1
+      matchCount: 1,
+      disabled: targetDisabled
     });
   }
 
@@ -80823,24 +80828,44 @@ var init_maestro_run_ledger = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
-async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+async function readVisibilityBeforeDeadline(dispatch, id, deadline, signal) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve22, reject) => {
     let settled = false;
     let timer;
+    const cleanup = () => {
+      if (timer !== void 0)
+        clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
     const finish = (value) => {
       if (settled)
         return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve22(Date.now() <= deadline ? value : null);
+    };
+    const fail3 = (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      cleanup();
+      reject(error2);
+    };
+    const onAbort = () => {
+      fail3(new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline"));
     };
     const armDeadline = () => {
       const nextRemainingMs = deadline - Date.now();
       timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
     };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
@@ -80849,9 +80874,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
         finish(null);
         return;
       }
-      settled = true;
-      clearTimeout(timer);
-      reject(error2);
+      fail3(error2);
     });
   });
 }
@@ -81035,7 +81058,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const deadline = startedAt + s.timeoutMs;
           let verdict = null;
           for (; ; ) {
-            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline, opts.signal);
             requireNotAborted();
             if (!observed)
               break;
@@ -81528,7 +81551,7 @@ function buildCdpDispatch(deps, signal) {
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
     if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
-    if (isDisabled(nodeProps(tree, id)))
+    if (frontmost.disabled === true || isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
     const pointerEventsError = pointerEventsBlock(tree, id);
     if (pointerEventsError)
@@ -96893,6 +96916,7 @@ var init_index = __esm({
             const parsed = JSON.parse(result.value);
             return {
               visible: parsed.visible === true,
+              ...typeof parsed.disabled === "boolean" ? { disabled: parsed.disabled } : {},
               ...parsed.reason ? { reason: parsed.reason } : {},
               ...typeof parsed.matchCount === "number" ? { matchCount: parsed.matchCount } : {},
               ...parsed.code ? { code: parsed.code } : {}

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82512,9 +82512,12 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin({ signal: flowAbort.signal });
+          await reproveManagedOrigin({
+            signal: flowAbort.signal,
+            readinessTimeoutMs: Math.max(1, flowDeadline - now())
+          });
         }
-        await completeOrigin(true);
+        await completeOrigin(true, flowAbort.signal);
         nativeOriginPreclaimed = false;
       }
       await commitReinstalledInstall();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -83412,7 +83412,7 @@ function createRunActionHandler(deps = {}) {
         params: args.params,
         attempt: { attemptId: initialAttemptId, ordinal: 1, maxAttempts, kind: "initial" },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
@@ -83728,7 +83728,7 @@ function createRunActionHandler(deps = {}) {
           parentAttemptId: initialAttemptId
         },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81420,13 +81420,16 @@ function replayTreeData(envelope) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  if (envelope.ok === true && !redbox && !truncated)
+  const agentError = typeof data?.__agent_error === "string" ? data.__agent_error.slice(0, 1e3) : void 0;
+  const serializationFailed = agentError !== void 0;
+  if (envelope.ok === true && !redbox && !truncated && !serializationFailed)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
-  const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
+  const message = serializationFailed ? agentError || "Component tree serialization failed" : truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const code = serializationFailed ? "EVAL_FAILED" : redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...serializationFailed ? { agentError } : {},
       ...truncated ? { truncated: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 47;
+    HELPERS_VERSION = 48;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -63964,21 +63964,77 @@ var init_injected_helpers = __esm({
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  // complete is true only when the renderer-ID loop finished without the
+  // finished is true only when the renderer-ID loop finished without the
   // empty-streak early-exit \u2014 empty roots are mounting evidence only then
   // (GH #789).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+  var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
-  function computeUnscannedRendererIds() {
-    try {
-      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
-      var out = [];
-      hook.renderers.forEach(function(_v, id) {
-        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
-      });
-      return out;
-    } catch (_) { return []; }
+  function rootScanCoverage() {
+    var reasons = [];
+    var registryIds = [];
+    var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    var renderers = hook && hook.renderers;
+    if (renderers) {
+      if (typeof renderers.keys !== 'function' || typeof renderers.forEach !== 'function') {
+        registryIds = null;
+      } else {
+        try {
+          var iterator = renderers.keys();
+          if (!iterator || typeof iterator.next !== 'function') {
+            registryIds = null;
+          } else {
+            var step;
+            var iterations = 0;
+            while (registryIds !== null) {
+              step = iterator.next();
+              if (!step || typeof step !== 'object' || typeof step.done !== 'boolean') {
+                registryIds = null;
+                break;
+              }
+              if (step.done) break;
+              if (++iterations > MAX_REGISTERED_RENDERER_IDS || typeof step.value !== 'number') {
+                registryIds = null;
+                break;
+              }
+              if (registryIds.indexOf(step.value) === -1) registryIds.push(step.value);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            }
+          }
+        } catch (_) {
+          registryIds = null;
+        }
+        if (registryIds !== null) {
+          try {
+            var forEachIterations = 0;
+            renderers.forEach(function(_v, id) {
+              if (registryIds === null) return;
+              if (++forEachIterations > MAX_REGISTERED_RENDERER_IDS || typeof id !== 'number') {
+                registryIds = null;
+                return;
+              }
+              if (registryIds.indexOf(id) === -1) registryIds.push(id);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            });
+          } catch (_) {
+            registryIds = null;
+          }
+        }
+      }
+    }
+    var addReason = function(reason) {
+      if (reasons.indexOf(reason) === -1) reasons.push(reason);
+    };
+    if (lastRootScan.rendererErrors > 0 || registryIds === null) addReason('renderer-error');
+    if (!lastRootScan.finished) addReason('root-enumeration-incomplete');
+    var unscannedRendererIds = [];
+    if (registryIds !== null) {
+      for (var i = 0; i < registryIds.length; i++) {
+        var id = registryIds[i];
+        if (!lastRootScan.visited[id]) unscannedRendererIds.push(id);
+      }
+      if (unscannedRendererIds.length > 0) addReason('renderers-unscanned');
+    }
+    return { reasons: reasons, unscannedRendererIds: unscannedRendererIds };
   }
 
   // Read the renderer IDs React DevTools actually registered. A malformed or
@@ -64005,7 +64061,7 @@ var init_injected_helpers = __esm({
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -64016,7 +64072,7 @@ var init_injected_helpers = __esm({
     var emptyStreak = 0;
     for (var rii = 0; rii < rendererIds.length; rii++) {
       var ri = rendererIds[rii];
-      if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+      lastRootScan.visited[ri] = true;
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size > 0) {
@@ -64031,7 +64087,7 @@ var init_injected_helpers = __esm({
         lastRootScan.rendererErrors++;
       }
     }
-    lastRootScan.complete = true;
+    lastRootScan.finished = true;
     return null;
   }
 
@@ -64048,7 +64104,7 @@ var init_injected_helpers = __esm({
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -64060,7 +64116,7 @@ var init_injected_helpers = __esm({
       var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
-        if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+        lastRootScan.visited[ri] = true;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -64085,7 +64141,7 @@ var init_injected_helpers = __esm({
           lastRootScan.rendererErrors++;
         }
       }
-      lastRootScan.complete = !abortedEarly;
+      if (!abortedEarly) lastRootScan.finished = true;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -64321,10 +64377,12 @@ var init_injected_helpers = __esm({
       o = o || {};
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
-      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
-      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
-      var unscanned = computeUnscannedRendererIds();
-      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      var coverage = rootScanCoverage();
+      for (var coverageIndex = 0; coverageIndex < coverage.reasons.length; coverageIndex++) {
+        if (reasons.indexOf(coverage.reasons[coverageIndex]) === -1) {
+          reasons.push(coverage.reasons[coverageIndex]);
+        }
+      }
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
       if (o.outputTruncated) reasons.push('output-truncated');
       var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
@@ -64337,8 +64395,8 @@ var init_injected_helpers = __esm({
         effectiveDepth: maxDepth,
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
-        rendererErrors: lastRootScan.rendererErrors,
-        unscannedRendererIds: unscanned
+        complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
 
@@ -64802,7 +64860,8 @@ var init_injected_helpers = __esm({
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
       // Only a complete, clean scan is mounting evidence.
-      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
+      var mountCoverage = rootScanCoverage();
+      var mountScanClean = mountHookUsable && mountCoverage.reasons.length === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
@@ -64810,7 +64869,7 @@ var init_injected_helpers = __esm({
           retryInMs: 2000
         });
       }
-      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+      if (mountHookUsable && mountCoverage.reasons.indexOf('root-enumeration-incomplete') !== -1 && mountRoots.length === 0) {
         return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
@@ -67610,12 +67669,8 @@ var init_injected_helpers = __esm({
         truncated: true
       });
     }
-    var unscannedRendererIds = computeUnscannedRendererIds();
-    if (
-      lastRootScan.rendererErrors > 0 ||
-      !lastRootScan.complete ||
-      unscannedRendererIds.length > 0
-    ) {
+    var coverage = rootScanCoverage();
+    if (coverage.reasons.length > 0) {
       return JSON.stringify({
         visible: false,
         code: 'ASSERTION_FAILED',
@@ -80791,6 +80846,10 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
+      if (Date.now() > deadline) {
+        finish(null);
+        return;
+      }
       settled = true;
       clearTimeout(timer);
       reject(error2);
@@ -81380,9 +81439,8 @@ function replayTreeData(envelope, selector) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
-  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
   const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81409,53 +81409,25 @@ var init_ios_proof_router = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
-function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
-  if (!node || typeof node !== "object")
-    return acc;
-  const n = node;
-  if (typeof n.testID === "string")
-    acc.add(n.testID);
-  if (typeof n.nativeID === "string")
-    acc.add(n.nativeID);
-  if (n.tree)
-    collectTestIds(n.tree, acc);
-  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
-  if (Array.isArray(kids))
-    for (const c of kids)
-      collectTestIds(c, acc);
-  return acc;
-}
-function isExactPresent(treeJson, selector) {
-  return collectTestIds(treeJson).has(selector);
-}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope, selector) {
+function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
-  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
-  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
-  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
-  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
-  if (envelope.ok === true && !redbox && !truncated && !incomplete)
+  if (envelope.ok === true && !redbox && !truncated)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
-      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -81464,37 +81436,6 @@ function replayTreeData(envelope, selector) {
       ...envelope.meta ? { meta: envelope.meta } : {}
     }
   });
-}
-function countExactMatches(treeJson, id) {
-  let matches = 0;
-  const root = treeJson && typeof treeJson === "object" && "tree" in treeJson ? treeJson.tree : treeJson;
-  const stack = [root];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node || typeof node !== "object")
-      continue;
-    const record2 = node;
-    if (record2.testID === id || record2.nativeID === id)
-      matches++;
-    const children = record2.children ?? record2.nodes ?? record2.matches;
-    if (Array.isArray(children))
-      stack.push(...children);
-  }
-  return matches;
-}
-function countVisibilityMatches(treeJson, id) {
-  const treeMatches = countExactMatches(treeJson, id);
-  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
-    return treeMatches;
-  const interactive = treeJson.interactive;
-  if (!Array.isArray(interactive))
-    return 0;
-  return interactive.filter((node) => {
-    if (!node || typeof node !== "object")
-      return false;
-    const record2 = node;
-    return record2.testID === id || record2.nativeID === id;
-  }).length;
 }
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
@@ -81574,17 +81515,16 @@ function buildCdpDispatch(deps, signal) {
   const assertExactInteractable = async (id) => {
     const tree = await deps.treeFor(id);
     requireNotAborted();
-    const treeMatches = countExactMatches(tree, id);
-    if (treeMatches === 0)
+    const frontmost = await deps.frontmostFor(id);
+    requireNotAborted();
+    if (frontmost.matchCount === 0)
       throw new ReplayDispatchError("TESTID_NOT_FOUND", `testID "${id}" not present`, {
         failedSelector: id
       });
-    const frontmost = await deps.frontmostFor?.(id);
-    requireNotAborted();
-    const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+    const matches = frontmost.matchCount ?? 1;
     if (matches > 1)
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
-    if (frontmost && !frontmost.visible)
+    if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
     if (isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
@@ -81604,24 +81544,23 @@ function buildCdpDispatch(deps, signal) {
       await deps.typeByTestId(id, text);
     },
     async visibility(id) {
-      const tree = await deps.treeFor(id);
-      const treeMatches = countVisibilityMatches(tree, id);
-      if (treeMatches === 0)
+      await deps.treeFor(id);
+      const frontmost = await deps.frontmostFor(id);
+      if (frontmost.matchCount === 0)
         return {
           visible: false,
           code: "TESTID_NOT_FOUND",
           reason: `testID "${id}" not present in the React tree`,
           meta: { failedSelector: id }
         };
-      const frontmost = await deps.frontmostFor?.(id);
-      const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+      const matches = frontmost.matchCount ?? 1;
       if (matches > 1)
         return {
           visible: false,
           code: "AMBIGUOUS_TESTID",
           reason: `testID "${id}" resolves to ${matches} mounted elements`
         };
-      if (frontmost && !frontmost.visible)
+      if (!frontmost.visible)
         return {
           visible: false,
           code: frontmost.code ?? "ASSERTION_FAILED",
@@ -96936,7 +96875,7 @@ var init_index = __esm({
           if (d && typeof d === "object" && "__agent_truncated" in d) {
             env = await fetchTree(true);
           }
-          const data = replayTreeData(env, id);
+          const data = replayTreeData(env);
           return unwrapTree(data);
         },
         frontmostFor: async (id) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80756,6 +80756,29 @@ var init_maestro_run_ledger = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
+async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs < 0)
+    return null;
+  return new Promise((resolve22, reject) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      resolve22(Date.now() <= deadline ? value : null);
+    };
+    const timer = setTimeout(() => finish(null), remainingMs);
+    Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error2);
+    });
+  });
+}
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -80932,10 +80955,17 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict;
+          let verdict = {
+            visible: false,
+            code: "TESTID_NOT_FOUND",
+            reason: `testID "${s.id}" not present before the visibility deadline`
+          };
           for (; ; ) {
-            verdict = await dispatch.visibility(s.id);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
+            if (!observed)
+              break;
+            verdict = observed;
             if (verdict.visible)
               break;
             const remainingMs = deadline - Date.now();
@@ -81301,25 +81331,51 @@ var init_ios_proof_router = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
+function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
+  if (!node || typeof node !== "object")
+    return acc;
+  const n = node;
+  if (typeof n.testID === "string")
+    acc.add(n.testID);
+  if (typeof n.nativeID === "string")
+    acc.add(n.nativeID);
+  if (n.tree)
+    collectTestIds(n.tree, acc);
+  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
+  if (Array.isArray(kids))
+    for (const c of kids)
+      collectTestIds(c, acc);
+  return acc;
+}
+function isExactPresent(treeJson, selector) {
+  return collectTestIds(treeJson).has(selector);
+}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope) {
+function replayTreeData(envelope, selector) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const truncated = data !== null && data.__agent_truncated === true;
-  if (envelope.ok === true && !redbox && !truncated)
+  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
+  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
+  const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
+  const complete = verdict?.state === "ok" && reasons.length === 0;
+  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
+      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -96786,7 +96842,7 @@ var init_index = __esm({
           if (d && typeof d === "object" && "__agent_truncated" in d) {
             env = await fetchTree(true);
           }
-          const data = replayTreeData(env);
+          const data = replayTreeData(env, id);
           return unwrapTree(data);
         },
         frontmostFor: async (id) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -94058,7 +94058,7 @@ var makeReplayDeps = (_args, signal) => {
       })).content[0].text);
       let env = await fetchTree(false);
       const d = env.data;
-      if (d && typeof d === "object" && "__agent_truncated" in d) {
+      if (d && typeof d === "object" && ("__agent_truncated" in d || d.truncated === true)) {
         env = await fetchTree(true);
       }
       const data = replayTreeData(env);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79311,12 +79311,13 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
-  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
+  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
+  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
   const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51588,11 +51588,7 @@ var INJECTED_HELPERS = `
     '_LogBoxInspectorContainer'
   ];
 
-  // Reset by every root-iteration pass; only valid when read synchronously
-  // after the pass that produced the tree (many helpers share the iterators).
-  // finished is true only when the renderer-ID loop finished without the
-  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
-  // (GH #789).
+  // Synchronous scan result; finished stays false after the GH #789 empty-streak exit.
   var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
   function rootScanCoverage() {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -78732,6 +78732,8 @@ var ReplayDispatchError = class extends Error {
 var interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)(?:\s*\?\?\s*(['"])(.*?)\2)?\}/g, (match, key, _quote, fallback) => p[key] ?? fallback ?? match);
 var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
+var VISIBILITY_POLL_INTERVAL_MS = 200;
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -78786,7 +78788,11 @@ function normalizeSteps(body, params) {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
           throw new UnsupportedStepError("assertVisible (missing string id)");
-        out.push({ t: "assert", id: interp(id, params) });
+        out.push({
+          t: "waitVisible",
+          id: interp(id, params),
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+        });
         break;
       }
       case "extendedWaitUntil": {
@@ -78796,10 +78802,10 @@ function normalizeSteps(body, params) {
           refuseUnsupportedKeys(v.visible, ["id"], "extendedWaitUntil.visible");
         }
         const id = isObj(v) && isObj(v.visible) ? asString(v.visible.id) : null;
-        const timeoutMs = isObj(v) ? v.timeout : void 0;
-        if (!id || !Number.isSafeInteger(timeoutMs) || Number(timeoutMs) < 0)
-          throw new UnsupportedStepError("extendedWaitUntil (need visible.id + non-negative integer timeout)");
-        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs: Number(timeoutMs) });
+        const timeoutMs = isObj(v) && "timeout" in v ? v.timeout : DEFAULT_VISIBILITY_TIMEOUT_MS;
+        if (!id || typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs < 0)
+          throw new UnsupportedStepError("extendedWaitUntil (need visible.id; timeout must be finite and non-negative when present)");
+        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs });
         break;
       }
       case "waitForAnimationToEnd": {
@@ -78902,39 +78908,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         }
-        case "assert": {
-          const verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          trace.push({
-            sourceIndex: sourceIndex(i),
-            t: s.t,
-            target: s.id,
-            ok: verdict.visible,
-            durationMs: Date.now() - startedAt
-          });
-          if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `assertVisible: "${s.id}" is not frontmost`, verdict.code ?? "ASSERTION_FAILED", verdict.meta);
-          break;
-        }
         case "waitVisible": {
-          const deadline = Date.now() + s.timeoutMs;
-          let verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          while (!verdict.visible && Date.now() < deadline) {
-            requireNotAborted();
-            await new Promise((resolve21) => setTimeout(resolve21, 100));
+          const deadline = startedAt + s.timeoutMs;
+          let verdict;
+          for (; ; ) {
             verdict = await dispatch.visibility(s.id);
             requireNotAborted();
+            if (verdict.visible)
+              break;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0)
+              break;
+            await new Promise((resolve21) => setTimeout(resolve21, Math.min(VISIBILITY_POLL_INTERVAL_MS, remainingMs)));
           }
+          const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
             ok: verdict.visible,
-            durationMs: Date.now() - startedAt
+            durationMs: waitedMs
           });
           if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `extendedWaitUntil: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", verdict.meta);
+            return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
         }
         case "wait":
@@ -78984,14 +78980,16 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
       }
     } catch (e) {
+      const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
         t: s.t,
         target: "id" in s ? s.id : void 0,
         ok: false,
-        durationMs: Date.now() - startedAt
+        durationMs: waitedMs
       });
-      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, e instanceof ReplayDispatchError ? e.meta : void 0);
+      const dispatchMeta = e instanceof ReplayDispatchError ? e.meta : void 0;
+      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, s.t === "waitVisible" ? { ...dispatchMeta, failedSelector: s.id, waitedMs } : dispatchMeta);
     }
   }
   if (opts.signal?.aborted) {
@@ -79254,14 +79252,17 @@ function unwrapTree(data) {
 function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
-  if (envelope.ok === true && !redbox)
-    return envelope.data;
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const message = redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const truncated = data !== null && data.__agent_truncated === true;
+  if (envelope.ok === true && !redbox && !truncated)
+    return envelope.data;
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...truncated ? { truncated: true } : {},
+      ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
       ...warning ? { warning } : {},
@@ -93942,12 +93943,11 @@ var makeReplayDeps = (_args, signal) => {
         ...interactiveOnly ? { interactiveOnly: true } : {}
       })).content[0].text);
       let env = await fetchTree(false);
-      let data = replayTreeData(env);
-      const d = data;
+      const d = env.data;
       if (d && typeof d === "object" && "__agent_truncated" in d) {
         env = await fetchTree(true);
-        data = replayTreeData(env);
       }
+      const data = replayTreeData(env);
       return unwrapTree(data);
     },
     frontmostFor: async (id) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -55301,8 +55301,7 @@ var INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
-      // A fiber and its work-in-progress alternate are the same logical node;
-      // committed .return chains may thread through either half of the pair.
+      // React return chains may thread through either half of a fiber/alternate pair.
       var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79351,53 +79351,25 @@ function loginPostconditionId(commands) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
-function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
-  if (!node || typeof node !== "object")
-    return acc;
-  const n = node;
-  if (typeof n.testID === "string")
-    acc.add(n.testID);
-  if (typeof n.nativeID === "string")
-    acc.add(n.nativeID);
-  if (n.tree)
-    collectTestIds(n.tree, acc);
-  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
-  if (Array.isArray(kids))
-    for (const c of kids)
-      collectTestIds(c, acc);
-  return acc;
-}
-function isExactPresent(treeJson, selector) {
-  return collectTestIds(treeJson).has(selector);
-}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope, selector) {
+function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
-  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
-  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
-  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
-  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
-  if (envelope.ok === true && !redbox && !truncated && !incomplete)
+  if (envelope.ok === true && !redbox && !truncated)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
-      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -79406,37 +79378,6 @@ function replayTreeData(envelope, selector) {
       ...envelope.meta ? { meta: envelope.meta } : {}
     }
   });
-}
-function countExactMatches(treeJson, id) {
-  let matches = 0;
-  const root = treeJson && typeof treeJson === "object" && "tree" in treeJson ? treeJson.tree : treeJson;
-  const stack = [root];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node || typeof node !== "object")
-      continue;
-    const record2 = node;
-    if (record2.testID === id || record2.nativeID === id)
-      matches++;
-    const children = record2.children ?? record2.nodes ?? record2.matches;
-    if (Array.isArray(children))
-      stack.push(...children);
-  }
-  return matches;
-}
-function countVisibilityMatches(treeJson, id) {
-  const treeMatches = countExactMatches(treeJson, id);
-  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
-    return treeMatches;
-  const interactive = treeJson.interactive;
-  if (!Array.isArray(interactive))
-    return 0;
-  return interactive.filter((node) => {
-    if (!node || typeof node !== "object")
-      return false;
-    const record2 = node;
-    return record2.testID === id || record2.nativeID === id;
-  }).length;
 }
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
@@ -79516,17 +79457,16 @@ function buildCdpDispatch(deps, signal) {
   const assertExactInteractable = async (id) => {
     const tree = await deps.treeFor(id);
     requireNotAborted();
-    const treeMatches = countExactMatches(tree, id);
-    if (treeMatches === 0)
+    const frontmost = await deps.frontmostFor(id);
+    requireNotAborted();
+    if (frontmost.matchCount === 0)
       throw new ReplayDispatchError("TESTID_NOT_FOUND", `testID "${id}" not present`, {
         failedSelector: id
       });
-    const frontmost = await deps.frontmostFor?.(id);
-    requireNotAborted();
-    const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+    const matches = frontmost.matchCount ?? 1;
     if (matches > 1)
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
-    if (frontmost && !frontmost.visible)
+    if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
     if (isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
@@ -79546,24 +79486,23 @@ function buildCdpDispatch(deps, signal) {
       await deps.typeByTestId(id, text);
     },
     async visibility(id) {
-      const tree = await deps.treeFor(id);
-      const treeMatches = countVisibilityMatches(tree, id);
-      if (treeMatches === 0)
+      await deps.treeFor(id);
+      const frontmost = await deps.frontmostFor(id);
+      if (frontmost.matchCount === 0)
         return {
           visible: false,
           code: "TESTID_NOT_FOUND",
           reason: `testID "${id}" not present in the React tree`,
           meta: { failedSelector: id }
         };
-      const frontmost = await deps.frontmostFor?.(id);
-      const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+      const matches = frontmost.matchCount ?? 1;
       if (matches > 1)
         return {
           visible: false,
           code: "AMBIGUOUS_TESTID",
           reason: `testID "${id}" resolves to ${matches} mounted elements`
         };
-      if (frontmost && !frontmost.visible)
+      if (!frontmost.visible)
         return {
           visible: false,
           code: frontmost.code ?? "ASSERTION_FAILED",
@@ -94097,7 +94036,7 @@ var makeReplayDeps = (_args, signal) => {
       if (d && typeof d === "object" && "__agent_truncated" in d) {
         env = await fetchTree(true);
       }
-      const data = replayTreeData(env, id);
+      const data = replayTreeData(env);
       return unwrapTree(data);
     },
     frontmostFor: async (id) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -78734,12 +78734,14 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+var MAX_TIMER_DELAY_MS = 2147483647;
 async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve21, reject) => {
     let settled = false;
+    let timer;
     const finish = (value) => {
       if (settled)
         return;
@@ -78747,7 +78749,11 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
       clearTimeout(timer);
       resolve21(Date.now() <= deadline ? value : null);
     };
-    const timer = setTimeout(() => finish(null), remainingMs);
+    const armDeadline = () => {
+      const nextRemainingMs = deadline - Date.now();
+      timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
+    };
+    armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
@@ -79344,6 +79350,20 @@ function countExactMatches(treeJson, id) {
   }
   return matches;
 }
+function countVisibilityMatches(treeJson, id) {
+  const treeMatches = countExactMatches(treeJson, id);
+  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
+    return treeMatches;
+  const interactive = treeJson.interactive;
+  if (!Array.isArray(interactive))
+    return 0;
+  return interactive.filter((node) => {
+    if (!node || typeof node !== "object")
+      return false;
+    const record2 = node;
+    return record2.testID === id || record2.nativeID === id;
+  }).length;
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -79453,7 +79473,7 @@ function buildCdpDispatch(deps, signal) {
     },
     async visibility(id) {
       const tree = await deps.treeFor(id);
-      const treeMatches = countExactMatches(tree, id);
+      const treeMatches = countVisibilityMatches(tree, id);
       if (treeMatches === 0)
         return {
           visible: false,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -78820,7 +78820,8 @@ function normalizeSteps(body, params) {
         out.push({
           t: "waitVisible",
           id: interp(id, params),
-          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+          evidenceType: "assert"
         });
         break;
       }
@@ -78897,6 +78898,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
+    const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
     try {
       requireNotAborted();
@@ -78939,11 +78941,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict = {
-            visible: false,
-            code: "TESTID_NOT_FOUND",
-            reason: `testID "${s.id}" not present before the visibility deadline`
-          };
+          let verdict = null;
           for (; ; ) {
             const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
@@ -78960,11 +78958,13 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
-            t: s.t,
+            t: evidenceType,
             target: s.id,
-            ok: verdict.visible,
+            ok: verdict?.visible === true,
             durationMs: waitedMs
           });
+          if (!verdict)
+            return fail3(i, `waitVisible: no readable visibility observation completed for "${s.id}" before the deadline`, "RUNNER_TIMEOUT", { failedSelector: s.id, waitedMs });
           if (!verdict.visible)
             return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
@@ -79019,7 +79019,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
       const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
-        t: s.t,
+        t: evidenceType,
         target: "id" in s ? s.id : void 0,
         ok: false,
         durationMs: waitedMs
@@ -79311,8 +79311,10 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0;
-  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
+  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
+  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
   const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
   const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 47;
+var HELPERS_VERSION = 48;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -51590,21 +51590,77 @@ var INJECTED_HELPERS = `
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  // complete is true only when the renderer-ID loop finished without the
+  // finished is true only when the renderer-ID loop finished without the
   // empty-streak early-exit \u2014 empty roots are mounting evidence only then
   // (GH #789).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+  var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
-  function computeUnscannedRendererIds() {
-    try {
-      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
-      var out = [];
-      hook.renderers.forEach(function(_v, id) {
-        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
-      });
-      return out;
-    } catch (_) { return []; }
+  function rootScanCoverage() {
+    var reasons = [];
+    var registryIds = [];
+    var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    var renderers = hook && hook.renderers;
+    if (renderers) {
+      if (typeof renderers.keys !== 'function' || typeof renderers.forEach !== 'function') {
+        registryIds = null;
+      } else {
+        try {
+          var iterator = renderers.keys();
+          if (!iterator || typeof iterator.next !== 'function') {
+            registryIds = null;
+          } else {
+            var step;
+            var iterations = 0;
+            while (registryIds !== null) {
+              step = iterator.next();
+              if (!step || typeof step !== 'object' || typeof step.done !== 'boolean') {
+                registryIds = null;
+                break;
+              }
+              if (step.done) break;
+              if (++iterations > MAX_REGISTERED_RENDERER_IDS || typeof step.value !== 'number') {
+                registryIds = null;
+                break;
+              }
+              if (registryIds.indexOf(step.value) === -1) registryIds.push(step.value);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            }
+          }
+        } catch (_) {
+          registryIds = null;
+        }
+        if (registryIds !== null) {
+          try {
+            var forEachIterations = 0;
+            renderers.forEach(function(_v, id) {
+              if (registryIds === null) return;
+              if (++forEachIterations > MAX_REGISTERED_RENDERER_IDS || typeof id !== 'number') {
+                registryIds = null;
+                return;
+              }
+              if (registryIds.indexOf(id) === -1) registryIds.push(id);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            });
+          } catch (_) {
+            registryIds = null;
+          }
+        }
+      }
+    }
+    var addReason = function(reason) {
+      if (reasons.indexOf(reason) === -1) reasons.push(reason);
+    };
+    if (lastRootScan.rendererErrors > 0 || registryIds === null) addReason('renderer-error');
+    if (!lastRootScan.finished) addReason('root-enumeration-incomplete');
+    var unscannedRendererIds = [];
+    if (registryIds !== null) {
+      for (var i = 0; i < registryIds.length; i++) {
+        var id = registryIds[i];
+        if (!lastRootScan.visited[id]) unscannedRendererIds.push(id);
+      }
+      if (unscannedRendererIds.length > 0) addReason('renderers-unscanned');
+    }
+    return { reasons: reasons, unscannedRendererIds: unscannedRendererIds };
   }
 
   // Read the renderer IDs React DevTools actually registered. A malformed or
@@ -51631,7 +51687,7 @@ var INJECTED_HELPERS = `
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -51642,7 +51698,7 @@ var INJECTED_HELPERS = `
     var emptyStreak = 0;
     for (var rii = 0; rii < rendererIds.length; rii++) {
       var ri = rendererIds[rii];
-      if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+      lastRootScan.visited[ri] = true;
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size > 0) {
@@ -51657,7 +51713,7 @@ var INJECTED_HELPERS = `
         lastRootScan.rendererErrors++;
       }
     }
-    lastRootScan.complete = true;
+    lastRootScan.finished = true;
     return null;
   }
 
@@ -51674,7 +51730,7 @@ var INJECTED_HELPERS = `
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -51686,7 +51742,7 @@ var INJECTED_HELPERS = `
       var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
-        if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+        lastRootScan.visited[ri] = true;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -51711,7 +51767,7 @@ var INJECTED_HELPERS = `
           lastRootScan.rendererErrors++;
         }
       }
-      lastRootScan.complete = !abortedEarly;
+      if (!abortedEarly) lastRootScan.finished = true;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -51947,10 +52003,12 @@ var INJECTED_HELPERS = `
       o = o || {};
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
-      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
-      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
-      var unscanned = computeUnscannedRendererIds();
-      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      var coverage = rootScanCoverage();
+      for (var coverageIndex = 0; coverageIndex < coverage.reasons.length; coverageIndex++) {
+        if (reasons.indexOf(coverage.reasons[coverageIndex]) === -1) {
+          reasons.push(coverage.reasons[coverageIndex]);
+        }
+      }
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
       if (o.outputTruncated) reasons.push('output-truncated');
       var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
@@ -51963,8 +52021,8 @@ var INJECTED_HELPERS = `
         effectiveDepth: maxDepth,
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
-        rendererErrors: lastRootScan.rendererErrors,
-        unscannedRendererIds: unscanned
+        complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
 
@@ -52428,7 +52486,8 @@ var INJECTED_HELPERS = `
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
       // Only a complete, clean scan is mounting evidence.
-      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
+      var mountCoverage = rootScanCoverage();
+      var mountScanClean = mountHookUsable && mountCoverage.reasons.length === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
@@ -52436,7 +52495,7 @@ var INJECTED_HELPERS = `
           retryInMs: 2000
         });
       }
-      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+      if (mountHookUsable && mountCoverage.reasons.indexOf('root-enumeration-incomplete') !== -1 && mountRoots.length === 0) {
         return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
@@ -55236,12 +55295,8 @@ var INJECTED_HELPERS = `
         truncated: true
       });
     }
-    var unscannedRendererIds = computeUnscannedRendererIds();
-    if (
-      lastRootScan.rendererErrors > 0 ||
-      !lastRootScan.complete ||
-      unscannedRendererIds.length > 0
-    ) {
+    var coverage = rootScanCoverage();
+    if (coverage.reasons.length > 0) {
       return JSON.stringify({
         visible: false,
         code: 'ASSERTION_FAILED',
@@ -78770,6 +78825,10 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
+      if (Date.now() > deadline) {
+        finish(null);
+        return;
+      }
       settled = true;
       clearTimeout(timer);
       reject(error2);
@@ -79322,9 +79381,8 @@ function replayTreeData(envelope, selector) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
-  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
   const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 48;
+var HELPERS_VERSION = 49;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -55300,10 +55300,13 @@ var INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
+      // A fiber and its work-in-progress alternate are the same logical node;
+      // committed .return chains may thread through either half of the pair.
+      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor) return true;
+        if (current === ancestor || current === ancestorAlternate) return true;
         current = current.return;
       }
       return false;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -81306,7 +81306,7 @@ function createRunActionHandler(deps = {}) {
         params: args.params,
         attempt: { attemptId: initialAttemptId, ordinal: 1, maxAttempts, kind: "initial" },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
@@ -81622,7 +81622,7 @@ function createRunActionHandler(deps = {}) {
           parentAttemptId: initialAttemptId
         },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -78734,6 +78734,29 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs < 0)
+    return null;
+  return new Promise((resolve21, reject) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      resolve21(Date.now() <= deadline ? value : null);
+    };
+    const timer = setTimeout(() => finish(null), remainingMs);
+    Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error2);
+    });
+  });
+}
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -78910,10 +78933,17 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict;
+          let verdict = {
+            visible: false,
+            code: "TESTID_NOT_FOUND",
+            reason: `testID "${s.id}" not present before the visibility deadline`
+          };
           for (; ; ) {
-            verdict = await dispatch.visibility(s.id);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
+            if (!observed)
+              break;
+            verdict = observed;
             if (verdict.visible)
               break;
             const remainingMs = deadline - Date.now();
@@ -79243,25 +79273,51 @@ function loginPostconditionId(commands) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
+function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
+  if (!node || typeof node !== "object")
+    return acc;
+  const n = node;
+  if (typeof n.testID === "string")
+    acc.add(n.testID);
+  if (typeof n.nativeID === "string")
+    acc.add(n.nativeID);
+  if (n.tree)
+    collectTestIds(n.tree, acc);
+  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
+  if (Array.isArray(kids))
+    for (const c of kids)
+      collectTestIds(c, acc);
+  return acc;
+}
+function isExactPresent(treeJson, selector) {
+  return collectTestIds(treeJson).has(selector);
+}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope) {
+function replayTreeData(envelope, selector) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const truncated = data !== null && data.__agent_truncated === true;
-  if (envelope.ok === true && !redbox && !truncated)
+  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
+  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
+  const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
+  const complete = verdict?.state === "ok" && reasons.length === 0;
+  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
+      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -93947,7 +94003,7 @@ var makeReplayDeps = (_args, signal) => {
       if (d && typeof d === "object" && "__agent_truncated" in d) {
         env = await fetchTree(true);
       }
-      const data = replayTreeData(env);
+      const data = replayTreeData(env, id);
       return unwrapTree(data);
     },
     frontmostFor: async (id) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -80468,7 +80468,7 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin();
+          await reproveManagedOrigin({ signal: flowAbort.signal });
         }
         await completeOrigin(true);
         nativeOriginPreclaimed = false;
@@ -81305,7 +81305,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));
@@ -81621,7 +81621,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79733,7 +79733,7 @@ function remapNativeSteps(steps, sourceIndices) {
     return mapped ? [mapped] : [];
   });
 }
-function partialNativeFailureMessage(meta) {
+function partialNativeFailureMessage(meta, nestedError) {
   const failedStep = remapNativeStep(meta.failedStep, 0, []);
   const lastStep = remapNativeStep(meta.lastStep, 0, []);
   const terminal = isRecord(meta.terminal) ? meta.terminal : null;
@@ -79742,7 +79742,12 @@ function partialNativeFailureMessage(meta) {
     kind: failureKind,
     selector: typeof terminal?.failureSelector === "string" ? terminal.failureSelector : null
   } : null;
-  const headline = formatFailureHeadline({ steps: [], failedStep, lastStep, reason }, { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true }, "Native replay segment failed.");
+  const headline = formatFailureHeadline(
+    { steps: [], failedStep, lastStep, reason },
+    { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true },
+    // Keep the nested envelope's own cause when no structured evidence exists.
+    nestedError?.replace(/^Maestro flow failed: /, "") || "Native replay segment failed."
+  );
   const runtimeDegradation = runtimeDegradationFromMetadata(meta.runtimeDegraded);
   return runtimeDegradation ? `${headline} \u2014 ${formatRuntimeDegradedHint(runtimeDegradation)}` : headline;
 }
@@ -79981,7 +79986,7 @@ function createMaestroRunHandler(deps = {}) {
               if (!nativeSegmentCoversAttempt) {
                 delete nestedMeta.trailingVerification;
                 delete nestedMeta.ledger;
-                nestedError = partialNativeFailureMessage(nestedMeta);
+                nestedError = partialNativeFailureMessage(nestedMeta, env.error);
               }
               combinedSteps.push(...remapNativeSteps(nestedMeta.steps, segment.sourceIndices));
               const uniqueProofDomains = [...new Set(proofDomains)];
@@ -80462,7 +80467,7 @@ function createMaestroRunHandler(deps = {}) {
         signal: flowAbort.signal
       });
       if (deferredNativeOriginTarget) {
-        if (nativeOriginPreclaimed && replayFactory && (args.reproveManagedOrigin || deps.reproveManagedOrigin || hasManagedNativeOriginAuthority(args))) {
+        if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
           await reproveManagedOrigin();
         }
         await completeOrigin(true);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 49;
+var HELPERS_VERSION = 50;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -52018,6 +52018,7 @@ var INJECTED_HELPERS = `
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
         complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        rendererErrors: lastRootScan.rendererErrors,
         unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
@@ -55335,6 +55336,9 @@ var INJECTED_HELPERS = `
       });
     }
     var target = logicalMatches[0];
+    var targetProps = target.memoizedProps || {};
+    var targetAccessibilityState = targetProps.accessibilityState || {};
+    var targetDisabled = targetProps.disabled === true || targetAccessibilityState.disabled === true;
     if (__hidden(target)) {
       return JSON.stringify({
         visible: false,
@@ -55343,7 +55347,7 @@ var INJECTED_HELPERS = `
       });
     }
 
-    var targetPointerEvents = (target.memoizedProps || {}).pointerEvents;
+    var targetPointerEvents = targetProps.pointerEvents;
     if (targetPointerEvents === 'none' || targetPointerEvents === 'box-none') {
       return JSON.stringify({
         visible: false,
@@ -55509,7 +55513,8 @@ var INJECTED_HELPERS = `
       route: routeOwner,
       activeRoute: activeRoute,
       modalCount: modals.length,
-      matchCount: 1
+      matchCount: 1,
+      disabled: targetDisabled
     });
   }
 
@@ -78802,24 +78807,44 @@ var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
 var MAX_TIMER_DELAY_MS = 2147483647;
-async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+async function readVisibilityBeforeDeadline(dispatch, id, deadline, signal) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve21, reject) => {
     let settled = false;
     let timer;
+    const cleanup = () => {
+      if (timer !== void 0)
+        clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
     const finish = (value) => {
       if (settled)
         return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve21(Date.now() <= deadline ? value : null);
+    };
+    const fail3 = (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      cleanup();
+      reject(error2);
+    };
+    const onAbort = () => {
+      fail3(new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline"));
     };
     const armDeadline = () => {
       const nextRemainingMs = deadline - Date.now();
       timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
     };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
@@ -78828,9 +78853,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
         finish(null);
         return;
       }
-      settled = true;
-      clearTimeout(timer);
-      reject(error2);
+      fail3(error2);
     });
   });
 }
@@ -79014,7 +79037,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const deadline = startedAt + s.timeoutMs;
           let verdict = null;
           for (; ; ) {
-            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline, opts.signal);
             requireNotAborted();
             if (!observed)
               break;
@@ -79470,7 +79493,7 @@ function buildCdpDispatch(deps, signal) {
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
     if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
-    if (isDisabled(nodeProps(tree, id)))
+    if (frontmost.disabled === true || isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
     const pointerEventsError = pointerEventsBlock(tree, id);
     if (pointerEventsError)
@@ -94054,6 +94077,7 @@ var makeReplayDeps = (_args, signal) => {
         const parsed = JSON.parse(result.value);
         return {
           visible: parsed.visible === true,
+          ...typeof parsed.disabled === "boolean" ? { disabled: parsed.disabled } : {},
           ...parsed.reason ? { reason: parsed.reason } : {},
           ...typeof parsed.matchCount === "number" ? { matchCount: parsed.matchCount } : {},
           ...parsed.code ? { code: parsed.code } : {}

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79362,13 +79362,16 @@ function replayTreeData(envelope) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  if (envelope.ok === true && !redbox && !truncated)
+  const agentError = typeof data?.__agent_error === "string" ? data.__agent_error.slice(0, 1e3) : void 0;
+  const serializationFailed = agentError !== void 0;
+  if (envelope.ok === true && !redbox && !truncated && !serializationFailed)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
-  const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
+  const message = serializationFailed ? agentError || "Component tree serialization failed" : truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const code = serializationFailed ? "EVAL_FAILED" : redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...serializationFailed ? { agentError } : {},
       ...truncated ? { truncated: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -80468,9 +80468,12 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin({ signal: flowAbort.signal });
+          await reproveManagedOrigin({
+            signal: flowAbort.signal,
+            readinessTimeoutMs: Math.max(1, flowDeadline - now())
+          });
         }
-        await completeOrigin(true);
+        await completeOrigin(true, flowAbort.signal);
         nativeOriginPreclaimed = false;
       }
       await commitReinstalledInstall();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51948,6 +51948,7 @@ var INJECTED_HELPERS = `
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
       if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
       var unscanned = computeUnscannedRendererIds();
       if (unscanned.length > 0) reasons.push('renderers-unscanned');
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
@@ -55233,6 +55234,18 @@ var INJECTED_HELPERS = `
         reason: 'frontmost testID scan exceeded its bounded React-tree budget',
         code: 'ASSERTION_FAILED',
         truncated: true
+      });
+    }
+    var unscannedRendererIds = computeUnscannedRendererIds();
+    if (
+      lastRootScan.rendererErrors > 0 ||
+      !lastRootScan.complete ||
+      unscannedRendererIds.length > 0
+    ) {
+      return JSON.stringify({
+        visible: false,
+        code: 'ASSERTION_FAILED',
+        reason: 'frontmost proof cannot cover every mounted renderer'
       });
     }
     function containsFiber(ancestor, candidate) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15136,6 +15136,8 @@ var ReplayDispatchError = class extends Error {
 var interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)(?:\s*\?\?\s*(['"])(.*?)\2)?\}/g, (match, key, _quote, fallback) => p[key] ?? fallback ?? match);
 var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
+var VISIBILITY_POLL_INTERVAL_MS = 200;
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -15190,7 +15192,11 @@ function normalizeSteps(body, params) {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
           throw new UnsupportedStepError("assertVisible (missing string id)");
-        out.push({ t: "assert", id: interp(id, params) });
+        out.push({
+          t: "waitVisible",
+          id: interp(id, params),
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+        });
         break;
       }
       case "extendedWaitUntil": {
@@ -15200,10 +15206,10 @@ function normalizeSteps(body, params) {
           refuseUnsupportedKeys(v.visible, ["id"], "extendedWaitUntil.visible");
         }
         const id = isObj(v) && isObj(v.visible) ? asString(v.visible.id) : null;
-        const timeoutMs = isObj(v) ? v.timeout : void 0;
-        if (!id || !Number.isSafeInteger(timeoutMs) || Number(timeoutMs) < 0)
-          throw new UnsupportedStepError("extendedWaitUntil (need visible.id + non-negative integer timeout)");
-        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs: Number(timeoutMs) });
+        const timeoutMs = isObj(v) && "timeout" in v ? v.timeout : DEFAULT_VISIBILITY_TIMEOUT_MS;
+        if (!id || typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs < 0)
+          throw new UnsupportedStepError("extendedWaitUntil (need visible.id; timeout must be finite and non-negative when present)");
+        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs });
         break;
       }
       case "waitForAnimationToEnd": {
@@ -15306,39 +15312,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         }
-        case "assert": {
-          const verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          trace.push({
-            sourceIndex: sourceIndex(i),
-            t: s.t,
-            target: s.id,
-            ok: verdict.visible,
-            durationMs: Date.now() - startedAt
-          });
-          if (!verdict.visible)
-            return fail(i, verdict.reason ?? `assertVisible: "${s.id}" is not frontmost`, verdict.code ?? "ASSERTION_FAILED", verdict.meta);
-          break;
-        }
         case "waitVisible": {
-          const deadline = Date.now() + s.timeoutMs;
-          let verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          while (!verdict.visible && Date.now() < deadline) {
-            requireNotAborted();
-            await new Promise((resolve9) => setTimeout(resolve9, 100));
+          const deadline = startedAt + s.timeoutMs;
+          let verdict;
+          for (; ; ) {
             verdict = await dispatch.visibility(s.id);
             requireNotAborted();
+            if (verdict.visible)
+              break;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0)
+              break;
+            await new Promise((resolve9) => setTimeout(resolve9, Math.min(VISIBILITY_POLL_INTERVAL_MS, remainingMs)));
           }
+          const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
             ok: verdict.visible,
-            durationMs: Date.now() - startedAt
+            durationMs: waitedMs
           });
           if (!verdict.visible)
-            return fail(i, verdict.reason ?? `extendedWaitUntil: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", verdict.meta);
+            return fail(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
         }
         case "wait":
@@ -15388,14 +15384,16 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
       }
     } catch (e) {
+      const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
         t: s.t,
         target: "id" in s ? s.id : void 0,
         ok: false,
-        durationMs: Date.now() - startedAt
+        durationMs: waitedMs
       });
-      return fail(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, e instanceof ReplayDispatchError ? e.meta : void 0);
+      const dispatchMeta = e instanceof ReplayDispatchError ? e.meta : void 0;
+      return fail(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, s.t === "waitVisible" ? { ...dispatchMeta, failedSelector: s.id, waitedMs } : dispatchMeta);
     }
   }
   if (opts.signal?.aborted) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15138,12 +15138,14 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+var MAX_TIMER_DELAY_MS = 2147483647;
 async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve9, reject) => {
     let settled = false;
+    let timer;
     const finish = (value) => {
       if (settled)
         return;
@@ -15151,7 +15153,11 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
       clearTimeout(timer);
       resolve9(Date.now() <= deadline ? value : null);
     };
-    const timer = setTimeout(() => finish(null), remainingMs);
+    const armDeadline = () => {
+      const nextRemainingMs = deadline - Date.now();
+      timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
+    };
+    armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
       if (settled)
         return;
@@ -15691,6 +15697,20 @@ function countExactMatches(treeJson, id) {
   }
   return matches;
 }
+function countVisibilityMatches(treeJson, id) {
+  const treeMatches = countExactMatches(treeJson, id);
+  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
+    return treeMatches;
+  const interactive = treeJson.interactive;
+  if (!Array.isArray(interactive))
+    return 0;
+  return interactive.filter((node) => {
+    if (!node || typeof node !== "object")
+      return false;
+    const record = node;
+    return record.testID === id || record.nativeID === id;
+  }).length;
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -15800,7 +15820,7 @@ function buildCdpDispatch(deps, signal) {
     },
     async visibility(id) {
       const tree = await deps.treeFor(id);
-      const treeMatches = countExactMatches(tree, id);
+      const treeMatches = countVisibilityMatches(tree, id);
       if (treeMatches === 0)
         return {
           visible: false,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -16767,9 +16767,12 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin({ signal: flowAbort.signal });
+          await reproveManagedOrigin({
+            signal: flowAbort.signal,
+            readinessTimeoutMs: Math.max(1, flowDeadline - now())
+          });
         }
-        await completeOrigin(true);
+        await completeOrigin(true, flowAbort.signal);
         nativeOriginPreclaimed = false;
       }
       await commitReinstalledInstall();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15161,6 +15161,10 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
       if (settled)
         return;
+      if (Date.now() > deadline) {
+        finish(null);
+        return;
+      }
       settled = true;
       clearTimeout(timer);
       reject(error);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -16767,7 +16767,7 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin();
+          await reproveManagedOrigin({ signal: flowAbort.signal });
         }
         await completeOrigin(true);
         nativeOriginPreclaimed = false;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -16032,7 +16032,7 @@ function remapNativeSteps(steps, sourceIndices) {
     return mapped ? [mapped] : [];
   });
 }
-function partialNativeFailureMessage(meta) {
+function partialNativeFailureMessage(meta, nestedError) {
   const failedStep = remapNativeStep(meta.failedStep, 0, []);
   const lastStep = remapNativeStep(meta.lastStep, 0, []);
   const terminal = isRecord(meta.terminal) ? meta.terminal : null;
@@ -16041,7 +16041,12 @@ function partialNativeFailureMessage(meta) {
     kind: failureKind,
     selector: typeof terminal?.failureSelector === "string" ? terminal.failureSelector : null
   } : null;
-  const headline = formatFailureHeadline({ steps: [], failedStep, lastStep, reason }, { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true }, "Native replay segment failed.");
+  const headline = formatFailureHeadline(
+    { steps: [], failedStep, lastStep, reason },
+    { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true },
+    // Keep the nested envelope's own cause when no structured evidence exists.
+    nestedError?.replace(/^Maestro flow failed: /, "") || "Native replay segment failed."
+  );
   const runtimeDegradation = runtimeDegradationFromMetadata(meta.runtimeDegraded);
   return runtimeDegradation ? `${headline} \u2014 ${formatRuntimeDegradedHint(runtimeDegradation)}` : headline;
 }
@@ -16280,7 +16285,7 @@ function createMaestroRunHandler(deps = {}) {
               if (!nativeSegmentCoversAttempt) {
                 delete nestedMeta.trailingVerification;
                 delete nestedMeta.ledger;
-                nestedError = partialNativeFailureMessage(nestedMeta);
+                nestedError = partialNativeFailureMessage(nestedMeta, env.error);
               }
               combinedSteps.push(...remapNativeSteps(nestedMeta.steps, segment.sourceIndices));
               const uniqueProofDomains = [...new Set(proofDomains)];
@@ -16761,7 +16766,7 @@ function createMaestroRunHandler(deps = {}) {
         signal: flowAbort.signal
       });
       if (deferredNativeOriginTarget) {
-        if (nativeOriginPreclaimed && replayFactory && (args.reproveManagedOrigin || deps.reproveManagedOrigin || hasManagedNativeOriginAuthority(args))) {
+        if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
           await reproveManagedOrigin();
         }
         await completeOrigin(true);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15138,6 +15138,29 @@ var asString = (x) => typeof x === "string" ? x : null;
 var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
+async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs < 0)
+    return null;
+  return new Promise((resolve9, reject) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      resolve9(Date.now() <= deadline ? value : null);
+    };
+    const timer = setTimeout(() => finish(null), remainingMs);
+    Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -15314,10 +15337,17 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict;
+          let verdict = {
+            visible: false,
+            code: "TESTID_NOT_FOUND",
+            reason: `testID "${s.id}" not present before the visibility deadline`
+          };
           for (; ; ) {
-            verdict = await dispatch.visibility(s.id);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
+            if (!observed)
+              break;
+            verdict = observed;
             if (verdict.visible)
               break;
             const remainingMs = deadline - Date.now();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15139,24 +15139,44 @@ var isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
 var DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
 var VISIBILITY_POLL_INTERVAL_MS = 200;
 var MAX_TIMER_DELAY_MS = 2147483647;
-async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+async function readVisibilityBeforeDeadline(dispatch, id, deadline, signal) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve9, reject) => {
     let settled = false;
     let timer;
+    const cleanup = () => {
+      if (timer !== void 0)
+        clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
     const finish = (value) => {
       if (settled)
         return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve9(Date.now() <= deadline ? value : null);
+    };
+    const fail = (error) => {
+      if (settled)
+        return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = () => {
+      fail(new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline"));
     };
     const armDeadline = () => {
       const nextRemainingMs = deadline - Date.now();
       timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
     };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error) => {
       if (settled)
@@ -15165,9 +15185,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
         finish(null);
         return;
       }
-      settled = true;
-      clearTimeout(timer);
-      reject(error);
+      fail(error);
     });
   });
 }
@@ -15351,7 +15369,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const deadline = startedAt + s.timeoutMs;
           let verdict = null;
           for (; ; ) {
-            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline, opts.signal);
             requireNotAborted();
             if (!observed)
               break;
@@ -15773,7 +15791,7 @@ function buildCdpDispatch(deps, signal) {
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
     if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
-    if (isDisabled(nodeProps(tree, id)))
+    if (frontmost.disabled === true || isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
     const pointerEventsError = pointerEventsBlock(tree, id);
     if (pointerEventsError)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15684,37 +15684,6 @@ function loginPostconditionId(commands) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
-function countExactMatches(treeJson, id) {
-  let matches = 0;
-  const root2 = treeJson && typeof treeJson === "object" && "tree" in treeJson ? treeJson.tree : treeJson;
-  const stack = [root2];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node || typeof node !== "object")
-      continue;
-    const record = node;
-    if (record.testID === id || record.nativeID === id)
-      matches++;
-    const children = record.children ?? record.nodes ?? record.matches;
-    if (Array.isArray(children))
-      stack.push(...children);
-  }
-  return matches;
-}
-function countVisibilityMatches(treeJson, id) {
-  const treeMatches = countExactMatches(treeJson, id);
-  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
-    return treeMatches;
-  const interactive = treeJson.interactive;
-  if (!Array.isArray(interactive))
-    return 0;
-  return interactive.filter((node) => {
-    if (!node || typeof node !== "object")
-      return false;
-    const record = node;
-    return record.testID === id || record.nativeID === id;
-  }).length;
-}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -15793,17 +15762,16 @@ function buildCdpDispatch(deps, signal) {
   const assertExactInteractable = async (id) => {
     const tree = await deps.treeFor(id);
     requireNotAborted();
-    const treeMatches = countExactMatches(tree, id);
-    if (treeMatches === 0)
+    const frontmost = await deps.frontmostFor(id);
+    requireNotAborted();
+    if (frontmost.matchCount === 0)
       throw new ReplayDispatchError("TESTID_NOT_FOUND", `testID "${id}" not present`, {
         failedSelector: id
       });
-    const frontmost = await deps.frontmostFor?.(id);
-    requireNotAborted();
-    const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+    const matches = frontmost.matchCount ?? 1;
     if (matches > 1)
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
-    if (frontmost && !frontmost.visible)
+    if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
     if (isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
@@ -15823,24 +15791,23 @@ function buildCdpDispatch(deps, signal) {
       await deps.typeByTestId(id, text);
     },
     async visibility(id) {
-      const tree = await deps.treeFor(id);
-      const treeMatches = countVisibilityMatches(tree, id);
-      if (treeMatches === 0)
+      await deps.treeFor(id);
+      const frontmost = await deps.frontmostFor(id);
+      if (frontmost.matchCount === 0)
         return {
           visible: false,
           code: "TESTID_NOT_FOUND",
           reason: `testID "${id}" not present in the React tree`,
           meta: { failedSelector: id }
         };
-      const frontmost = await deps.frontmostFor?.(id);
-      const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+      const matches = frontmost.matchCount ?? 1;
       if (matches > 1)
         return {
           visible: false,
           code: "AMBIGUOUS_TESTID",
           reason: `testID "${id}" resolves to ${matches} mounted elements`
         };
-      if (frontmost && !frontmost.visible)
+      if (!frontmost.visible)
         return {
           visible: false,
           code: frontmost.code ?? "ASSERTION_FAILED",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15224,7 +15224,8 @@ function normalizeSteps(body, params) {
         out.push({
           t: "waitVisible",
           id: interp(id, params),
-          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+          evidenceType: "assert"
         });
         break;
       }
@@ -15301,6 +15302,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
+    const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
     try {
       requireNotAborted();
@@ -15343,11 +15345,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict = {
-            visible: false,
-            code: "TESTID_NOT_FOUND",
-            reason: `testID "${s.id}" not present before the visibility deadline`
-          };
+          let verdict = null;
           for (; ; ) {
             const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
@@ -15364,11 +15362,13 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
-            t: s.t,
+            t: evidenceType,
             target: s.id,
-            ok: verdict.visible,
+            ok: verdict?.visible === true,
             durationMs: waitedMs
           });
+          if (!verdict)
+            return fail(i, `waitVisible: no readable visibility observation completed for "${s.id}" before the deadline`, "RUNNER_TIMEOUT", { failedSelector: s.id, waitedMs });
           if (!verdict.visible)
             return fail(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
@@ -15423,7 +15423,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
       const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
-        t: s.t,
+        t: evidenceType,
         target: "id" in s ? s.id : void 0,
         ok: false,
         durationMs: waitedMs

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82512,7 +82512,7 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin();
+          await reproveManagedOrigin({ signal: flowAbort.signal });
         }
         await completeOrigin(true);
         nativeOriginPreclaimed = false;
@@ -83411,7 +83411,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));
@@ -83727,7 +83727,7 @@ function createRunActionHandler(deps = {}) {
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
+        reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
       }));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67675,8 +67675,7 @@ var init_injected_helpers = __esm({
       });
     }
     function containsFiber(ancestor, candidate) {
-      // A fiber and its work-in-progress alternate are the same logical node;
-      // committed .return chains may thread through either half of the pair.
+      // React return chains may thread through either half of a fiber/alternate pair.
       var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81788,7 +81788,7 @@ function remapNativeSteps(steps, sourceIndices) {
     return mapped ? [mapped] : [];
   });
 }
-function partialNativeFailureMessage(meta) {
+function partialNativeFailureMessage(meta, nestedError) {
   const failedStep = remapNativeStep(meta.failedStep, 0, []);
   const lastStep = remapNativeStep(meta.lastStep, 0, []);
   const terminal = isRecord(meta.terminal) ? meta.terminal : null;
@@ -81797,7 +81797,12 @@ function partialNativeFailureMessage(meta) {
     kind: failureKind,
     selector: typeof terminal?.failureSelector === "string" ? terminal.failureSelector : null
   } : null;
-  const headline = formatFailureHeadline({ steps: [], failedStep, lastStep, reason }, { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true }, "Native replay segment failed.");
+  const headline = formatFailureHeadline(
+    { steps: [], failedStep, lastStep, reason },
+    { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true },
+    // Keep the nested envelope's own cause when no structured evidence exists.
+    nestedError?.replace(/^Maestro flow failed: /, "") || "Native replay segment failed."
+  );
   const runtimeDegradation = runtimeDegradationFromMetadata(meta.runtimeDegraded);
   return runtimeDegradation ? `${headline} \u2014 ${formatRuntimeDegradedHint(runtimeDegradation)}` : headline;
 }
@@ -82025,7 +82030,7 @@ function createMaestroRunHandler(deps = {}) {
               if (!nativeSegmentCoversAttempt) {
                 delete nestedMeta.trailingVerification;
                 delete nestedMeta.ledger;
-                nestedError = partialNativeFailureMessage(nestedMeta);
+                nestedError = partialNativeFailureMessage(nestedMeta, env.error);
               }
               combinedSteps.push(...remapNativeSteps(nestedMeta.steps, segment.sourceIndices));
               const uniqueProofDomains = [...new Set(proofDomains)];
@@ -82506,7 +82511,7 @@ function createMaestroRunHandler(deps = {}) {
         signal: flowAbort.signal
       });
       if (deferredNativeOriginTarget) {
-        if (nativeOriginPreclaimed && replayFactory && (args.reproveManagedOrigin || deps.reproveManagedOrigin || hasManagedNativeOriginAuthority(args))) {
+        if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
           await reproveManagedOrigin();
         }
         await completeOrigin(true);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80841,7 +80841,8 @@ function normalizeSteps(body, params) {
         out.push({
           t: "waitVisible",
           id: interp(id, params),
-          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+          evidenceType: "assert"
         });
         break;
       }
@@ -80918,6 +80919,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
+    const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
     try {
       requireNotAborted();
@@ -80960,11 +80962,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict = {
-            visible: false,
-            code: "TESTID_NOT_FOUND",
-            reason: `testID "${s.id}" not present before the visibility deadline`
-          };
+          let verdict = null;
           for (; ; ) {
             const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
@@ -80981,11 +80979,13 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
-            t: s.t,
+            t: evidenceType,
             target: s.id,
-            ok: verdict.visible,
+            ok: verdict?.visible === true,
             durationMs: waitedMs
           });
+          if (!verdict)
+            return fail3(i, `waitVisible: no readable visibility observation completed for "${s.id}" before the deadline`, "RUNNER_TIMEOUT", { failedSelector: s.id, waitedMs });
           if (!verdict.visible)
             return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
@@ -81040,7 +81040,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
       const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
-        t: s.t,
+        t: evidenceType,
         target: "id" in s ? s.id : void 0,
         ok: false,
         durationMs: waitedMs
@@ -81369,8 +81369,10 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0;
-  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
+  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
+  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
   const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
   const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81369,12 +81369,13 @@ function replayTreeData(envelope, selector) {
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const completeFiltered = complete && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && (filteredTree === null || isExactPresent(filteredTree, selector));
-  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
+  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
+  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
   const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -96897,7 +96897,7 @@ var init_index = __esm({
           })).content[0].text);
           let env = await fetchTree(false);
           const d = env.data;
-          if (d && typeof d === "object" && "__agent_truncated" in d) {
+          if (d && typeof d === "object" && ("__agent_truncated" in d || d.truncated === true)) {
             env = await fetchTree(true);
           }
           const data = replayTreeData(env);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 48;
+    HELPERS_VERSION = 49;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -67674,10 +67674,13 @@ var init_injected_helpers = __esm({
       });
     }
     function containsFiber(ancestor, candidate) {
+      // A fiber and its work-in-progress alternate are the same logical node;
+      // committed .return chains may thread through either half of the pair.
+      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor) return true;
+        if (current === ancestor || current === ancestorAlternate) return true;
         current = current.return;
       }
       return false;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63962,11 +63962,7 @@ var init_injected_helpers = __esm({
     '_LogBoxInspectorContainer'
   ];
 
-  // Reset by every root-iteration pass; only valid when read synchronously
-  // after the pass that produced the tree (many helpers share the iterators).
-  // finished is true only when the renderer-ID loop finished without the
-  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
-  // (GH #789).
+  // Synchronous scan result; finished stays false after the GH #789 empty-streak exit.
   var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
   function rootScanCoverage() {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80762,6 +80762,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     return null;
   return new Promise((resolve22, reject) => {
     let settled = false;
+    let timer;
     const finish = (value) => {
       if (settled)
         return;
@@ -80769,7 +80770,11 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
       clearTimeout(timer);
       resolve22(Date.now() <= deadline ? value : null);
     };
-    const timer = setTimeout(() => finish(null), remainingMs);
+    const armDeadline = () => {
+      const nextRemainingMs = deadline - Date.now();
+      timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
+    };
+    armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
@@ -81049,7 +81054,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
-var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj, DEFAULT_VISIBILITY_TIMEOUT_MS, VISIBILITY_POLL_INTERVAL_MS;
+var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj, DEFAULT_VISIBILITY_TIMEOUT_MS, VISIBILITY_POLL_INTERVAL_MS, MAX_TIMER_DELAY_MS;
 var init_cdp_flow_replay = __esm({
   "packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js"() {
     "use strict";
@@ -81076,6 +81081,7 @@ var init_cdp_flow_replay = __esm({
     isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
     DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
     VISIBILITY_POLL_INTERVAL_MS = 200;
+    MAX_TIMER_DELAY_MS = 2147483647;
   }
 });
 
@@ -81402,6 +81408,20 @@ function countExactMatches(treeJson, id) {
   }
   return matches;
 }
+function countVisibilityMatches(treeJson, id) {
+  const treeMatches = countExactMatches(treeJson, id);
+  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
+    return treeMatches;
+  const interactive = treeJson.interactive;
+  if (!Array.isArray(interactive))
+    return 0;
+  return interactive.filter((node) => {
+    if (!node || typeof node !== "object")
+      return false;
+    const record2 = node;
+    return record2.testID === id || record2.nativeID === id;
+  }).length;
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -81511,7 +81531,7 @@ function buildCdpDispatch(deps, signal) {
     },
     async visibility(id) {
       const tree = await deps.treeFor(id);
-      const treeMatches = countExactMatches(tree, id);
+      const treeMatches = countVisibilityMatches(tree, id);
       if (treeMatches === 0)
         return {
           visible: false,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -64322,6 +64322,7 @@ var init_injected_helpers = __esm({
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
       if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
       var unscanned = computeUnscannedRendererIds();
       if (unscanned.length > 0) reasons.push('renderers-unscanned');
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
@@ -67607,6 +67608,18 @@ var init_injected_helpers = __esm({
         reason: 'frontmost testID scan exceeded its bounded React-tree budget',
         code: 'ASSERTION_FAILED',
         truncated: true
+      });
+    }
+    var unscannedRendererIds = computeUnscannedRendererIds();
+    if (
+      lastRootScan.rendererErrors > 0 ||
+      !lastRootScan.complete ||
+      unscannedRendererIds.length > 0
+    ) {
+      return JSON.stringify({
+        visible: false,
+        code: 'ASSERTION_FAILED',
+        reason: 'frontmost proof cannot cover every mounted renderer'
       });
     }
     function containsFiber(ancestor, candidate) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80810,7 +80810,11 @@ function normalizeSteps(body, params) {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
           throw new UnsupportedStepError("assertVisible (missing string id)");
-        out.push({ t: "assert", id: interp(id, params) });
+        out.push({
+          t: "waitVisible",
+          id: interp(id, params),
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS
+        });
         break;
       }
       case "extendedWaitUntil": {
@@ -80820,10 +80824,10 @@ function normalizeSteps(body, params) {
           refuseUnsupportedKeys(v.visible, ["id"], "extendedWaitUntil.visible");
         }
         const id = isObj(v) && isObj(v.visible) ? asString(v.visible.id) : null;
-        const timeoutMs = isObj(v) ? v.timeout : void 0;
-        if (!id || !Number.isSafeInteger(timeoutMs) || Number(timeoutMs) < 0)
-          throw new UnsupportedStepError("extendedWaitUntil (need visible.id + non-negative integer timeout)");
-        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs: Number(timeoutMs) });
+        const timeoutMs = isObj(v) && "timeout" in v ? v.timeout : DEFAULT_VISIBILITY_TIMEOUT_MS;
+        if (!id || typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs < 0)
+          throw new UnsupportedStepError("extendedWaitUntil (need visible.id; timeout must be finite and non-negative when present)");
+        out.push({ t: "waitVisible", id: interp(id, params), timeoutMs });
         break;
       }
       case "waitForAnimationToEnd": {
@@ -80926,39 +80930,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         }
-        case "assert": {
-          const verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          trace.push({
-            sourceIndex: sourceIndex(i),
-            t: s.t,
-            target: s.id,
-            ok: verdict.visible,
-            durationMs: Date.now() - startedAt
-          });
-          if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `assertVisible: "${s.id}" is not frontmost`, verdict.code ?? "ASSERTION_FAILED", verdict.meta);
-          break;
-        }
         case "waitVisible": {
-          const deadline = Date.now() + s.timeoutMs;
-          let verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          while (!verdict.visible && Date.now() < deadline) {
-            requireNotAborted();
-            await new Promise((resolve22) => setTimeout(resolve22, 100));
+          const deadline = startedAt + s.timeoutMs;
+          let verdict;
+          for (; ; ) {
             verdict = await dispatch.visibility(s.id);
             requireNotAborted();
+            if (verdict.visible)
+              break;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0)
+              break;
+            await new Promise((resolve22) => setTimeout(resolve22, Math.min(VISIBILITY_POLL_INTERVAL_MS, remainingMs)));
           }
+          const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
             ok: verdict.visible,
-            durationMs: Date.now() - startedAt
+            durationMs: waitedMs
           });
           if (!verdict.visible)
-            return fail3(i, verdict.reason ?? `extendedWaitUntil: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", verdict.meta);
+            return fail3(i, verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`, verdict.code ?? "TESTID_NOT_FOUND", { ...verdict.meta, failedSelector: s.id, waitedMs });
           break;
         }
         case "wait":
@@ -81008,14 +81002,16 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
       }
     } catch (e) {
+      const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
         t: s.t,
         target: "id" in s ? s.id : void 0,
         ok: false,
-        durationMs: Date.now() - startedAt
+        durationMs: waitedMs
       });
-      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, e instanceof ReplayDispatchError ? e.meta : void 0);
+      const dispatchMeta = e instanceof ReplayDispatchError ? e.meta : void 0;
+      return fail3(i, e instanceof Error ? e.message : String(e), e instanceof ReplayDispatchError ? e.code : void 0, s.t === "waitVisible" ? { ...dispatchMeta, failedSelector: s.id, waitedMs } : dispatchMeta);
     }
   }
   if (opts.signal?.aborted) {
@@ -81023,7 +81019,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
-var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj;
+var UnsupportedStepError, ReplayDispatchError, interp, asString, isObj, DEFAULT_VISIBILITY_TIMEOUT_MS, VISIBILITY_POLL_INTERVAL_MS;
 var init_cdp_flow_replay = __esm({
   "packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js"() {
     "use strict";
@@ -81048,6 +81044,8 @@ var init_cdp_flow_replay = __esm({
     interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)(?:\s*\?\?\s*(['"])(.*?)\2)?\}/g, (match, key, _quote, fallback) => p[key] ?? fallback ?? match);
     asString = (x) => typeof x === "string" ? x : null;
     isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+    DEFAULT_VISIBILITY_TIMEOUT_MS = 17e3;
+    VISIBILITY_POLL_INTERVAL_MS = 200;
   }
 });
 
@@ -81312,14 +81310,17 @@ function unwrapTree(data) {
 function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
-  if (envelope.ok === true && !redbox)
-    return envelope.data;
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const message = redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const truncated = data !== null && data.__agent_truncated === true;
+  if (envelope.ok === true && !redbox && !truncated)
+    return envelope.data;
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...truncated ? { truncated: true } : {},
+      ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
       ...warning ? { warning } : {},
@@ -96781,12 +96782,11 @@ var init_index = __esm({
             ...interactiveOnly ? { interactiveOnly: true } : {}
           })).content[0].text);
           let env = await fetchTree(false);
-          let data = replayTreeData(env);
-          const d = data;
+          const d = env.data;
           if (d && typeof d === "object" && "__agent_truncated" in d) {
             env = await fetchTree(true);
-            data = replayTreeData(env);
           }
+          const data = replayTreeData(env);
           return unwrapTree(data);
         },
         frontmostFor: async (id) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 49;
+    HELPERS_VERSION = 50;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -64392,6 +64392,7 @@ var init_injected_helpers = __esm({
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
         complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        rendererErrors: lastRootScan.rendererErrors,
         unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
@@ -67709,6 +67710,9 @@ var init_injected_helpers = __esm({
       });
     }
     var target = logicalMatches[0];
+    var targetProps = target.memoizedProps || {};
+    var targetAccessibilityState = targetProps.accessibilityState || {};
+    var targetDisabled = targetProps.disabled === true || targetAccessibilityState.disabled === true;
     if (__hidden(target)) {
       return JSON.stringify({
         visible: false,
@@ -67717,7 +67721,7 @@ var init_injected_helpers = __esm({
       });
     }
 
-    var targetPointerEvents = (target.memoizedProps || {}).pointerEvents;
+    var targetPointerEvents = targetProps.pointerEvents;
     if (targetPointerEvents === 'none' || targetPointerEvents === 'box-none') {
       return JSON.stringify({
         visible: false,
@@ -67883,7 +67887,8 @@ var init_injected_helpers = __esm({
       route: routeOwner,
       activeRoute: activeRoute,
       modalCount: modals.length,
-      matchCount: 1
+      matchCount: 1,
+      disabled: targetDisabled
     });
   }
 
@@ -80823,24 +80828,44 @@ var init_maestro_run_ledger = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
-async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+async function readVisibilityBeforeDeadline(dispatch, id, deadline, signal) {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0)
     return null;
   return new Promise((resolve22, reject) => {
     let settled = false;
     let timer;
+    const cleanup = () => {
+      if (timer !== void 0)
+        clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
     const finish = (value) => {
       if (settled)
         return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve22(Date.now() <= deadline ? value : null);
+    };
+    const fail3 = (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      cleanup();
+      reject(error2);
+    };
+    const onAbort = () => {
+      fail3(new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline"));
     };
     const armDeadline = () => {
       const nextRemainingMs = deadline - Date.now();
       timer = setTimeout(() => Date.now() >= deadline ? finish(null) : armDeadline(), Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS));
     };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     armDeadline();
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
@@ -80849,9 +80874,7 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
         finish(null);
         return;
       }
-      settled = true;
-      clearTimeout(timer);
-      reject(error2);
+      fail3(error2);
     });
   });
 }
@@ -81035,7 +81058,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const deadline = startedAt + s.timeoutMs;
           let verdict = null;
           for (; ; ) {
-            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline, opts.signal);
             requireNotAborted();
             if (!observed)
               break;
@@ -81528,7 +81551,7 @@ function buildCdpDispatch(deps, signal) {
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
     if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
-    if (isDisabled(nodeProps(tree, id)))
+    if (frontmost.disabled === true || isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
     const pointerEventsError = pointerEventsBlock(tree, id);
     if (pointerEventsError)
@@ -96893,6 +96916,7 @@ var init_index = __esm({
             const parsed = JSON.parse(result.value);
             return {
               visible: parsed.visible === true,
+              ...typeof parsed.disabled === "boolean" ? { disabled: parsed.disabled } : {},
               ...parsed.reason ? { reason: parsed.reason } : {},
               ...typeof parsed.matchCount === "number" ? { matchCount: parsed.matchCount } : {},
               ...parsed.code ? { code: parsed.code } : {}

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82512,9 +82512,12 @@ function createMaestroRunHandler(deps = {}) {
       });
       if (deferredNativeOriginTarget) {
         if (nativeOriginPreclaimed && (args.reproveManagedOrigin || deps.reproveManagedOrigin || replayFactory && hasManagedNativeOriginAuthority(args))) {
-          await reproveManagedOrigin({ signal: flowAbort.signal });
+          await reproveManagedOrigin({
+            signal: flowAbort.signal,
+            readinessTimeoutMs: Math.max(1, flowDeadline - now())
+          });
         }
-        await completeOrigin(true);
+        await completeOrigin(true, flowAbort.signal);
         nativeOriginPreclaimed = false;
       }
       await commitReinstalledInstall();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -83412,7 +83412,7 @@ function createRunActionHandler(deps = {}) {
         params: args.params,
         attempt: { attemptId: initialAttemptId, ordinal: 1, maxAttempts, kind: "initial" },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
@@ -83728,7 +83728,7 @@ function createRunActionHandler(deps = {}) {
           parentAttemptId: initialAttemptId
         },
         claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+        completeNativeOrigin: (targetExpected, signal) => completeNativeOrigin(args, targetExpected, signal),
         relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
         reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
         completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81420,13 +81420,16 @@ function replayTreeData(envelope) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  if (envelope.ok === true && !redbox && !truncated)
+  const agentError = typeof data?.__agent_error === "string" ? data.__agent_error.slice(0, 1e3) : void 0;
+  const serializationFailed = agentError !== void 0;
+  if (envelope.ok === true && !redbox && !truncated && !serializationFailed)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
-  const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
+  const message = serializationFailed ? agentError || "Component tree serialization failed" : truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const code = serializationFailed ? "EVAL_FAILED" : redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...serializationFailed ? { agentError } : {},
       ...truncated ? { truncated: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 47;
+    HELPERS_VERSION = 48;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -63964,21 +63964,77 @@ var init_injected_helpers = __esm({
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  // complete is true only when the renderer-ID loop finished without the
+  // finished is true only when the renderer-ID loop finished without the
   // empty-streak early-exit \u2014 empty roots are mounting evidence only then
   // (GH #789).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+  var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
-  function computeUnscannedRendererIds() {
-    try {
-      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
-      var out = [];
-      hook.renderers.forEach(function(_v, id) {
-        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
-      });
-      return out;
-    } catch (_) { return []; }
+  function rootScanCoverage() {
+    var reasons = [];
+    var registryIds = [];
+    var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    var renderers = hook && hook.renderers;
+    if (renderers) {
+      if (typeof renderers.keys !== 'function' || typeof renderers.forEach !== 'function') {
+        registryIds = null;
+      } else {
+        try {
+          var iterator = renderers.keys();
+          if (!iterator || typeof iterator.next !== 'function') {
+            registryIds = null;
+          } else {
+            var step;
+            var iterations = 0;
+            while (registryIds !== null) {
+              step = iterator.next();
+              if (!step || typeof step !== 'object' || typeof step.done !== 'boolean') {
+                registryIds = null;
+                break;
+              }
+              if (step.done) break;
+              if (++iterations > MAX_REGISTERED_RENDERER_IDS || typeof step.value !== 'number') {
+                registryIds = null;
+                break;
+              }
+              if (registryIds.indexOf(step.value) === -1) registryIds.push(step.value);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            }
+          }
+        } catch (_) {
+          registryIds = null;
+        }
+        if (registryIds !== null) {
+          try {
+            var forEachIterations = 0;
+            renderers.forEach(function(_v, id) {
+              if (registryIds === null) return;
+              if (++forEachIterations > MAX_REGISTERED_RENDERER_IDS || typeof id !== 'number') {
+                registryIds = null;
+                return;
+              }
+              if (registryIds.indexOf(id) === -1) registryIds.push(id);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            });
+          } catch (_) {
+            registryIds = null;
+          }
+        }
+      }
+    }
+    var addReason = function(reason) {
+      if (reasons.indexOf(reason) === -1) reasons.push(reason);
+    };
+    if (lastRootScan.rendererErrors > 0 || registryIds === null) addReason('renderer-error');
+    if (!lastRootScan.finished) addReason('root-enumeration-incomplete');
+    var unscannedRendererIds = [];
+    if (registryIds !== null) {
+      for (var i = 0; i < registryIds.length; i++) {
+        var id = registryIds[i];
+        if (!lastRootScan.visited[id]) unscannedRendererIds.push(id);
+      }
+      if (unscannedRendererIds.length > 0) addReason('renderers-unscanned');
+    }
+    return { reasons: reasons, unscannedRendererIds: unscannedRendererIds };
   }
 
   // Read the renderer IDs React DevTools actually registered. A malformed or
@@ -64005,7 +64061,7 @@ var init_injected_helpers = __esm({
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -64016,7 +64072,7 @@ var init_injected_helpers = __esm({
     var emptyStreak = 0;
     for (var rii = 0; rii < rendererIds.length; rii++) {
       var ri = rendererIds[rii];
-      if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+      lastRootScan.visited[ri] = true;
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size > 0) {
@@ -64031,7 +64087,7 @@ var init_injected_helpers = __esm({
         lastRootScan.rendererErrors++;
       }
     }
-    lastRootScan.complete = true;
+    lastRootScan.finished = true;
     return null;
   }
 
@@ -64048,7 +64104,7 @@ var init_injected_helpers = __esm({
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -64060,7 +64116,7 @@ var init_injected_helpers = __esm({
       var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
-        if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+        lastRootScan.visited[ri] = true;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -64085,7 +64141,7 @@ var init_injected_helpers = __esm({
           lastRootScan.rendererErrors++;
         }
       }
-      lastRootScan.complete = !abortedEarly;
+      if (!abortedEarly) lastRootScan.finished = true;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -64321,10 +64377,12 @@ var init_injected_helpers = __esm({
       o = o || {};
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
-      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
-      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
-      var unscanned = computeUnscannedRendererIds();
-      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      var coverage = rootScanCoverage();
+      for (var coverageIndex = 0; coverageIndex < coverage.reasons.length; coverageIndex++) {
+        if (reasons.indexOf(coverage.reasons[coverageIndex]) === -1) {
+          reasons.push(coverage.reasons[coverageIndex]);
+        }
+      }
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
       if (o.outputTruncated) reasons.push('output-truncated');
       var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
@@ -64337,8 +64395,8 @@ var init_injected_helpers = __esm({
         effectiveDepth: maxDepth,
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
-        rendererErrors: lastRootScan.rendererErrors,
-        unscannedRendererIds: unscanned
+        complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
 
@@ -64802,7 +64860,8 @@ var init_injected_helpers = __esm({
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
       // Only a complete, clean scan is mounting evidence.
-      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
+      var mountCoverage = rootScanCoverage();
+      var mountScanClean = mountHookUsable && mountCoverage.reasons.length === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
@@ -64810,7 +64869,7 @@ var init_injected_helpers = __esm({
           retryInMs: 2000
         });
       }
-      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+      if (mountHookUsable && mountCoverage.reasons.indexOf('root-enumeration-incomplete') !== -1 && mountRoots.length === 0) {
         return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
@@ -67610,12 +67669,8 @@ var init_injected_helpers = __esm({
         truncated: true
       });
     }
-    var unscannedRendererIds = computeUnscannedRendererIds();
-    if (
-      lastRootScan.rendererErrors > 0 ||
-      !lastRootScan.complete ||
-      unscannedRendererIds.length > 0
-    ) {
+    var coverage = rootScanCoverage();
+    if (coverage.reasons.length > 0) {
       return JSON.stringify({
         visible: false,
         code: 'ASSERTION_FAILED',
@@ -80791,6 +80846,10 @@ async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
     Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
       if (settled)
         return;
+      if (Date.now() > deadline) {
+        finish(null);
+        return;
+      }
       settled = true;
       clearTimeout(timer);
       reject(error2);
@@ -81380,9 +81439,8 @@ function replayTreeData(envelope, selector) {
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
   const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
-  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.state === "ok" && reasons.length === 0 && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0 && verdict.droppedSubtrees === 0 && verdict.collapsedChildLists === 0;
+  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
   const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
   const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
   const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81409,53 +81409,25 @@ var init_ios_proof_router = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
-function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
-  if (!node || typeof node !== "object")
-    return acc;
-  const n = node;
-  if (typeof n.testID === "string")
-    acc.add(n.testID);
-  if (typeof n.nativeID === "string")
-    acc.add(n.nativeID);
-  if (n.tree)
-    collectTestIds(n.tree, acc);
-  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
-  if (Array.isArray(kids))
-    for (const c of kids)
-      collectTestIds(c, acc);
-  return acc;
-}
-function isExactPresent(treeJson, selector) {
-  return collectTestIds(treeJson).has(selector);
-}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope, selector) {
+function replayTreeData(envelope) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict = verdict?.complete === true && typeof verdict.rootsSeeded === "number" && verdict.rootsSeeded > 0;
-  const filteredTree = data !== null && "tree" in data ? data.tree : void 0;
-  const serializedMatches = filteredTree && typeof filteredTree === "object" && !Array.isArray(filteredTree) && Array.isArray(filteredTree.matches) ? filteredTree.matches : [];
-  const exactFilteredMatch = verdict?.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && serializedMatches.length < 10 && isExactPresent(filteredTree, selector);
-  const completeFilteredAbsence = completeAbsenceVerdict && verdict.path === "filter" && typeof selector === "string" && data !== null && "tree" in data && filteredTree === null;
-  const exactInteractiveMatch = verdict?.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
-  const incomplete = envelope.ok === true && !redbox && !truncated && !exactFilteredMatch && !completeFilteredAbsence && !exactInteractiveMatch;
-  if (envelope.ok === true && !redbox && !truncated && !incomplete)
+  if (envelope.ok === true && !redbox && !truncated)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
-      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -81464,37 +81436,6 @@ function replayTreeData(envelope, selector) {
       ...envelope.meta ? { meta: envelope.meta } : {}
     }
   });
-}
-function countExactMatches(treeJson, id) {
-  let matches = 0;
-  const root = treeJson && typeof treeJson === "object" && "tree" in treeJson ? treeJson.tree : treeJson;
-  const stack = [root];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node || typeof node !== "object")
-      continue;
-    const record2 = node;
-    if (record2.testID === id || record2.nativeID === id)
-      matches++;
-    const children = record2.children ?? record2.nodes ?? record2.matches;
-    if (Array.isArray(children))
-      stack.push(...children);
-  }
-  return matches;
-}
-function countVisibilityMatches(treeJson, id) {
-  const treeMatches = countExactMatches(treeJson, id);
-  if (treeMatches > 0 || !treeJson || typeof treeJson !== "object")
-    return treeMatches;
-  const interactive = treeJson.interactive;
-  if (!Array.isArray(interactive))
-    return 0;
-  return interactive.filter((node) => {
-    if (!node || typeof node !== "object")
-      return false;
-    const record2 = node;
-    return record2.testID === id || record2.nativeID === id;
-  }).length;
 }
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
@@ -81574,17 +81515,16 @@ function buildCdpDispatch(deps, signal) {
   const assertExactInteractable = async (id) => {
     const tree = await deps.treeFor(id);
     requireNotAborted();
-    const treeMatches = countExactMatches(tree, id);
-    if (treeMatches === 0)
+    const frontmost = await deps.frontmostFor(id);
+    requireNotAborted();
+    if (frontmost.matchCount === 0)
       throw new ReplayDispatchError("TESTID_NOT_FOUND", `testID "${id}" not present`, {
         failedSelector: id
       });
-    const frontmost = await deps.frontmostFor?.(id);
-    requireNotAborted();
-    const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+    const matches = frontmost.matchCount ?? 1;
     if (matches > 1)
       throw new ReplayDispatchError("AMBIGUOUS_TESTID", `testID "${id}" resolves to ${matches} mounted elements`, { matchCount: matches });
-    if (frontmost && !frontmost.visible)
+    if (!frontmost.visible)
       throw new ReplayDispatchError(frontmost.code ?? "ASSERTION_FAILED", frontmost.reason ?? `testID "${id}" is mounted but not frontmost`);
     if (isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `testID "${id}" is disabled/non-interactable`);
@@ -81604,24 +81544,23 @@ function buildCdpDispatch(deps, signal) {
       await deps.typeByTestId(id, text);
     },
     async visibility(id) {
-      const tree = await deps.treeFor(id);
-      const treeMatches = countVisibilityMatches(tree, id);
-      if (treeMatches === 0)
+      await deps.treeFor(id);
+      const frontmost = await deps.frontmostFor(id);
+      if (frontmost.matchCount === 0)
         return {
           visible: false,
           code: "TESTID_NOT_FOUND",
           reason: `testID "${id}" not present in the React tree`,
           meta: { failedSelector: id }
         };
-      const frontmost = await deps.frontmostFor?.(id);
-      const matches = frontmost ? frontmost.matchCount ?? 1 : treeMatches;
+      const matches = frontmost.matchCount ?? 1;
       if (matches > 1)
         return {
           visible: false,
           code: "AMBIGUOUS_TESTID",
           reason: `testID "${id}" resolves to ${matches} mounted elements`
         };
-      if (frontmost && !frontmost.visible)
+      if (!frontmost.visible)
         return {
           visible: false,
           code: frontmost.code ?? "ASSERTION_FAILED",
@@ -96936,7 +96875,7 @@ var init_index = __esm({
           if (d && typeof d === "object" && "__agent_truncated" in d) {
             env = await fetchTree(true);
           }
-          const data = replayTreeData(env, id);
+          const data = replayTreeData(env);
           return unwrapTree(data);
         },
         frontmostFor: async (id) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -80756,6 +80756,29 @@ var init_maestro_run_ledger = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
+async function readVisibilityBeforeDeadline(dispatch, id, deadline) {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs < 0)
+    return null;
+  return new Promise((resolve22, reject) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      resolve22(Date.now() <= deadline ? value : null);
+    };
+    const timer = setTimeout(() => finish(null), remainingMs);
+    Promise.resolve().then(() => dispatch.visibility(id)).then(finish, (error2) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error2);
+    });
+  });
+}
 function refuseUnsupportedKeys(value, allowed, label) {
   const unsupported = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unsupported.length > 0) {
@@ -80932,10 +80955,17 @@ async function replayFlow(steps, dispatch, opts = {}) {
         }
         case "waitVisible": {
           const deadline = startedAt + s.timeoutMs;
-          let verdict;
+          let verdict = {
+            visible: false,
+            code: "TESTID_NOT_FOUND",
+            reason: `testID "${s.id}" not present before the visibility deadline`
+          };
           for (; ; ) {
-            verdict = await dispatch.visibility(s.id);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
+            if (!observed)
+              break;
+            verdict = observed;
             if (verdict.visible)
               break;
             const remainingMs = deadline - Date.now();
@@ -81301,25 +81331,51 @@ var init_ios_proof_router = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
+function collectTestIds(node, acc = /* @__PURE__ */ new Set()) {
+  if (!node || typeof node !== "object")
+    return acc;
+  const n = node;
+  if (typeof n.testID === "string")
+    acc.add(n.testID);
+  if (typeof n.nativeID === "string")
+    acc.add(n.nativeID);
+  if (n.tree)
+    collectTestIds(n.tree, acc);
+  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
+  if (Array.isArray(kids))
+    for (const c of kids)
+      collectTestIds(c, acc);
+  return acc;
+}
+function isExactPresent(treeJson, selector) {
+  return collectTestIds(treeJson).has(selector);
+}
 function unwrapTree(data) {
   if (!data || typeof data !== "object")
     return null;
   const d = data;
   return "tree" in d ? d.tree : d;
 }
-function replayTreeData(envelope) {
+function replayTreeData(envelope, selector) {
   const warning = typeof envelope.meta?.warning === "string" ? envelope.meta.warning : void 0;
   const redbox = warning === "APP_HAS_REDBOX";
   const data = envelope.data && typeof envelope.data === "object" && !Array.isArray(envelope.data) ? envelope.data : null;
-  const truncated = data !== null && data.__agent_truncated === true;
-  if (envelope.ok === true && !redbox && !truncated)
+  const verdict = envelope.meta?.treeVerdict && typeof envelope.meta.treeVerdict === "object" && !Array.isArray(envelope.meta.treeVerdict) ? envelope.meta.treeVerdict : null;
+  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
+  const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
+  const complete = verdict?.state === "ok" && reasons.length === 0;
+  const completeFiltered = complete && verdict.path === "filter" && data !== null && "tree" in data;
+  const completeInteractiveMatch = complete && verdict.path === "interactive" && typeof selector === "string" && isExactPresent(data, selector);
+  const incomplete = envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  if (envelope.ok === true && !redbox && !truncated && !incomplete)
     return envelope.data;
-  const message = truncated ? "Component tree proof exceeded the readable payload budget" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
+  const message = truncated ? "Component tree proof exceeded the readable payload budget" : incomplete ? "Component tree proof is incomplete" : redbox && typeof data?.message === "string" ? data.message.slice(0, 1e3) : envelope.error?.slice(0, 1e3) ?? "Component tree proof is unavailable";
   const code = redbox ? warning : envelope.code ?? "EVAL_FAILED";
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...truncated ? { truncated: true } : {},
+      ...incomplete ? { incomplete: true } : {},
       ...truncated && typeof data.originalLength === "number" ? { originalLength: data.originalLength } : {},
       ...envelope.code ? { code: envelope.code } : {},
       ...envelope.error ? { error: envelope.error.slice(0, 1e3) } : {},
@@ -96786,7 +96842,7 @@ var init_index = __esm({
           if (d && typeof d === "object" && "__agent_truncated" in d) {
             env = await fetchTree(true);
           }
-          const data = replayTreeData(env);
+          const data = replayTreeData(env, id);
           return unwrapTree(data);
         },
         frontmostFor: async (id) => {

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -67,17 +67,36 @@ async function readVisibilityBeforeDeadline(
   dispatch: ReplayDispatch,
   id: string,
   deadline: number,
+  signal?: AbortSignal,
 ): Promise<ReplayVisibility | null> {
   const remainingMs = deadline - Date.now();
   if (remainingMs < 0) return null;
   return new Promise<ReplayVisibility | null>((resolve, reject) => {
     let settled = false;
-    let timer: ReturnType<typeof setTimeout>;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    };
     const finish = (value: ReplayVisibility | null): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve(Date.now() <= deadline ? value : null);
+    };
+    const fail = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = (): void => {
+      fail(
+        new ReplayDispatchError(
+          'RUNNER_TIMEOUT',
+          'React-tree replay exceeded its execution deadline',
+        ),
+      );
     };
     const armDeadline = (): void => {
       const nextRemainingMs = deadline - Date.now();
@@ -86,6 +105,11 @@ async function readVisibilityBeforeDeadline(
         Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS),
       );
     };
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     armDeadline();
     Promise.resolve()
       .then(() => dispatch.visibility(id))
@@ -95,9 +119,7 @@ async function readVisibilityBeforeDeadline(
           finish(null);
           return;
         }
-        settled = true;
-        clearTimeout(timer);
-        reject(error);
+        fail(error);
       });
   });
 }
@@ -309,7 +331,12 @@ export async function replayFlow(
           const deadline = startedAt + s.timeoutMs;
           let verdict: ReplayVisibility | null = null;
           for (;;) {
-            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
+            const observed = await readVisibilityBeforeDeadline(
+              dispatch,
+              s.id,
+              deadline,
+              opts.signal,
+            );
             requireNotAborted();
             if (!observed) break;
             verdict = observed;

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -2,7 +2,7 @@ export type ReplayStep =
   | { t: 'launch'; stopApp: boolean }
   | { t: 'tap'; id: string }
   | { t: 'type'; text: string }
-  | { t: 'waitVisible'; id: string; timeoutMs: number }
+  | { t: 'waitVisible'; id: string; timeoutMs: number; evidenceType?: 'assert' }
   | { t: 'wait'; timeoutMs: number }
   | { t: 'runFlow'; whenVisible: string; commands: ReplayStep[] };
 
@@ -161,6 +161,7 @@ export function normalizeSteps(body: unknown[], params: Record<string, string>):
           t: 'waitVisible',
           id: interp(id, params),
           timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+          evidenceType: 'assert',
         });
         break;
       }
@@ -260,6 +261,7 @@ export async function replayFlow(
 
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
+    const evidenceType = s.t === 'waitVisible' ? (s.evidenceType ?? s.t) : s.t;
     const startedAt = Date.now();
     try {
       requireNotAborted();
@@ -301,11 +303,7 @@ export async function replayFlow(
         }
         case 'waitVisible': {
           const deadline = startedAt + s.timeoutMs;
-          let verdict: ReplayVisibility = {
-            visible: false,
-            code: 'TESTID_NOT_FOUND',
-            reason: `testID "${s.id}" not present before the visibility deadline`,
-          };
+          let verdict: ReplayVisibility | null = null;
           for (;;) {
             const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
@@ -321,11 +319,18 @@ export async function replayFlow(
           const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
-            t: s.t,
+            t: evidenceType,
             target: s.id,
-            ok: verdict.visible,
+            ok: verdict?.visible === true,
             durationMs: waitedMs,
           });
+          if (!verdict)
+            return fail(
+              i,
+              `waitVisible: no readable visibility observation completed for "${s.id}" before the deadline`,
+              'RUNNER_TIMEOUT',
+              { failedSelector: s.id, waitedMs },
+            );
           if (!verdict.visible)
             return fail(
               i,
@@ -390,7 +395,7 @@ export async function replayFlow(
       const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
-        t: s.t,
+        t: evidenceType,
         target: 'id' in s ? s.id : undefined,
         ok: false,
         durationMs: waitedMs,

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -91,6 +91,10 @@ async function readVisibilityBeforeDeadline(
       .then(() => dispatch.visibility(id))
       .then(finish, (error: unknown) => {
         if (settled) return;
+        if (Date.now() > deadline) {
+          finish(null);
+          return;
+        }
         settled = true;
         clearTimeout(timer);
         reject(error);

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -62,6 +62,33 @@ const isObj = (x: unknown): x is Record<string, unknown> =>
 const DEFAULT_VISIBILITY_TIMEOUT_MS = 17_000;
 const VISIBILITY_POLL_INTERVAL_MS = 200;
 
+async function readVisibilityBeforeDeadline(
+  dispatch: ReplayDispatch,
+  id: string,
+  deadline: number,
+): Promise<ReplayVisibility | null> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs < 0) return null;
+  return new Promise<ReplayVisibility | null>((resolve, reject) => {
+    let settled = false;
+    const finish = (value: ReplayVisibility | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(Date.now() <= deadline ? value : null);
+    };
+    const timer = setTimeout(() => finish(null), remainingMs);
+    Promise.resolve()
+      .then(() => dispatch.visibility(id))
+      .then(finish, (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
 function refuseUnsupportedKeys(
   value: Record<string, unknown>,
   allowed: readonly string[],
@@ -265,10 +292,16 @@ export async function replayFlow(
         }
         case 'waitVisible': {
           const deadline = startedAt + s.timeoutMs;
-          let verdict: ReplayVisibility;
+          let verdict: ReplayVisibility = {
+            visible: false,
+            code: 'TESTID_NOT_FOUND',
+            reason: `testID "${s.id}" not present before the visibility deadline`,
+          };
           for (;;) {
-            verdict = await dispatch.visibility(s.id);
+            const observed = await readVisibilityBeforeDeadline(dispatch, s.id, deadline);
             requireNotAborted();
+            if (!observed) break;
+            verdict = observed;
             if (verdict.visible) break;
             const remainingMs = deadline - Date.now();
             if (remainingMs <= 0) break;

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -2,7 +2,6 @@ export type ReplayStep =
   | { t: 'launch'; stopApp: boolean }
   | { t: 'tap'; id: string }
   | { t: 'type'; text: string }
-  | { t: 'assert'; id: string }
   | { t: 'waitVisible'; id: string; timeoutMs: number }
   | { t: 'wait'; timeoutMs: number }
   | { t: 'runFlow'; whenVisible: string; commands: ReplayStep[] };
@@ -60,6 +59,8 @@ const interp = (s: string, p: Record<string, string>): string =>
 const asString = (x: unknown): string | null => (typeof x === 'string' ? x : null);
 const isObj = (x: unknown): x is Record<string, unknown> =>
   typeof x === 'object' && x !== null && !Array.isArray(x);
+const DEFAULT_VISIBILITY_TIMEOUT_MS = 17_000;
+const VISIBILITY_POLL_INTERVAL_MS = 200;
 
 function refuseUnsupportedKeys(
   value: Record<string, unknown>,
@@ -120,7 +121,11 @@ export function normalizeSteps(body: unknown[], params: Record<string, string>):
         if (isObj(v)) refuseUnsupportedKeys(v, ['id'], 'assertVisible');
         const id = isObj(v) ? asString(v.id) : null;
         if (!id) throw new UnsupportedStepError('assertVisible (missing string id)');
-        out.push({ t: 'assert', id: interp(id, params) });
+        out.push({
+          t: 'waitVisible',
+          id: interp(id, params),
+          timeoutMs: DEFAULT_VISIBILITY_TIMEOUT_MS,
+        });
         break;
       }
       case 'extendedWaitUntil': {
@@ -129,12 +134,12 @@ export function normalizeSteps(body: unknown[], params: Record<string, string>):
           refuseUnsupportedKeys(v.visible, ['id'], 'extendedWaitUntil.visible');
         }
         const id = isObj(v) && isObj(v.visible) ? asString(v.visible.id) : null;
-        const timeoutMs = isObj(v) ? v.timeout : undefined;
-        if (!id || !Number.isSafeInteger(timeoutMs) || Number(timeoutMs) < 0)
+        const timeoutMs = isObj(v) && 'timeout' in v ? v.timeout : DEFAULT_VISIBILITY_TIMEOUT_MS;
+        if (!id || typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs < 0)
           throw new UnsupportedStepError(
-            'extendedWaitUntil (need visible.id + non-negative integer timeout)',
+            'extendedWaitUntil (need visible.id; timeout must be finite and non-negative when present)',
           );
-        out.push({ t: 'waitVisible', id: interp(id, params), timeoutMs: Number(timeoutMs) });
+        out.push({ t: 'waitVisible', id: interp(id, params), timeoutMs });
         break;
       }
       case 'waitForAnimationToEnd': {
@@ -258,48 +263,33 @@ export async function replayFlow(
           });
           break;
         }
-        case 'assert': {
-          const verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          trace.push({
-            sourceIndex: sourceIndex(i),
-            t: s.t,
-            target: s.id,
-            ok: verdict.visible,
-            durationMs: Date.now() - startedAt,
-          });
-          if (!verdict.visible)
-            return fail(
-              i,
-              verdict.reason ?? `assertVisible: "${s.id}" is not frontmost`,
-              verdict.code ?? 'ASSERTION_FAILED',
-              verdict.meta,
-            );
-          break;
-        }
         case 'waitVisible': {
-          const deadline = Date.now() + s.timeoutMs;
-          let verdict = await dispatch.visibility(s.id);
-          requireNotAborted();
-          while (!verdict.visible && Date.now() < deadline) {
-            requireNotAborted();
-            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+          const deadline = startedAt + s.timeoutMs;
+          let verdict: ReplayVisibility;
+          for (;;) {
             verdict = await dispatch.visibility(s.id);
             requireNotAborted();
+            if (verdict.visible) break;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) break;
+            await new Promise<void>((resolve) =>
+              setTimeout(resolve, Math.min(VISIBILITY_POLL_INTERVAL_MS, remainingMs)),
+            );
           }
+          const waitedMs = Date.now() - startedAt;
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
             ok: verdict.visible,
-            durationMs: Date.now() - startedAt,
+            durationMs: waitedMs,
           });
           if (!verdict.visible)
             return fail(
               i,
-              verdict.reason ?? `extendedWaitUntil: "${s.id}" is not frontmost`,
+              verdict.reason ?? `waitVisible: "${s.id}" is not frontmost`,
               verdict.code ?? 'TESTID_NOT_FOUND',
-              verdict.meta,
+              { ...verdict.meta, failedSelector: s.id, waitedMs },
             );
           break;
         }
@@ -355,18 +345,20 @@ export async function replayFlow(
         }
       }
     } catch (e) {
+      const waitedMs = Date.now() - startedAt;
       trace.push({
         sourceIndex: sourceIndex(i),
         t: s.t,
         target: 'id' in s ? s.id : undefined,
         ok: false,
-        durationMs: Date.now() - startedAt,
+        durationMs: waitedMs,
       });
+      const dispatchMeta = e instanceof ReplayDispatchError ? e.meta : undefined;
       return fail(
         i,
         e instanceof Error ? e.message : String(e),
         e instanceof ReplayDispatchError ? e.code : undefined,
-        e instanceof ReplayDispatchError ? e.meta : undefined,
+        s.t === 'waitVisible' ? { ...dispatchMeta, failedSelector: s.id, waitedMs } : dispatchMeta,
       );
     }
   }

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -61,6 +61,7 @@ const isObj = (x: unknown): x is Record<string, unknown> =>
   typeof x === 'object' && x !== null && !Array.isArray(x);
 const DEFAULT_VISIBILITY_TIMEOUT_MS = 17_000;
 const VISIBILITY_POLL_INTERVAL_MS = 200;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 async function readVisibilityBeforeDeadline(
   dispatch: ReplayDispatch,
@@ -71,13 +72,21 @@ async function readVisibilityBeforeDeadline(
   if (remainingMs < 0) return null;
   return new Promise<ReplayVisibility | null>((resolve, reject) => {
     let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
     const finish = (value: ReplayVisibility | null): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       resolve(Date.now() <= deadline ? value : null);
     };
-    const timer = setTimeout(() => finish(null), remainingMs);
+    const armDeadline = (): void => {
+      const nextRemainingMs = deadline - Date.now();
+      timer = setTimeout(
+        () => (Date.now() >= deadline ? finish(null) : armDeadline()),
+        Math.min(Math.max(0, nextRemainingMs), MAX_TIMER_DELAY_MS),
+      );
+    };
+    armDeadline();
     Promise.resolve()
       .then(() => dispatch.visibility(id))
       .then(finish, (error: unknown) => {

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -394,7 +394,11 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
       let env = await fetchTree(false);
       // Retry with the salient digest when the full filtered payload exceeds the helper bound.
       const d = env.data as Record<string, unknown> | null;
-      if (d && typeof d === 'object' && '__agent_truncated' in d) {
+      if (
+        d &&
+        typeof d === 'object' &&
+        ('__agent_truncated' in d || d.truncated === true)
+      ) {
         env = await fetchTree(true);
       }
       const data = replayTreeData(env);

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -392,13 +392,12 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
           meta?: Record<string, unknown>;
         };
       let env = await fetchTree(false);
-      let data = replayTreeData(env);
       // Retry with the salient digest when the full filtered payload exceeds the helper bound.
-      const d = data as Record<string, unknown> | null;
+      const d = env.data as Record<string, unknown> | null;
       if (d && typeof d === 'object' && '__agent_truncated' in d) {
         env = await fetchTree(true);
-        data = replayTreeData(env);
       }
+      const data = replayTreeData(env);
       return unwrapTree(data);
     },
     frontmostFor: async (id: string) => {

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -414,12 +414,14 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
       try {
         const parsed = JSON.parse(result.value) as {
           visible?: boolean;
+          disabled?: boolean;
           reason?: string;
           matchCount?: number;
           code?: string;
         };
         return {
           visible: parsed.visible === true,
+          ...(typeof parsed.disabled === 'boolean' ? { disabled: parsed.disabled } : {}),
           ...(parsed.reason ? { reason: parsed.reason } : {}),
           ...(typeof parsed.matchCount === 'number' ? { matchCount: parsed.matchCount } : {}),
           ...(parsed.code ? { code: parsed.code } : {}),

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -394,11 +394,7 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
       let env = await fetchTree(false);
       // Retry with the salient digest when the full filtered payload exceeds the helper bound.
       const d = env.data as Record<string, unknown> | null;
-      if (
-        d &&
-        typeof d === 'object' &&
-        ('__agent_truncated' in d || d.truncated === true)
-      ) {
+      if (d && typeof d === 'object' && ('__agent_truncated' in d || d.truncated === true)) {
         env = await fetchTree(true);
       }
       const data = replayTreeData(env);

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -397,7 +397,7 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
       if (d && typeof d === 'object' && '__agent_truncated' in d) {
         env = await fetchTree(true);
       }
-      const data = replayTreeData(env);
+      const data = replayTreeData(env, id);
       return unwrapTree(data);
     },
     frontmostFor: async (id: string) => {

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -397,7 +397,7 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
       if (d && typeof d === 'object' && '__agent_truncated' in d) {
         env = await fetchTree(true);
       }
-      const data = replayTreeData(env, id);
+      const data = replayTreeData(env);
       return unwrapTree(data);
     },
     frontmostFor: async (id: string) => {

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -3761,8 +3761,7 @@ export const INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
-      // A fiber and its work-in-progress alternate are the same logical node;
-      // committed .return chains may thread through either half of the pair.
+      // React return chains may thread through either half of a fiber/alternate pair.
       var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -408,6 +408,7 @@ export const INJECTED_HELPERS = `
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
       if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
       var unscanned = computeUnscannedRendererIds();
       if (unscanned.length > 0) reasons.push('renderers-unscanned');
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
@@ -3693,6 +3694,18 @@ export const INJECTED_HELPERS = `
         reason: 'frontmost testID scan exceeded its bounded React-tree budget',
         code: 'ASSERTION_FAILED',
         truncated: true
+      });
+    }
+    var unscannedRendererIds = computeUnscannedRendererIds();
+    if (
+      lastRootScan.rendererErrors > 0 ||
+      !lastRootScan.complete ||
+      unscannedRendererIds.length > 0
+    ) {
+      return JSON.stringify({
+        visible: false,
+        code: 'ASSERTION_FAILED',
+        reason: 'frontmost proof cannot cover every mounted renderer'
       });
     }
     function containsFiber(ancestor, candidate) {

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 47;
+export const HELPERS_VERSION = 48;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -50,21 +50,77 @@ export const INJECTED_HELPERS = `
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  // complete is true only when the renderer-ID loop finished without the
+  // finished is true only when the renderer-ID loop finished without the
   // empty-streak early-exit — empty roots are mounting evidence only then
   // (GH #789).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+  var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
-  function computeUnscannedRendererIds() {
-    try {
-      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
-      var out = [];
-      hook.renderers.forEach(function(_v, id) {
-        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
-      });
-      return out;
-    } catch (_) { return []; }
+  function rootScanCoverage() {
+    var reasons = [];
+    var registryIds = [];
+    var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    var renderers = hook && hook.renderers;
+    if (renderers) {
+      if (typeof renderers.keys !== 'function' || typeof renderers.forEach !== 'function') {
+        registryIds = null;
+      } else {
+        try {
+          var iterator = renderers.keys();
+          if (!iterator || typeof iterator.next !== 'function') {
+            registryIds = null;
+          } else {
+            var step;
+            var iterations = 0;
+            while (registryIds !== null) {
+              step = iterator.next();
+              if (!step || typeof step !== 'object' || typeof step.done !== 'boolean') {
+                registryIds = null;
+                break;
+              }
+              if (step.done) break;
+              if (++iterations > MAX_REGISTERED_RENDERER_IDS || typeof step.value !== 'number') {
+                registryIds = null;
+                break;
+              }
+              if (registryIds.indexOf(step.value) === -1) registryIds.push(step.value);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            }
+          }
+        } catch (_) {
+          registryIds = null;
+        }
+        if (registryIds !== null) {
+          try {
+            var forEachIterations = 0;
+            renderers.forEach(function(_v, id) {
+              if (registryIds === null) return;
+              if (++forEachIterations > MAX_REGISTERED_RENDERER_IDS || typeof id !== 'number') {
+                registryIds = null;
+                return;
+              }
+              if (registryIds.indexOf(id) === -1) registryIds.push(id);
+              if (registryIds.length > MAX_REGISTERED_RENDERER_IDS) registryIds = null;
+            });
+          } catch (_) {
+            registryIds = null;
+          }
+        }
+      }
+    }
+    var addReason = function(reason) {
+      if (reasons.indexOf(reason) === -1) reasons.push(reason);
+    };
+    if (lastRootScan.rendererErrors > 0 || registryIds === null) addReason('renderer-error');
+    if (!lastRootScan.finished) addReason('root-enumeration-incomplete');
+    var unscannedRendererIds = [];
+    if (registryIds !== null) {
+      for (var i = 0; i < registryIds.length; i++) {
+        var id = registryIds[i];
+        if (!lastRootScan.visited[id]) unscannedRendererIds.push(id);
+      }
+      if (unscannedRendererIds.length > 0) addReason('renderers-unscanned');
+    }
+    return { reasons: reasons, unscannedRendererIds: unscannedRendererIds };
   }
 
   // Read the renderer IDs React DevTools actually registered. A malformed or
@@ -91,7 +147,7 @@ export const INJECTED_HELPERS = `
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -102,7 +158,7 @@ export const INJECTED_HELPERS = `
     var emptyStreak = 0;
     for (var rii = 0; rii < rendererIds.length; rii++) {
       var ri = rendererIds[rii];
-      if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+      lastRootScan.visited[ri] = true;
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size > 0) {
@@ -117,7 +173,7 @@ export const INJECTED_HELPERS = `
         lastRootScan.rendererErrors++;
       }
     }
-    lastRootScan.complete = true;
+    lastRootScan.finished = true;
     return null;
   }
 
@@ -134,7 +190,7 @@ export const INJECTED_HELPERS = `
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
+    lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -146,7 +202,7 @@ export const INJECTED_HELPERS = `
       var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
-        if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
+        lastRootScan.visited[ri] = true;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -171,7 +227,7 @@ export const INJECTED_HELPERS = `
           lastRootScan.rendererErrors++;
         }
       }
-      lastRootScan.complete = !abortedEarly;
+      if (!abortedEarly) lastRootScan.finished = true;
     }
     // GH #126 Gap B — extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -407,10 +463,12 @@ export const INJECTED_HELPERS = `
       o = o || {};
       var reasons = [];
       if (o.noRenderer) reasons.push('no-renderer');
-      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
-      if (!lastRootScan.complete) reasons.push('root-enumeration-incomplete');
-      var unscanned = computeUnscannedRendererIds();
-      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      var coverage = rootScanCoverage();
+      for (var coverageIndex = 0; coverageIndex < coverage.reasons.length; coverageIndex++) {
+        if (reasons.indexOf(coverage.reasons[coverageIndex]) === -1) {
+          reasons.push(coverage.reasons[coverageIndex]);
+        }
+      }
       if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
       if (o.outputTruncated) reasons.push('output-truncated');
       var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
@@ -423,8 +481,8 @@ export const INJECTED_HELPERS = `
         effectiveDepth: maxDepth,
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
-        rendererErrors: lastRootScan.rendererErrors,
-        unscannedRendererIds: unscanned
+        complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
 
@@ -888,7 +946,8 @@ export const INJECTED_HELPERS = `
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
       // Only a complete, clean scan is mounting evidence.
-      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
+      var mountCoverage = rootScanCoverage();
+      var mountScanClean = mountHookUsable && mountCoverage.reasons.length === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting — no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
@@ -896,7 +955,7 @@ export const INJECTED_HELPERS = `
           retryInMs: 2000
         });
       }
-      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+      if (mountHookUsable && mountCoverage.reasons.indexOf('root-enumeration-incomplete') !== -1 && mountRoots.length === 0) {
         return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
@@ -3696,12 +3755,8 @@ export const INJECTED_HELPERS = `
         truncated: true
       });
     }
-    var unscannedRendererIds = computeUnscannedRendererIds();
-    if (
-      lastRootScan.rendererErrors > 0 ||
-      !lastRootScan.complete ||
-      unscannedRendererIds.length > 0
-    ) {
+    var coverage = rootScanCoverage();
+    if (coverage.reasons.length > 0) {
       return JSON.stringify({
         visible: false,
         code: 'ASSERTION_FAILED',

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 49;
+export const HELPERS_VERSION = 50;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -478,6 +478,7 @@ export const INJECTED_HELPERS = `
         droppedSubtrees: walkQuality.droppedSubtrees,
         collapsedChildLists: walkQuality.collapsedChildLists,
         complete: state === 'ok' && reasons.length === 0 && walkQuality.droppedSubtrees === 0 && walkQuality.collapsedChildLists === 0,
+        rendererErrors: lastRootScan.rendererErrors,
         unscannedRendererIds: coverage.unscannedRendererIds
       };
     }
@@ -3795,6 +3796,9 @@ export const INJECTED_HELPERS = `
       });
     }
     var target = logicalMatches[0];
+    var targetProps = target.memoizedProps || {};
+    var targetAccessibilityState = targetProps.accessibilityState || {};
+    var targetDisabled = targetProps.disabled === true || targetAccessibilityState.disabled === true;
     if (__hidden(target)) {
       return JSON.stringify({
         visible: false,
@@ -3803,7 +3807,7 @@ export const INJECTED_HELPERS = `
       });
     }
 
-    var targetPointerEvents = (target.memoizedProps || {}).pointerEvents;
+    var targetPointerEvents = targetProps.pointerEvents;
     if (targetPointerEvents === 'none' || targetPointerEvents === 'box-none') {
       return JSON.stringify({
         visible: false,
@@ -3969,7 +3973,8 @@ export const INJECTED_HELPERS = `
       route: routeOwner,
       activeRoute: activeRoute,
       modalCount: modals.length,
-      matchCount: 1
+      matchCount: 1,
+      disabled: targetDisabled
     });
   }
 

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 48;
+export const HELPERS_VERSION = 49;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -3760,10 +3760,13 @@ export const INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
+      // A fiber and its work-in-progress alternate are the same logical node;
+      // committed .return chains may thread through either half of the pair.
+      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor) return true;
+        if (current === ancestor || current === ancestorAlternate) return true;
         current = current.return;
       }
       return false;

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -48,11 +48,7 @@ export const INJECTED_HELPERS = `
     '_LogBoxInspectorContainer'
   ];
 
-  // Reset by every root-iteration pass; only valid when read synchronously
-  // after the pass that produced the tree (many helpers share the iterators).
-  // finished is true only when the renderer-ID loop finished without the
-  // empty-streak early-exit — empty roots are mounting evidence only then
-  // (GH #789).
+  // Synchronous scan result; finished stays false after the GH #789 empty-streak exit.
   var lastRootScan = { rendererErrors: 0, visited: {}, finished: false };
 
   function rootScanCoverage() {

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -129,6 +129,18 @@ function countExactMatches(treeJson: unknown, id: string): number {
   return matches;
 }
 
+function countVisibilityMatches(treeJson: unknown, id: string): number {
+  const treeMatches = countExactMatches(treeJson, id);
+  if (treeMatches > 0 || !treeJson || typeof treeJson !== 'object') return treeMatches;
+  const interactive = (treeJson as Record<string, unknown>).interactive;
+  if (!Array.isArray(interactive)) return 0;
+  return interactive.filter((node) => {
+    if (!node || typeof node !== 'object') return false;
+    const record = node as Record<string, unknown>;
+    return record.testID === id || record.nativeID === id;
+  }).length;
+}
+
 function nodeProps(treeJson: unknown, id: string): Record<string, unknown> | null {
   // find the node whose testID === id or nativeID === id and return its props bag if exposed
   const stack: unknown[] = [treeJson];
@@ -262,7 +274,7 @@ export function buildCdpDispatch(deps: CdpReplayDeps, signal?: AbortSignal): Rep
     },
     async visibility(id) {
       const tree = await deps.treeFor(id);
-      const treeMatches = countExactMatches(tree, id);
+      const treeMatches = countVisibilityMatches(tree, id);
       if (treeMatches === 0)
         return {
           visible: false,

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -75,6 +75,7 @@ export interface CdpReplayDeps {
   // Exact-ID oracle; matchCount 0 proves absence, while refusals omit it.
   frontmostFor(id: string): Promise<{
     visible: boolean;
+    disabled?: boolean;
     reason?: string;
     matchCount?: number;
     code?: string;
@@ -189,7 +190,7 @@ export function buildCdpDispatch(deps: CdpReplayDeps, signal?: AbortSignal): Rep
         frontmost.code ?? 'ASSERTION_FAILED',
         frontmost.reason ?? `testID "${id}" is mounted but not frontmost`,
       );
-    if (isDisabled(nodeProps(tree, id)))
+    if (frontmost.disabled === true || isDisabled(nodeProps(tree, id)))
       throw new ReplayDispatchError(
         'INTERACTION_NOT_ACTUATED',
         `testID "${id}" is disabled/non-interactable`,

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -70,11 +70,9 @@ export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
 export interface CdpReplayDeps {
   pressByTestId(id: string): Promise<void>;
   typeByTestId(id: string, text: string): Promise<void>;
-  // returns parsed readable getTree data filtered to `id`
+  // Returns parsed readable getTree data filtered to `id`.
   treeFor(id: string): Promise<unknown>;
-  // exact-ID oracle (injected isTestIdFrontmost): sole owner of presence,
-  // absence, match count, and frontmost evidence — matchCount 0 is complete
-  // readable absence; refusals carry no matchCount
+  // Exact-ID oracle; matchCount 0 proves absence, while refusals omit it.
   frontmostFor(id: string): Promise<{
     visible: boolean;
     reason?: string;

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -58,15 +58,11 @@ export function replayTreeData(envelope: ReplayTreeEnvelope, selector?: string):
     !Array.isArray(envelope.meta.treeVerdict)
       ? (envelope.meta.treeVerdict as Record<string, unknown>)
       : null;
-  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
   const completeAbsenceVerdict =
-    verdict?.state === 'ok' &&
-    reasons.length === 0 &&
+    verdict?.complete === true &&
     typeof verdict.rootsSeeded === 'number' &&
-    verdict.rootsSeeded > 0 &&
-    verdict.droppedSubtrees === 0 &&
-    verdict.collapsedChildLists === 0;
+    verdict.rootsSeeded > 0;
   const filteredTree = data !== null && 'tree' in data ? data.tree : undefined;
   const serializedMatches =
     filteredTree &&

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -6,27 +6,6 @@ import {
 } from '../domain/cdp-flow-replay.js';
 import type { ReplayDispatch } from '../domain/cdp-flow-replay.js';
 
-// __RN_AGENT.getTree() wraps the node tree under a top-level `.tree` key —
-// `{ tree: <node> | { matches: [...] }, totalNodes, rootsSeeded }` — and the
-// interactive digest under `.interactive`. collectTestIds descends through all
-// of those container shapes so it works on the real handler payload, not only
-// on a bare node. (Boundary bug fix: treeFor used to hand the wrapper straight
-// to isExactPresent, which then saw zero testIDs and the fallback never fired.)
-export function collectTestIds(node: unknown, acc: Set<string> = new Set()): Set<string> {
-  if (!node || typeof node !== 'object') return acc;
-  const n = node as Record<string, unknown>;
-  if (typeof n.testID === 'string') acc.add(n.testID);
-  if (typeof n.nativeID === 'string') acc.add(n.nativeID);
-  if (n.tree) collectTestIds(n.tree, acc);
-  const kids = n.children ?? n.interactive ?? n.nodes ?? n.matches;
-  if (Array.isArray(kids)) for (const c of kids) collectTestIds(c, acc);
-  return acc;
-}
-
-export function isExactPresent(treeJson: unknown, selector: string): boolean {
-  return collectTestIds(treeJson).has(selector);
-}
-
 // Unwrap getTree's `{ tree: <node>|{matches} }` envelope to the node(s) the
 // dispatch helpers walk. Returns the bare node for a single match, the
 // `{ matches: [...] }` wrapper for multiple, or the input unchanged when it is
@@ -45,72 +24,30 @@ export interface ReplayTreeEnvelope {
   meta?: Record<string, unknown>;
 }
 
-export function replayTreeData(envelope: ReplayTreeEnvelope, selector?: string): unknown {
+// Readability gate only: transport failures, redbox, and truncation reject with
+// their typed envelope. Exact-ID presence/absence is never inferred here — the
+// filtered tree is substring-matched, so that decision belongs to the injected
+// exact-ID oracle (isTestIdFrontmost) consumed through frontmostFor.
+export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
   const warning = typeof envelope.meta?.warning === 'string' ? envelope.meta.warning : undefined;
   const redbox = warning === 'APP_HAS_REDBOX';
   const data =
     envelope.data && typeof envelope.data === 'object' && !Array.isArray(envelope.data)
       ? (envelope.data as Record<string, unknown>)
       : null;
-  const verdict =
-    envelope.meta?.treeVerdict &&
-    typeof envelope.meta.treeVerdict === 'object' &&
-    !Array.isArray(envelope.meta.treeVerdict)
-      ? (envelope.meta.treeVerdict as Record<string, unknown>)
-      : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const completeAbsenceVerdict =
-    verdict?.complete === true &&
-    typeof verdict.rootsSeeded === 'number' &&
-    verdict.rootsSeeded > 0;
-  const filteredTree = data !== null && 'tree' in data ? data.tree : undefined;
-  const serializedMatches =
-    filteredTree &&
-    typeof filteredTree === 'object' &&
-    !Array.isArray(filteredTree) &&
-    Array.isArray((filteredTree as Record<string, unknown>).matches)
-      ? ((filteredTree as Record<string, unknown>).matches as unknown[])
-      : [];
-  const exactFilteredMatch =
-    verdict?.path === 'filter' &&
-    typeof selector === 'string' &&
-    data !== null &&
-    'tree' in data &&
-    serializedMatches.length < 10 &&
-    isExactPresent(filteredTree, selector);
-  const completeFilteredAbsence =
-    completeAbsenceVerdict &&
-    verdict.path === 'filter' &&
-    typeof selector === 'string' &&
-    data !== null &&
-    'tree' in data &&
-    filteredTree === null;
-  const exactInteractiveMatch =
-    verdict?.path === 'interactive' &&
-    typeof selector === 'string' &&
-    isExactPresent(data, selector);
-  const incomplete =
-    envelope.ok === true &&
-    !redbox &&
-    !truncated &&
-    !exactFilteredMatch &&
-    !completeFilteredAbsence &&
-    !exactInteractiveMatch;
-  if (envelope.ok === true && !redbox && !truncated && !incomplete) return envelope.data;
+  if (envelope.ok === true && !redbox && !truncated) return envelope.data;
 
   const message = truncated
     ? 'Component tree proof exceeded the readable payload budget'
-    : incomplete
-      ? 'Component tree proof is incomplete'
-      : redbox && typeof data?.message === 'string'
-        ? data.message.slice(0, 1000)
-        : (envelope.error?.slice(0, 1000) ?? 'Component tree proof is unavailable');
+    : redbox && typeof data?.message === 'string'
+      ? data.message.slice(0, 1000)
+      : (envelope.error?.slice(0, 1000) ?? 'Component tree proof is unavailable');
   const code = redbox ? warning : (envelope.code ?? 'EVAL_FAILED');
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...(truncated ? { truncated: true } : {}),
-      ...(incomplete ? { incomplete: true } : {}),
       ...(truncated && typeof data.originalLength === 'number'
         ? { originalLength: data.originalLength }
         : {}),
@@ -126,9 +63,13 @@ export function replayTreeData(envelope: ReplayTreeEnvelope, selector?: string):
 export interface CdpReplayDeps {
   pressByTestId(id: string): Promise<void>;
   typeByTestId(id: string, text: string): Promise<void>;
-  // returns parsed successful getTree data filtered to `id`; failures reject with their envelope
+  // returns parsed readable getTree data filtered to `id`; transport, redbox,
+  // and truncation failures reject with their envelope
   treeFor(id: string): Promise<unknown>;
-  frontmostFor?(id: string): Promise<{
+  // exact-ID oracle (injected isTestIdFrontmost): sole owner of presence,
+  // absence, match count, and frontmost evidence — matchCount 0 is complete
+  // readable absence; refusals carry no matchCount
+  frontmostFor(id: string): Promise<{
     visible: boolean;
     reason?: string;
     matchCount?: number;
@@ -136,36 +77,6 @@ export interface CdpReplayDeps {
   }>;
   launchApp(stopApp: boolean): Promise<void>;
   settle(timeoutMs: number): Promise<void>;
-}
-
-function countExactMatches(treeJson: unknown, id: string): number {
-  let matches = 0;
-  const root =
-    treeJson && typeof treeJson === 'object' && 'tree' in treeJson
-      ? (treeJson as Record<string, unknown>).tree
-      : treeJson;
-  const stack: unknown[] = [root];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node || typeof node !== 'object') continue;
-    const record = node as Record<string, unknown>;
-    if (record.testID === id || record.nativeID === id) matches++;
-    const children = record.children ?? record.nodes ?? record.matches;
-    if (Array.isArray(children)) stack.push(...children);
-  }
-  return matches;
-}
-
-function countVisibilityMatches(treeJson: unknown, id: string): number {
-  const treeMatches = countExactMatches(treeJson, id);
-  if (treeMatches > 0 || !treeJson || typeof treeJson !== 'object') return treeMatches;
-  const interactive = (treeJson as Record<string, unknown>).interactive;
-  if (!Array.isArray(interactive)) return 0;
-  return interactive.filter((node) => {
-    if (!node || typeof node !== 'object') return false;
-    const record = node as Record<string, unknown>;
-    return record.testID === id || record.nativeID === id;
-  }).length;
 }
 
 function nodeProps(treeJson: unknown, id: string): Record<string, unknown> | null {
@@ -256,21 +167,20 @@ export function buildCdpDispatch(deps: CdpReplayDeps, signal?: AbortSignal): Rep
   const assertExactInteractable = async (id: string): Promise<void> => {
     const tree = await deps.treeFor(id);
     requireNotAborted();
-    const treeMatches = countExactMatches(tree, id);
-    if (treeMatches === 0)
+    const frontmost = await deps.frontmostFor(id);
+    requireNotAborted();
+    if (frontmost.matchCount === 0)
       throw new ReplayDispatchError('TESTID_NOT_FOUND', `testID "${id}" not present`, {
         failedSelector: id,
       });
-    const frontmost = await deps.frontmostFor?.(id);
-    requireNotAborted();
-    const matches = frontmost ? (frontmost.matchCount ?? 1) : treeMatches;
+    const matches = frontmost.matchCount ?? 1;
     if (matches > 1)
       throw new ReplayDispatchError(
         'AMBIGUOUS_TESTID',
         `testID "${id}" resolves to ${matches} mounted elements`,
         { matchCount: matches },
       );
-    if (frontmost && !frontmost.visible)
+    if (!frontmost.visible)
       throw new ReplayDispatchError(
         frontmost.code ?? 'ASSERTION_FAILED',
         frontmost.reason ?? `testID "${id}" is mounted but not frontmost`,
@@ -300,24 +210,23 @@ export function buildCdpDispatch(deps: CdpReplayDeps, signal?: AbortSignal): Rep
       await deps.typeByTestId(id, text);
     },
     async visibility(id) {
-      const tree = await deps.treeFor(id);
-      const treeMatches = countVisibilityMatches(tree, id);
-      if (treeMatches === 0)
+      await deps.treeFor(id);
+      const frontmost = await deps.frontmostFor(id);
+      if (frontmost.matchCount === 0)
         return {
           visible: false,
           code: 'TESTID_NOT_FOUND',
           reason: `testID "${id}" not present in the React tree`,
           meta: { failedSelector: id },
         };
-      const frontmost = await deps.frontmostFor?.(id);
-      const matches = frontmost ? (frontmost.matchCount ?? 1) : treeMatches;
+      const matches = frontmost.matchCount ?? 1;
       if (matches > 1)
         return {
           visible: false,
           code: 'AMBIGUOUS_TESTID',
           reason: `testID "${id}" resolves to ${matches} mounted elements`,
         };
-      if (frontmost && !frontmost.visible)
+      if (!frontmost.visible)
         return {
           visible: false,
           code: frontmost.code ?? 'ASSERTION_FAILED',

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -60,7 +60,7 @@ export function replayTreeData(envelope: ReplayTreeEnvelope, selector?: string):
       : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete =
+  const completeAbsenceVerdict =
     verdict?.state === 'ok' &&
     reasons.length === 0 &&
     typeof verdict.rootsSeeded === 'number' &&
@@ -75,21 +75,31 @@ export function replayTreeData(envelope: ReplayTreeEnvelope, selector?: string):
     Array.isArray((filteredTree as Record<string, unknown>).matches)
       ? ((filteredTree as Record<string, unknown>).matches as unknown[])
       : [];
-  const completeFiltered =
-    complete &&
-    verdict.path === 'filter' &&
+  const exactFilteredMatch =
+    verdict?.path === 'filter' &&
     typeof selector === 'string' &&
     data !== null &&
     'tree' in data &&
     serializedMatches.length < 10 &&
-    (filteredTree === null || isExactPresent(filteredTree, selector));
-  const completeInteractiveMatch =
-    complete &&
-    verdict.path === 'interactive' &&
+    isExactPresent(filteredTree, selector);
+  const completeFilteredAbsence =
+    completeAbsenceVerdict &&
+    verdict.path === 'filter' &&
+    typeof selector === 'string' &&
+    data !== null &&
+    'tree' in data &&
+    filteredTree === null;
+  const exactInteractiveMatch =
+    verdict?.path === 'interactive' &&
     typeof selector === 'string' &&
     isExactPresent(data, selector);
   const incomplete =
-    envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+    envelope.ok === true &&
+    !redbox &&
+    !truncated &&
+    !exactFilteredMatch &&
+    !completeFilteredAbsence &&
+    !exactInteractiveMatch;
   if (envelope.ok === true && !redbox && !truncated && !incomplete) return envelope.data;
 
   const message = truncated

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -48,20 +48,26 @@ export interface ReplayTreeEnvelope {
 export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
   const warning = typeof envelope.meta?.warning === 'string' ? envelope.meta.warning : undefined;
   const redbox = warning === 'APP_HAS_REDBOX';
-  if (envelope.ok === true && !redbox) return envelope.data;
-
   const data =
     envelope.data && typeof envelope.data === 'object' && !Array.isArray(envelope.data)
       ? (envelope.data as Record<string, unknown>)
       : null;
-  const message =
-    redbox && typeof data?.message === 'string'
+  const truncated = data !== null && data.__agent_truncated === true;
+  if (envelope.ok === true && !redbox && !truncated) return envelope.data;
+
+  const message = truncated
+    ? 'Component tree proof exceeded the readable payload budget'
+    : redbox && typeof data?.message === 'string'
       ? data.message.slice(0, 1000)
       : (envelope.error?.slice(0, 1000) ?? 'Component tree proof is unavailable');
   const code = redbox ? warning : (envelope.code ?? 'EVAL_FAILED');
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...(truncated ? { truncated: true } : {}),
+      ...(truncated && typeof data.originalLength === 'number'
+        ? { originalLength: data.originalLength }
+        : {}),
       ...(envelope.code ? { code: envelope.code } : {}),
       ...(envelope.error ? { error: envelope.error.slice(0, 1000) } : {}),
       ...(warning ? { warning } : {}),

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -24,10 +24,7 @@ export interface ReplayTreeEnvelope {
   meta?: Record<string, unknown>;
 }
 
-// Readability gate only: transport failures, redbox, and truncation reject with
-// their typed envelope. Exact-ID presence/absence is never inferred here — the
-// filtered tree is substring-matched, so that decision belongs to the injected
-// exact-ID oracle (isTestIdFrontmost) consumed through frontmostFor.
+// Readability gate only: transport, redbox, truncation, and serialization failures reject.
 export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
   const warning = typeof envelope.meta?.warning === 'string' ? envelope.meta.warning : undefined;
   const redbox = warning === 'APP_HAS_REDBOX';
@@ -36,17 +33,27 @@ export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
       ? (envelope.data as Record<string, unknown>)
       : null;
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  if (envelope.ok === true && !redbox && !truncated) return envelope.data;
+  const agentError =
+    typeof data?.__agent_error === 'string' ? data.__agent_error.slice(0, 1000) : undefined;
+  const serializationFailed = agentError !== undefined;
+  if (envelope.ok === true && !redbox && !truncated && !serializationFailed) return envelope.data;
 
-  const message = truncated
-    ? 'Component tree proof exceeded the readable payload budget'
-    : redbox && typeof data?.message === 'string'
-      ? data.message.slice(0, 1000)
-      : (envelope.error?.slice(0, 1000) ?? 'Component tree proof is unavailable');
-  const code = redbox ? warning : (envelope.code ?? 'EVAL_FAILED');
+  const message = serializationFailed
+    ? agentError || 'Component tree serialization failed'
+    : truncated
+      ? 'Component tree proof exceeded the readable payload budget'
+      : redbox && typeof data?.message === 'string'
+        ? data.message.slice(0, 1000)
+        : (envelope.error?.slice(0, 1000) ?? 'Component tree proof is unavailable');
+  const code = serializationFailed
+    ? 'EVAL_FAILED'
+    : redbox
+      ? warning
+      : (envelope.code ?? 'EVAL_FAILED');
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
+      ...(serializationFailed ? { agentError } : {}),
       ...(truncated ? { truncated: true } : {}),
       ...(truncated && typeof data.originalLength === 'number'
         ? { originalLength: data.originalLength }
@@ -63,8 +70,7 @@ export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
 export interface CdpReplayDeps {
   pressByTestId(id: string): Promise<void>;
   typeByTestId(id: string, text: string): Promise<void>;
-  // returns parsed readable getTree data filtered to `id`; transport, redbox,
-  // and truncation failures reject with their envelope
+  // returns parsed readable getTree data filtered to `id`
   treeFor(id: string): Promise<unknown>;
   // exact-ID oracle (injected isTestIdFrontmost): sole owner of presence,
   // absence, match count, and frontmost evidence — matchCount 0 is complete

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -45,26 +45,45 @@ export interface ReplayTreeEnvelope {
   meta?: Record<string, unknown>;
 }
 
-export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
+export function replayTreeData(envelope: ReplayTreeEnvelope, selector?: string): unknown {
   const warning = typeof envelope.meta?.warning === 'string' ? envelope.meta.warning : undefined;
   const redbox = warning === 'APP_HAS_REDBOX';
   const data =
     envelope.data && typeof envelope.data === 'object' && !Array.isArray(envelope.data)
       ? (envelope.data as Record<string, unknown>)
       : null;
-  const truncated = data !== null && data.__agent_truncated === true;
-  if (envelope.ok === true && !redbox && !truncated) return envelope.data;
+  const verdict =
+    envelope.meta?.treeVerdict &&
+    typeof envelope.meta.treeVerdict === 'object' &&
+    !Array.isArray(envelope.meta.treeVerdict)
+      ? (envelope.meta.treeVerdict as Record<string, unknown>)
+      : null;
+  const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
+  const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
+  const complete = verdict?.state === 'ok' && reasons.length === 0;
+  const completeFiltered = complete && verdict.path === 'filter' && data !== null && 'tree' in data;
+  const completeInteractiveMatch =
+    complete &&
+    verdict.path === 'interactive' &&
+    typeof selector === 'string' &&
+    isExactPresent(data, selector);
+  const incomplete =
+    envelope.ok === true && !redbox && !truncated && !completeFiltered && !completeInteractiveMatch;
+  if (envelope.ok === true && !redbox && !truncated && !incomplete) return envelope.data;
 
   const message = truncated
     ? 'Component tree proof exceeded the readable payload budget'
-    : redbox && typeof data?.message === 'string'
-      ? data.message.slice(0, 1000)
-      : (envelope.error?.slice(0, 1000) ?? 'Component tree proof is unavailable');
+    : incomplete
+      ? 'Component tree proof is incomplete'
+      : redbox && typeof data?.message === 'string'
+        ? data.message.slice(0, 1000)
+        : (envelope.error?.slice(0, 1000) ?? 'Component tree proof is unavailable');
   const code = redbox ? warning : (envelope.code ?? 'EVAL_FAILED');
   throw new ReplayDispatchError(code, message, {
     treeEnvelope: {
       ok: envelope.ok === true,
       ...(truncated ? { truncated: true } : {}),
+      ...(incomplete ? { incomplete: true } : {}),
       ...(truncated && typeof data.originalLength === 'number'
         ? { originalLength: data.originalLength }
         : {}),

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -60,8 +60,29 @@ export function replayTreeData(envelope: ReplayTreeEnvelope, selector?: string):
       : null;
   const reasons = Array.isArray(verdict?.reasons) ? verdict.reasons : [];
   const truncated = data !== null && (data.__agent_truncated === true || data.truncated === true);
-  const complete = verdict?.state === 'ok' && reasons.length === 0;
-  const completeFiltered = complete && verdict.path === 'filter' && data !== null && 'tree' in data;
+  const complete =
+    verdict?.state === 'ok' &&
+    reasons.length === 0 &&
+    typeof verdict.rootsSeeded === 'number' &&
+    verdict.rootsSeeded > 0 &&
+    verdict.droppedSubtrees === 0 &&
+    verdict.collapsedChildLists === 0;
+  const filteredTree = data !== null && 'tree' in data ? data.tree : undefined;
+  const serializedMatches =
+    filteredTree &&
+    typeof filteredTree === 'object' &&
+    !Array.isArray(filteredTree) &&
+    Array.isArray((filteredTree as Record<string, unknown>).matches)
+      ? ((filteredTree as Record<string, unknown>).matches as unknown[])
+      : [];
+  const completeFiltered =
+    complete &&
+    verdict.path === 'filter' &&
+    typeof selector === 'string' &&
+    data !== null &&
+    'tree' in data &&
+    serializedMatches.length < 10 &&
+    (filteredTree === null || isExactPresent(filteredTree, selector));
   const completeInteractiveMatch =
     complete &&
     verdict.path === 'interactive' &&

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -487,7 +487,7 @@ function remapNativeSteps(steps: unknown, sourceIndices: number[]): PartitionedR
   });
 }
 
-function partialNativeFailureMessage(meta: Record<string, unknown>): string {
+function partialNativeFailureMessage(meta: Record<string, unknown>, nestedError?: string): string {
   const failedStep = remapNativeStep(meta.failedStep, 0, []);
   const lastStep = remapNativeStep(meta.lastStep, 0, []);
   const terminal = isRecord(meta.terminal) ? meta.terminal : null;
@@ -504,7 +504,8 @@ function partialNativeFailureMessage(meta: Record<string, unknown>): string {
   const headline = formatFailureHeadline(
     { steps: [], failedStep, lastStep, reason },
     { timedOut: meta.timedOut === true, outputTruncated: meta.outputTruncated === true },
-    'Native replay segment failed.',
+    // Keep the nested envelope's own cause when no structured evidence exists.
+    nestedError?.replace(/^Maestro flow failed: /, '') || 'Native replay segment failed.',
   );
   const runtimeDegradation = runtimeDegradationFromMetadata(meta.runtimeDegraded);
   return runtimeDegradation
@@ -898,7 +899,7 @@ export function createMaestroRunHandler(
               if (!nativeSegmentCoversAttempt) {
                 delete nestedMeta.trailingVerification;
                 delete nestedMeta.ledger;
-                nestedError = partialNativeFailureMessage(nestedMeta);
+                nestedError = partialNativeFailureMessage(nestedMeta, env.error);
               }
               combinedSteps.push(...remapNativeSteps(nestedMeta.steps, segment.sourceIndices));
               const uniqueProofDomains = [...new Set(proofDomains)];
@@ -1585,12 +1586,12 @@ export function createMaestroRunHandler(
         },
       );
       if (deferredNativeOriginTarget) {
+        // A caller-supplied reprove must run even without local replayDeps (nested native leg).
         if (
           nativeOriginPreclaimed &&
-          replayFactory &&
           (args.reproveManagedOrigin ||
             deps.reproveManagedOrigin ||
-            hasManagedNativeOriginAuthority(args))
+            (replayFactory && hasManagedNativeOriginAuthority(args)))
         ) {
           await reproveManagedOrigin();
         }

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -97,6 +97,7 @@ import {
   reissueManagedInstallAuthority,
   relaunchManagedNativeOriginApp,
   reproveManagedNativeOrigin,
+  type ManagedNativeOriginReproveOptions,
 } from '../session/authority-gate.js';
 import { SessionAuthorityError } from '../session/registry.js';
 import {
@@ -201,7 +202,7 @@ export interface MaestroRunArgs {
   completeNativeOrigin?: (targetExpected: boolean, signal?: AbortSignal) => Promise<void>;
   relaunchManagedApp?: (stopApp?: boolean) => Promise<void>;
   /** GH #708: re-prove the managed origin at flow end without relaunching. */
-  reproveManagedOrigin?: (options?: { signal?: AbortSignal }) => Promise<void>;
+  reproveManagedOrigin?: (options?: ManagedNativeOriginReproveOptions) => Promise<void>;
   completeRunnerPark?: (signal?: AbortSignal) => Promise<void>;
   /** GH #705: commit a new install receipt after a clearState reinstall. */
   reissueInstallReceipt?: (() => Promise<void>) | null;
@@ -218,7 +219,7 @@ export interface MaestroAuthorityCallbacks {
   claimNativeOrigin: () => Promise<void>;
   completeNativeOrigin: (targetExpected: boolean, signal?: AbortSignal) => Promise<void>;
   relaunchManagedApp: (stopApp?: boolean) => Promise<void>;
-  reproveManagedOrigin: (options?: { signal?: AbortSignal }) => Promise<void>;
+  reproveManagedOrigin: (options?: ManagedNativeOriginReproveOptions) => Promise<void>;
   completeRunnerPark: (signal?: AbortSignal) => Promise<void>;
   reissueInstallReceipt: (() => Promise<void>) | null;
 }
@@ -316,7 +317,7 @@ export async function executeMaestroAuthorityStages<T>(
   claimOrigin: () => Promise<void>,
   completeOrigin: (targetExpected: boolean, signal?: AbortSignal) => Promise<void>,
   relaunchManagedApp: (stopApp?: boolean) => Promise<void>,
-  reproveManagedOrigin?: (options?: { signal?: AbortSignal }) => Promise<void>,
+  reproveManagedOrigin?: (options?: ManagedNativeOriginReproveOptions) => Promise<void>,
   options: { firstOriginClaimed?: boolean; signal?: AbortSignal } = {},
 ): Promise<T[]> {
   const plan = planMaestroAuthorityStages(commands);
@@ -413,7 +414,7 @@ export interface MaestroRunDeps {
   claimNativeOrigin?: () => Promise<void>;
   completeNativeOrigin?: (targetExpected: boolean, signal?: AbortSignal) => Promise<void>;
   relaunchManagedApp?: () => Promise<void>;
-  reproveManagedOrigin?: (options?: { signal?: AbortSignal }) => Promise<void>;
+  reproveManagedOrigin?: (options?: ManagedNativeOriginReproveOptions) => Promise<void>;
   reissueInstallReceipt?: () => Promise<void>;
   now?: () => number;
   execFile?: (
@@ -1593,9 +1594,12 @@ export function createMaestroRunHandler(
             deps.reproveManagedOrigin ||
             (replayFactory && hasManagedNativeOriginAuthority(args)))
         ) {
-          await reproveManagedOrigin({ signal: flowAbort.signal });
+          await reproveManagedOrigin({
+            signal: flowAbort.signal,
+            readinessTimeoutMs: Math.max(1, flowDeadline - now()),
+          });
         }
-        await completeOrigin(true);
+        await completeOrigin(true, flowAbort.signal);
         nativeOriginPreclaimed = false;
       }
       await commitReinstalledInstall();

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -1593,7 +1593,7 @@ export function createMaestroRunHandler(
             deps.reproveManagedOrigin ||
             (replayFactory && hasManagedNativeOriginAuthority(args)))
         ) {
-          await reproveManagedOrigin();
+          await reproveManagedOrigin({ signal: flowAbort.signal });
         }
         await completeOrigin(true);
         nativeOriginPreclaimed = false;

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -507,7 +507,11 @@ export interface RunActionDeps {
   } | null;
   claimBundleAuthority?: (args: RunActionArgs) => Promise<boolean>;
   claimNativeOrigin?: (args: RunActionArgs) => Promise<void>;
-  completeNativeOrigin?: (args: RunActionArgs, targetExpected: boolean) => Promise<void>;
+  completeNativeOrigin?: (
+    args: RunActionArgs,
+    targetExpected: boolean,
+    signal?: AbortSignal,
+  ) => Promise<void>;
   relaunchManagedApp?: (args: RunActionArgs, stopApp?: boolean) => Promise<void>;
   reproveManagedOrigin?: (
     args: RunActionArgs,
@@ -781,7 +785,8 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           params: args.params,
           attempt: { attemptId: initialAttemptId, ordinal: 1, maxAttempts, kind: 'initial' },
           claimNativeOrigin: () => claimNativeOrigin(args),
-          completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+          completeNativeOrigin: (targetExpected, signal) =>
+            completeNativeOrigin(args, targetExpected, signal),
           relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
           reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
           completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
@@ -1212,7 +1217,8 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
             parentAttemptId: initialAttemptId,
           },
           claimNativeOrigin: () => claimNativeOrigin(args),
-          completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+          completeNativeOrigin: (targetExpected, signal) =>
+            completeNativeOrigin(args, targetExpected, signal),
           relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
           reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
           completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -508,7 +508,10 @@ export interface RunActionDeps {
   claimNativeOrigin?: (args: RunActionArgs) => Promise<void>;
   completeNativeOrigin?: (args: RunActionArgs, targetExpected: boolean) => Promise<void>;
   relaunchManagedApp?: (args: RunActionArgs, stopApp?: boolean) => Promise<void>;
-  reproveManagedOrigin?: (args: RunActionArgs) => Promise<void>;
+  reproveManagedOrigin?: (
+    args: RunActionArgs,
+    options?: { signal?: AbortSignal },
+  ) => Promise<void>;
   reissueInstallReceipt?: (args: RunActionArgs) => Promise<void>;
   /** GH #705: the session's attested install receipt, for appFile auto-resolution. */
   installReceipt?: () => { platform?: unknown; deviceId?: unknown; appId?: unknown } | null;
@@ -779,7 +782,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           claimNativeOrigin: () => claimNativeOrigin(args),
           completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
           relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-          reproveManagedOrigin: () => reproveManagedOrigin(args),
+          reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
           completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
           reissueInstallReceipt: () => reissueInstallReceipt(args),
         }),
@@ -1210,7 +1213,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           claimNativeOrigin: () => claimNativeOrigin(args),
           completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
           relaunchManagedApp: (stopApp) => relaunchManagedApp(args, stopApp),
-          reproveManagedOrigin: () => reproveManagedOrigin(args),
+          reproveManagedOrigin: (options) => reproveManagedOrigin(args, options),
           completeRunnerPark: (signal) => completeManagedRunnerParkAuthority(args, signal),
           reissueInstallReceipt: () => reissueInstallReceipt(args),
         }),

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -70,6 +70,7 @@ import {
   reissueManagedInstallAuthority,
   relaunchManagedNativeOriginApp,
   reproveManagedNativeOrigin,
+  type ManagedNativeOriginReproveOptions,
 } from '../session/authority-gate.js';
 import { getWorkerAuthorityRuntime } from '../session/runtime.js';
 import { flowUsesClearState, resolveIosAppFile } from './resolve-ios-app-file.js';
@@ -510,7 +511,7 @@ export interface RunActionDeps {
   relaunchManagedApp?: (args: RunActionArgs, stopApp?: boolean) => Promise<void>;
   reproveManagedOrigin?: (
     args: RunActionArgs,
-    options?: { signal?: AbortSignal },
+    options?: ManagedNativeOriginReproveOptions,
   ) => Promise<void>;
   reissueInstallReceipt?: (args: RunActionArgs) => Promise<void>;
   /** GH #705: the session's attested install receipt, for appFile auto-resolution. */

--- a/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
+++ b/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// @ts-expect-error -- untyped JS test helper
+import { startSupervisor } from '../helpers/supervisor-harness.js';
+
+const APP_ROOT = process.env.OTP_FIXTURE_ROOT;
+const DEVICE_ID = process.env.OTP_FIXTURE_DEVICE_ID;
+const APP_ID = 'com.rndevagent.expo55devclient';
+const ACTION_ID = 'otp-omitted-timeout';
+const EVIDENCE_PATH = '/tmp/maestro-login-action-capability-evidence.json';
+const STATUS_PATH = '/tmp/maestro-login-action-capability-status.json';
+const SUPERVISOR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../claude-plugin/rn-dev-agent-core/dist/supervisor.js',
+);
+
+assert.ok(APP_ROOT, 'OTP_FIXTURE_ROOT is required');
+assert.ok(DEVICE_ID, 'OTP_FIXTURE_DEVICE_ID is required');
+
+async function rpc(supervisor: any, method: string, params?: unknown) {
+  const id = supervisor.send(method, params);
+  for (;;) {
+    const line = JSON.parse(await supervisor.nextLine());
+    if (line.id === id) return line;
+  }
+}
+
+async function callTool(supervisor: any, name: string, args: Record<string, unknown> = {}) {
+  const line = await rpc(supervisor, 'tools/call', { name, arguments: args });
+  const text = line.result?.content?.[0]?.text ?? '';
+  let envelope: any = null;
+  try {
+    envelope = JSON.parse(text);
+  } catch {}
+  return { envelope, isError: Boolean(line.result?.isError), text };
+}
+
+function totalRuns(): number {
+  const statePath = join(APP_ROOT!, '.rn-agent/state', `${ACTION_ID}.state.json`);
+  if (!existsSync(statePath)) return 0;
+  const state = JSON.parse(readFileSync(statePath, 'utf8'));
+  return state.stats?.totalRuns ?? 0;
+}
+
+async function requireOk(supervisor: any, name: string, args: Record<string, unknown> = {}) {
+  const result = await callTool(supervisor, name, args);
+  assert.equal(result.envelope?.ok, true, `${name}: ${result.text.slice(0, 800)}`);
+  return result.envelope;
+}
+
+async function run() {
+  const declaredEnv = {
+    RN_DEV_AGENT_DECLARED_ROOT: APP_ROOT!,
+    RN_DEV_AGENT_DECLARED_MANIFESTS: 'package.json',
+  };
+  const supervisor = startSupervisor({
+    supervisorPath: SUPERVISOR,
+    cwd: APP_ROOT,
+    lineTimeoutMs: 600_000,
+    env: declaredEnv,
+  });
+  const evidence: Record<string, unknown> = {
+    appRoot: APP_ROOT,
+    appId: APP_ID,
+    deviceId: DEVICE_ID,
+  };
+  let adapter: ChildProcess | undefined;
+  let runnerOpened = false;
+  let primaryError: unknown;
+  let finalStatus: Awaited<ReturnType<typeof callTool>> | undefined;
+
+  try {
+    const init = await rpc(supervisor, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'otp-omitted-timeout-gate', version: '1.0.0' },
+    });
+    assert.ok(init.result);
+    supervisor.notify('notifications/initialized');
+
+    evidence.initialStatus = (
+      await callTool(supervisor, 'rn_session', { action: 'status' })
+    ).envelope;
+    evidence.initialCdp = (await callTool(supervisor, 'cdp_status', { platform: 'ios' })).envelope;
+    evidence.devices = (await callTool(supervisor, 'device_list')).envelope;
+
+    await requireOk(supervisor, 'rn_session', {
+      action: 'bind_source',
+      projectRoot: APP_ROOT,
+    });
+    let bound = await callTool(supervisor, 'rn_session', {
+      action: 'bind_device',
+      platform: 'ios',
+      deviceId: DEVICE_ID,
+      appId: APP_ID,
+    });
+    if (bound.envelope?.code === 'STALE_DEVICE_RELEASE_REQUIRED') {
+      bound = await callTool(supervisor, 'rn_session', {
+        action: 'bind_device',
+        platform: 'ios',
+        deviceId: DEVICE_ID,
+        appId: APP_ID,
+        confirmed: true,
+      });
+    }
+    assert.equal(bound.envelope?.ok, true, `bind_device: ${bound.text.slice(0, 800)}`);
+    await requireOk(supervisor, 'rn_session', { action: 'preview_integration' });
+    await requireOk(supervisor, 'rn_session', { action: 'apply_integration', confirmed: true });
+
+    adapter = spawn('corepack', ['pnpm', 'run', 'ios'], {
+      cwd: APP_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        PATH: `${join(APP_ROOT!, 'node_modules', '.bin')}:${process.env.PATH ?? ''}`,
+      },
+    });
+    adapter.stdout?.on('data', (chunk) => process.stdout.write(`[fixture] ${chunk}`));
+    adapter.stderr?.on('data', (chunk) => process.stderr.write(`[fixture] ${chunk}`));
+
+    const readyDeadline = Date.now() + 1_500_000;
+    for (;;) {
+      assert.ok(Date.now() < readyDeadline, 'managed fixture bring-up timed out');
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      const status = await requireOk(supervisor, 'rn_session', { action: 'status' });
+      const authority = status.data?.authority ?? {};
+      console.log(
+        `authority device=${authority.deviceBound} install=${authority.installBound} metro=${authority.metroBound} bundle=${authority.bundleBound}`,
+      );
+      if (authority.installBound && authority.metroBound) break;
+    }
+
+    await requireOk(supervisor, 'device_snapshot', {
+      action: 'open',
+      platform: 'ios',
+      deviceId: DEVICE_ID,
+      appId: APP_ID,
+      attachOnly: true,
+    });
+    runnerOpened = true;
+    const launchSurface = await requireOk(supervisor, 'device_snapshot', { action: 'snapshot' });
+    console.log(`launch surface: ${JSON.stringify(launchSurface.data).slice(0, 1_500)}`);
+    await requireOk(supervisor, 'cdp_connect', { platform: 'ios', bundleId: APP_ID });
+    await requireOk(supervisor, 'cdp_error_log', { clear: true });
+
+    await requireOk(supervisor, 'cdp_interact', {
+      action: 'press',
+      testID: 'open_otp',
+    });
+    const nativeVisibility = await callTool(supervisor, 'expect_visible_by_testid', {
+      testID: 'otp_email-pressable',
+      timeoutMs: 7_000,
+    });
+    const cdpVisibility = await callTool(supervisor, 'cdp_component_tree', {
+      filter: 'otp_email-pressable',
+      depth: 6,
+    });
+    const wdaProbe = await callTool(supervisor, 'maestro_run', {
+      platform: 'ios',
+      appId: APP_ID,
+      deviceId: DEVICE_ID,
+      inlineYaml: `appId: ${APP_ID}\n---\n- assertVisible: otp_email-pressable\n`,
+      timeoutMs: 10_000,
+    });
+    evidence.surfaceBoundary = {
+      nativeVisibility: nativeVisibility.envelope,
+      cdpVisibility: cdpVisibility.envelope,
+      wdaProbe: wdaProbe.envelope,
+      wdaBlind: wdaProbe.envelope?.ok !== true && cdpVisibility.envelope?.ok === true,
+    };
+    assert.equal(cdpVisibility.envelope?.ok, true, `CDP modal probe: ${cdpVisibility.text}`);
+    assert.equal(
+      wdaProbe.envelope?.ok,
+      false,
+      `owned OTP fixture did not reproduce the WDA-blind boundary: ${wdaProbe.text.slice(0, 800)}`,
+    );
+    assert.equal(wdaProbe.envelope?.meta?.proofDomain, 'xctest-native');
+    await requireOk(supervisor, 'cdp_interact', { action: 'press', testID: 'otp_cancel' });
+
+    const beforeRuns = totalRuns();
+    const action = await requireOk(supervisor, 'cdp_run_action', {
+      actionId: ACTION_ID,
+      projectRoot: APP_ROOT,
+      platform: 'ios',
+      autoRepair: false,
+      trigger: 'agent',
+    });
+    const afterRuns = totalRuns();
+    assert.equal(action.data?.passed, true);
+    assert.equal(action.data?.proofDomain, 'partitioned');
+    assert.equal(afterRuns, beforeRuns + 1);
+    const waitStep = action.data?.perStepReadback?.steps?.find(
+      (step: any) => step.index === 2 && step.verb === 'waitVisible',
+    );
+    assert.ok(waitStep, `missing wait trace: ${JSON.stringify(action.data?.perStepReadback)}`);
+    assert.ok(waitStep.durationMs >= 500, `wait mounted too early: ${waitStep.durationMs}ms`);
+    const completionTree = await requireOk(supervisor, 'cdp_component_tree', {
+      filter: 'otp_done',
+      depth: 4,
+    });
+    await requireOk(supervisor, 'expect_visible_by_testid', {
+      testID: 'otp_done',
+      timeoutMs: 2_000,
+    });
+    evidence.action = { beforeRuns, afterRuns, result: action, completionTree };
+
+    const wrongStartedAt = Date.now();
+    const wrongId = await callTool(supervisor, 'maestro_run', {
+      platform: 'ios',
+      appId: APP_ID,
+      deviceId: DEVICE_ID,
+      inlineYaml: `appId: ${APP_ID}\n---\n- tapOn:\n    id: open_otp\n- extendedWaitUntil:\n    visible:\n      id: missing_otp\n`,
+    });
+    const wrongElapsedMs = Date.now() - wrongStartedAt;
+    assert.equal(wrongId.envelope?.code, 'TESTID_NOT_FOUND', wrongId.text.slice(0, 800));
+    assert.equal(wrongId.envelope?.meta?.failedStepIndex, 1);
+    assert.ok(wrongElapsedMs >= 16_500, `default timeout ended after ${wrongElapsedMs}ms`);
+    evidence.wrongIdControl = { elapsedMs: wrongElapsedMs, result: wrongId.envelope };
+    await requireOk(supervisor, 'cdp_interact', { action: 'press', testID: 'otp_cancel' });
+
+    const shortStartedAt = Date.now();
+    const shortTimeout = await callTool(supervisor, 'maestro_run', {
+      platform: 'ios',
+      appId: APP_ID,
+      deviceId: DEVICE_ID,
+      inlineYaml: `appId: ${APP_ID}\n---\n- tapOn:\n    id: open_otp\n- extendedWaitUntil:\n    visible:\n      id: otp_email-pressable\n    timeout: 300\n`,
+    });
+    const shortElapsedMs = Date.now() - shortStartedAt;
+    assert.equal(shortTimeout.envelope?.code, 'TESTID_NOT_FOUND', shortTimeout.text.slice(0, 800));
+    assert.equal(shortTimeout.envelope?.meta?.failedStepIndex, 1);
+    assert.ok(
+      shortElapsedMs >= 250 && shortElapsedMs < 2_000,
+      `300ms control took ${shortElapsedMs}ms`,
+    );
+    evidence.shortTimeoutControl = { elapsedMs: shortElapsedMs, result: shortTimeout.envelope };
+    await new Promise((resolve) => setTimeout(resolve, 5_500));
+    await requireOk(supervisor, 'cdp_interact', { action: 'press', testID: 'otp_cancel' });
+    evidence.errors = (await callTool(supervisor, 'cdp_error_log')).envelope;
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    const teardown: Array<[string, Record<string, unknown>]> = [];
+    if (runnerOpened) teardown.push(['device_snapshot', { action: 'close' }]);
+    teardown.push(['cdp_disconnect', {}]);
+    teardown.push(['rn_session', { action: 'stop_metro' }]);
+    teardown.push(['rn_session', { action: 'restore_integration', confirmed: true }]);
+    teardown.push(['rn_session', { action: 'release' }]);
+    const cleanup: Record<string, unknown> = {};
+    for (const [name, args] of teardown) {
+      try {
+        cleanup[name] = (await callTool(supervisor, name, args)).envelope;
+      } catch (error) {
+        cleanup[name] = { error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+    evidence.cleanup = cleanup;
+    finalStatus = await callTool(supervisor, 'rn_session', { action: 'status' });
+    evidence.finalStatus = finalStatus.envelope;
+    writeFileSync(EVIDENCE_PATH, JSON.stringify(evidence, null, 2));
+    writeFileSync(STATUS_PATH, JSON.stringify(finalStatus.envelope, null, 2));
+    adapter?.kill('SIGTERM');
+    supervisor.child.kill('SIGTERM');
+  }
+  if (primaryError) throw primaryError;
+  assert.ok(finalStatus);
+  assert.ok(
+    ['released', 'selected'].includes(finalStatus.envelope?.data?.authority?.state),
+    `unexpected post-release state: ${finalStatus.text.slice(0, 800)}`,
+  );
+  assert.equal(finalStatus.envelope?.data?.authority?.metroBound, false);
+  assert.equal(finalStatus.envelope?.data?.authority?.runnerBound, false);
+  assert.equal(
+    finalStatus.envelope?.data?.authority?.migration?.packageIntegration?.installed,
+    false,
+  );
+}
+
+await run();
+console.log(`evidence=${EVIDENCE_PATH}`);
+console.log(`status=${STATUS_PATH}`);

--- a/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
+++ b/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
@@ -125,6 +125,7 @@ async function run() {
   let adapter: ChildProcess | undefined;
   let runnerOpened = false;
   let primaryError: unknown;
+  const cleanupErrors: Error[] = [];
   let finalStatus: Awaited<ReturnType<typeof callTool>> | undefined;
 
   try {
@@ -327,7 +328,6 @@ async function run() {
     ]);
     teardown.push(['rn_session.release', 'rn_session', { action: 'release' }]);
     const cleanup: Record<string, unknown> = {};
-    const cleanupErrors: Error[] = [];
     for (const [label, name, args] of teardown) {
       try {
         const result = await callTool(supervisor, name, args);
@@ -400,15 +400,15 @@ async function run() {
     } catch (error) {
       cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
     }
-    if (primaryError && cleanupErrors.length > 0) {
-      throw new AggregateError(
-        [primaryError, ...cleanupErrors],
-        'OTP proof failed and reverse cleanup was incomplete',
-      );
-    }
-    if (cleanupErrors.length > 0) {
-      throw new AggregateError(cleanupErrors, 'OTP proof reverse cleanup was incomplete');
-    }
+  }
+  if (primaryError && cleanupErrors.length > 0) {
+    throw new AggregateError(
+      [primaryError, ...cleanupErrors],
+      'OTP proof failed and reverse cleanup was incomplete',
+    );
+  }
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(cleanupErrors, 'OTP proof reverse cleanup was incomplete');
   }
   if (primaryError) throw primaryError;
 }

--- a/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
+++ b/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
@@ -52,6 +52,60 @@ async function requireOk(supervisor: any, name: string, args: Record<string, unk
   return result.envelope;
 }
 
+function collectTestIds(value: unknown, ids: Set<string> = new Set()): Set<string> {
+  if (!value || typeof value !== 'object') return ids;
+  const record = value as Record<string, unknown>;
+  if (typeof record.testID === 'string') ids.add(record.testID);
+  if (typeof record.nativeID === 'string') ids.add(record.nativeID);
+  for (const child of [record.tree, record.children, record.nodes, record.matches]) {
+    if (Array.isArray(child)) {
+      for (const item of child) collectTestIds(item, ids);
+    } else {
+      collectTestIds(child, ids);
+    }
+  }
+  return ids;
+}
+
+function assertCompleteExactTree(
+  result: Awaited<ReturnType<typeof callTool>>,
+  testId: string,
+): void {
+  assert.equal(result.envelope?.ok, true, `CDP modal probe: ${result.text.slice(0, 800)}`);
+  assert.notEqual(result.envelope?.data?.__agent_truncated, true);
+  assert.notEqual(result.envelope?.data?.truncated, true);
+  assert.equal(result.envelope?.meta?.treeVerdict?.state, 'ok');
+  assert.equal(result.envelope?.meta?.treeVerdict?.path, 'filter');
+  assert.deepEqual(result.envelope?.meta?.treeVerdict?.reasons, []);
+  assert.equal(collectTestIds(result.envelope?.data).has(testId), true, `${testId} is absent`);
+}
+
+function hasExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (hasExited(child)) return true;
+  return new Promise((resolveExit) => {
+    const finish = (exited: boolean): void => {
+      clearTimeout(timer);
+      child.off('exit', onExit);
+      resolveExit(exited);
+    };
+    const onExit = (): void => finish(true);
+    const timer = setTimeout(() => finish(hasExited(child)), timeoutMs);
+    child.once('exit', onExit);
+  });
+}
+
+async function terminateChild(child: ChildProcess, label: string): Promise<void> {
+  if (hasExited(child)) return;
+  child.kill('SIGTERM');
+  if (await waitForExit(child, 10_000)) return;
+  child.kill('SIGKILL');
+  assert.equal(await waitForExit(child, 5_000), true, `${label} did not terminate`);
+}
+
 async function run() {
   const declaredEnv = {
     RN_DEV_AGENT_DECLARED_ROOT: APP_ROOT!,
@@ -170,15 +224,16 @@ async function run() {
       nativeVisibility: nativeVisibility.envelope,
       cdpVisibility: cdpVisibility.envelope,
       wdaProbe: wdaProbe.envelope,
-      wdaBlind: wdaProbe.envelope?.ok !== true && cdpVisibility.envelope?.ok === true,
+      wdaBlind: false,
     };
-    assert.equal(cdpVisibility.envelope?.ok, true, `CDP modal probe: ${cdpVisibility.text}`);
+    assertCompleteExactTree(cdpVisibility, 'otp_email-pressable');
     assert.equal(
       wdaProbe.envelope?.ok,
       false,
       `owned OTP fixture did not reproduce the WDA-blind boundary: ${wdaProbe.text.slice(0, 800)}`,
     );
     assert.equal(wdaProbe.envelope?.meta?.proofDomain, 'xctest-native');
+    (evidence.surfaceBoundary as Record<string, unknown>).wdaBlind = true;
     await requireOk(supervisor, 'cdp_interact', { action: 'press', testID: 'otp_cancel' });
 
     const beforeRuns = totalRuns();
@@ -193,7 +248,21 @@ async function run() {
     assert.equal(action.data?.passed, true);
     assert.equal(action.data?.proofDomain, 'partitioned');
     assert.equal(afterRuns, beforeRuns + 1);
-    const waitStep = action.data?.perStepReadback?.steps?.find(
+    const actionTrace = action.data?.perStepReadback?.steps ?? [];
+    assert.equal(action.data?.perStepReadback?.complete, true);
+    assert.deepEqual(
+      actionTrace.map((step: any) => step.index),
+      [0, 1, 2, 3, 4, 5, 6],
+      `incomplete or repeated action trace: ${JSON.stringify(actionTrace)}`,
+    );
+    assert.deepEqual(
+      actionTrace.slice(0, 2).map((step: any) => [step.index, step.status]),
+      [
+        [0, 'pass'],
+        [1, 'pass'],
+      ],
+    );
+    const waitStep = actionTrace.find(
       (step: any) => step.index === 2 && step.verb === 'waitVisible',
     );
     assert.ok(waitStep, `missing wait trace: ${JSON.stringify(action.data?.perStepReadback)}`);
@@ -243,40 +312,102 @@ async function run() {
   } catch (error) {
     primaryError = error;
   } finally {
-    const teardown: Array<[string, Record<string, unknown>]> = [];
-    if (runnerOpened) teardown.push(['device_snapshot', { action: 'close' }]);
-    teardown.push(['cdp_disconnect', {}]);
-    teardown.push(['rn_session', { action: 'stop_metro' }]);
-    teardown.push(['rn_session', { action: 'restore_integration', confirmed: true }]);
-    teardown.push(['rn_session', { action: 'release' }]);
+    const teardown: Array<[string, string, Record<string, unknown>]> = [];
+    if (runnerOpened)
+      teardown.push(['device_snapshot.close', 'device_snapshot', { action: 'close' }]);
+    teardown.push(['cdp_disconnect', 'cdp_disconnect', {}]);
+    teardown.push(['rn_session.stop_metro', 'rn_session', { action: 'stop_metro' }]);
+    teardown.push([
+      'rn_session.restore_integration',
+      'rn_session',
+      { action: 'restore_integration', confirmed: true },
+    ]);
+    teardown.push(['rn_session.release', 'rn_session', { action: 'release' }]);
     const cleanup: Record<string, unknown> = {};
-    for (const [name, args] of teardown) {
+    const cleanupErrors: Error[] = [];
+    for (const [label, name, args] of teardown) {
       try {
-        cleanup[name] = (await callTool(supervisor, name, args)).envelope;
+        const result = await callTool(supervisor, name, args);
+        cleanup[label] = result.envelope ?? { text: result.text.slice(0, 800) };
+        assert.equal(result.envelope?.ok, true, `${label}: ${result.text.slice(0, 800)}`);
       } catch (error) {
-        cleanup[name] = { error: error instanceof Error ? error.message : String(error) };
+        const cleanupError = error instanceof Error ? error : new Error(String(error));
+        cleanup[label] = { error: cleanupError.message };
+        cleanupErrors.push(cleanupError);
       }
     }
     evidence.cleanup = cleanup;
-    finalStatus = await callTool(supervisor, 'rn_session', { action: 'status' });
-    evidence.finalStatus = finalStatus.envelope;
-    writeFileSync(EVIDENCE_PATH, JSON.stringify(evidence, null, 2));
-    writeFileSync(STATUS_PATH, JSON.stringify(finalStatus.envelope, null, 2));
-    adapter?.kill('SIGTERM');
-    supervisor.child.kill('SIGTERM');
+    try {
+      finalStatus = await callTool(supervisor, 'rn_session', { action: 'status' });
+      evidence.finalStatus = finalStatus.envelope;
+      assert.equal(finalStatus.envelope?.ok, true, finalStatus.text.slice(0, 800));
+      assert.ok(
+        ['released', 'selected'].includes(finalStatus.envelope?.data?.authority?.state),
+        `unexpected post-release state: ${finalStatus.text.slice(0, 800)}`,
+      );
+      assert.equal(finalStatus.envelope?.data?.authority?.deviceBound, false);
+      assert.equal(finalStatus.envelope?.data?.authority?.installBound, false);
+      assert.equal(finalStatus.envelope?.data?.authority?.metroBound, false);
+      assert.equal(finalStatus.envelope?.data?.authority?.bundleBound, false);
+      assert.equal(finalStatus.envelope?.data?.authority?.runnerBound, false);
+      assert.equal(finalStatus.envelope?.data?.authority?.recorderBound, false);
+      assert.equal(
+        finalStatus.envelope?.data?.authority?.migration?.packageIntegration?.installed,
+        false,
+      );
+    } catch (error) {
+      cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+    }
+    const processes: Record<string, unknown> = {};
+    if (adapter) {
+      try {
+        await terminateChild(adapter, 'fixture adapter');
+        processes.adapter = {
+          exited: true,
+          exitCode: adapter.exitCode,
+          signalCode: adapter.signalCode,
+        };
+      } catch (error) {
+        const cleanupError = error instanceof Error ? error : new Error(String(error));
+        processes.adapter = { error: cleanupError.message };
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    try {
+      await terminateChild(supervisor.child, 'supervisor');
+      processes.supervisor = {
+        exited: true,
+        exitCode: supervisor.child.exitCode,
+        signalCode: supervisor.child.signalCode,
+      };
+    } catch (error) {
+      const cleanupError = error instanceof Error ? error : new Error(String(error));
+      processes.supervisor = { error: cleanupError.message };
+      cleanupErrors.push(cleanupError);
+    }
+    evidence.processes = processes;
+    evidence.cleanupErrors = cleanupErrors.map((error) => error.message);
+    try {
+      writeFileSync(EVIDENCE_PATH, JSON.stringify(evidence, null, 2));
+    } catch (error) {
+      cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+    }
+    try {
+      writeFileSync(STATUS_PATH, JSON.stringify(finalStatus?.envelope ?? null, null, 2));
+    } catch (error) {
+      cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+    }
+    if (primaryError && cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [primaryError, ...cleanupErrors],
+        'OTP proof failed and reverse cleanup was incomplete',
+      );
+    }
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'OTP proof reverse cleanup was incomplete');
+    }
   }
   if (primaryError) throw primaryError;
-  assert.ok(finalStatus);
-  assert.ok(
-    ['released', 'selected'].includes(finalStatus.envelope?.data?.authority?.state),
-    `unexpected post-release state: ${finalStatus.text.slice(0, 800)}`,
-  );
-  assert.equal(finalStatus.envelope?.data?.authority?.metroBound, false);
-  assert.equal(finalStatus.envelope?.data?.authority?.runnerBound, false);
-  assert.equal(
-    finalStatus.envelope?.data?.authority?.migration?.packageIntegration?.installed,
-    false,
-  );
 }
 
 await run();

--- a/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
+++ b/packages/rn-dev-agent-core/test/smoke/otp-omitted-timeout-gate.ts
@@ -228,11 +228,14 @@ async function run() {
     };
     assertCompleteExactTree(cdpVisibility, 'otp_email-pressable');
     assert.equal(
-      wdaProbe.envelope?.ok,
-      false,
+      wdaProbe.envelope?.code,
+      'NATIVE_SURFACE_BLIND',
       `owned OTP fixture did not reproduce the WDA-blind boundary: ${wdaProbe.text.slice(0, 800)}`,
     );
     assert.equal(wdaProbe.envelope?.meta?.proofDomain, 'xctest-native');
+    assert.equal(wdaProbe.envelope?.meta?.cleanup?.cleanupProven, true);
+    assert.equal(wdaProbe.envelope?.meta?.cleanup?.wdaProcessSettled, true);
+    assert.equal(wdaProbe.envelope?.meta?.cleanup?.runnerParkCommitted, true);
     (evidence.surfaceBoundary as Record<string, unknown>).wdaBlind = true;
     await requireOk(supervisor, 'cdp_interact', { action: 'press', testID: 'otp_cancel' });
 

--- a/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   normalizeSteps,
+  ReplayDispatchError,
   UnsupportedStepError,
   replayFlow,
 } from '../../dist/domain/cdp-flow-replay.js';
@@ -370,6 +371,36 @@ test('waitVisible cannot pass from an oracle result completed after its deadline
   assert.equal(result.failureCode, 'TESTID_NOT_FOUND');
   assert.equal(reads, 2);
   assert.ok(elapsedMs >= 225 && elapsedMs < 500, `deadline completed after ${elapsedMs}ms`);
+});
+
+test('waitVisible discards an oracle rejection completed after its deadline', async () => {
+  const dispatch = mockDispatch();
+  dispatch.visibility = async () => {
+    const blockedUntil = Date.now() + 30;
+    while (Date.now() < blockedUntil) {}
+    throw new ReplayDispatchError('RECONNECT_TIMEOUT', 'stale transport refusal');
+  };
+  const result = await replayFlow([{ t: 'waitVisible', id: 'late-error', timeoutMs: 5 }], dispatch);
+  assert.equal(result.passed, false);
+  assert.equal(result.failureCode, 'RUNNER_TIMEOUT');
+  assert.doesNotMatch(result.reason ?? '', /stale transport refusal/);
+});
+
+test('waitVisible preserves an oracle rejection completed before its deadline', async () => {
+  const dispatch = mockDispatch();
+  dispatch.visibility = async () => {
+    throw new ReplayDispatchError('RECONNECT_TIMEOUT', 'current transport refusal', {
+      reconnectAttempted: true,
+    });
+  };
+  const result = await replayFlow(
+    [{ t: 'waitVisible', id: 'current-error', timeoutMs: 100 }],
+    dispatch,
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.failureCode, 'RECONNECT_TIMEOUT');
+  assert.equal(result.reason, 'current transport refusal');
+  assert.equal(result.failureMeta?.reconnectAttempted, true);
 });
 
 test('waitVisible preserves finite timeouts above Node timer range', async () => {

--- a/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
@@ -26,7 +26,7 @@ test('normalizeSteps maps the supported subset with ${VAR} interpolation', () =>
     { t: 'launch', stopApp: false },
     { t: 'tap', id: 'wizard-title-input' },
     { t: 'type', text: 'Ship it' },
-    { t: 'assert', id: 'wizard-step-1' },
+    { t: 'waitVisible', id: 'wizard-step-1', timeoutMs: 17_000 },
     { t: 'tap', id: 'wizard-priority-high' },
     { t: 'wait', timeoutMs: 400 },
     {
@@ -68,6 +68,38 @@ test('normalizeSteps rejects malformed supported steps (never a silent "undefine
   assert.throws(() => normalizeSteps([42], {}), UnsupportedStepError); // non-object
 });
 
+test('id visibility commands normalize to one timed wait operation', () => {
+  assert.deepEqual(
+    normalizeSteps(
+      [
+        { extendedWaitUntil: { visible: { id: 'otp' } } },
+        { extendedWaitUntil: { visible: { id: 'slow-otp' }, timeout: 750 } },
+        { assertVisible: { id: 'complete' } },
+      ],
+      {},
+    ),
+    [
+      { t: 'waitVisible', id: 'otp', timeoutMs: 17_000 },
+      { t: 'waitVisible', id: 'slow-otp', timeoutMs: 750 },
+      { t: 'waitVisible', id: 'complete', timeoutMs: 17_000 },
+    ],
+  );
+});
+
+test('unsupported extended wait variants remain loud refusals', () => {
+  for (const command of [
+    { extendedWaitUntil: { visible: { id: 'otp' }, timeout: -1 } },
+    { extendedWaitUntil: { visible: { id: 'otp' }, timeout: Number.POSITIVE_INFINITY } },
+    { extendedWaitUntil: { visible: { id: 'otp' }, timeout: '750' } },
+    { extendedWaitUntil: { visible: { id: 'otp' }, timeout: 750, extra: true } },
+    { extendedWaitUntil: { notVisible: { id: 'otp' }, timeout: 750 } },
+    { extendedWaitUntil: { visible: { text: 'One-time code' }, timeout: 750 } },
+    { extendedWaitUntil: { visible: { id: { regex: 'otp.*' } }, timeout: 750 } },
+  ]) {
+    assert.throws(() => normalizeSteps([command], {}), UnsupportedStepError);
+  }
+});
+
 function mockDispatch(over = {}) {
   const calls = [];
   return {
@@ -107,7 +139,7 @@ test('replayFlow happy path: type routes to last tapped, all pass', async () => 
     [
       { t: 'tap', id: 'title' },
       { t: 'type', text: 'Hi' },
-      { t: 'assert', id: 'step-2' },
+      { t: 'waitVisible', id: 'step-2', timeoutMs: 17_000 },
     ],
     d,
   );
@@ -133,7 +165,7 @@ test('replayFlow runFlow recurses only when whenVisible present', async () => {
   const r = await replayFlow(
     [
       { t: 'runFlow', whenVisible: 'onboarding', commands: [{ t: 'tap', id: 'done' }] },
-      { t: 'assert', id: 'tabs' },
+      { t: 'waitVisible', id: 'tabs', timeoutMs: 17_000 },
     ],
     d,
   );
@@ -190,9 +222,13 @@ test('replayFlow cannot pass when an awaited final dispatch exceeds its deadline
     controller.abort(new Error('deadline'));
     return { visible: true };
   };
-  const result = await replayFlow([{ t: 'assert', id: 'final' }], dispatch, {
-    signal: controller.signal,
-  });
+  const result = await replayFlow(
+    [{ t: 'waitVisible', id: 'final', timeoutMs: 17_000 }],
+    dispatch,
+    {
+      signal: controller.signal,
+    },
+  );
   assert.equal(result.passed, false);
   assert.equal(result.failureCode, 'RUNNER_TIMEOUT');
 });
@@ -204,7 +240,92 @@ test('replayFlow fails the step when a target is disabled (no false green)', asy
   assert.equal(r.failedStepIndex, 0);
 });
 
-test('replayFlow fails assert when target not visible', async () => {
-  const r = await replayFlow([{ t: 'assert', id: 'ghost' }], mockDispatch({ visible: [] }));
+test('replayFlow fails a zero-budget visibility wait when the target is absent', async () => {
+  const r = await replayFlow(
+    [{ t: 'waitVisible', id: 'ghost', timeoutMs: 0 }],
+    mockDispatch({ visible: [] }),
+  );
   assert.equal(r.passed, false);
+});
+
+test('waitVisible polls readable absence, then continues without replaying a prefix', async () => {
+  let reads = 0;
+  const dispatch = mockDispatch();
+  dispatch.visibility = async (id) => {
+    dispatch.calls.push(['visibility', id]);
+    reads += 1;
+    return {
+      visible: reads >= 3,
+      code: reads >= 3 ? undefined : 'TESTID_NOT_FOUND',
+      meta: { failedSelector: id },
+    };
+  };
+  const result = await replayFlow(
+    [
+      { t: 'waitVisible', id: 'otp', timeoutMs: 1_000 },
+      { t: 'tap', id: 'otp' },
+    ],
+    dispatch,
+    { indexOffset: 4 },
+  );
+  assert.equal(result.passed, true);
+  assert.deepEqual(
+    result.steps.map(({ sourceIndex, t, ok }) => ({ sourceIndex, t, ok })),
+    [
+      { sourceIndex: 4, t: 'waitVisible', ok: true },
+      { sourceIndex: 5, t: 'tap', ok: true },
+    ],
+  );
+  assert.deepEqual(dispatch.calls, [
+    ['visibility', 'otp'],
+    ['visibility', 'otp'],
+    ['visibility', 'otp'],
+    ['press', 'otp'],
+  ]);
+});
+
+test('id-based assertVisible uses the same timed polling semantics', async () => {
+  let reads = 0;
+  const dispatch = mockDispatch();
+  dispatch.visibility = async (id) => {
+    reads += 1;
+    return {
+      visible: reads >= 2,
+      code: reads >= 2 ? undefined : 'TESTID_NOT_FOUND',
+      meta: { failedSelector: id },
+    };
+  };
+  const result = await replayFlow(
+    normalizeSteps([{ assertVisible: { id: 'complete' } }], {}),
+    dispatch,
+  );
+  assert.equal(result.passed, true);
+  assert.equal(reads, 2);
+  assert.ok(result.steps[0].durationMs >= 150);
+});
+
+test('failed waitVisible preserves source index, selector, elapsed wait, and stops the suffix', async () => {
+  const dispatch = mockDispatch({ visible: [] });
+  const result = await replayFlow(
+    [
+      { t: 'waitVisible', id: 'missing-otp', timeoutMs: 250 },
+      { t: 'tap', id: 'must-not-dispatch' },
+    ],
+    dispatch,
+    { indexOffset: 7 },
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.failureCode, 'TESTID_NOT_FOUND');
+  assert.equal(result.failedStepIndex, 7);
+  assert.equal(result.failureMeta?.failedSelector, 'missing-otp');
+  assert.ok(result.failureMeta?.waitedMs >= 200);
+  assert.ok(result.failureMeta?.waitedMs < 1_000);
+  assert.deepEqual(
+    result.steps.map(({ sourceIndex, t, ok }) => ({ sourceIndex, t, ok })),
+    [{ sourceIndex: 7, t: 'waitVisible', ok: false }],
+  );
+  assert.equal(
+    dispatch.calls.some((call) => call[0] === 'press'),
+    false,
+  );
 });

--- a/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
@@ -234,6 +234,22 @@ test('replayFlow cannot pass when an awaited final dispatch exceeds its deadline
   assert.equal(result.failureCode, 'RUNNER_TIMEOUT');
 });
 
+test('waitVisible aborts a stalled visibility read at the outer replay deadline', async () => {
+  const controller = new AbortController();
+  const dispatch = mockDispatch();
+  dispatch.visibility = async () => new Promise(() => {});
+  const startedAt = Date.now();
+  setTimeout(() => controller.abort(new Error('deadline')), 20);
+  const result = await replayFlow(
+    [{ t: 'waitVisible', id: 'stalled', timeoutMs: 17_000 }],
+    dispatch,
+    { signal: controller.signal },
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.failureCode, 'RUNNER_TIMEOUT');
+  assert.ok(Date.now() - startedAt < 500);
+});
+
 test('replayFlow fails the step when a target is disabled (no false green)', async () => {
   const d = mockDispatch({ pressThrows: ['save'] });
   const r = await replayFlow([{ t: 'tap', id: 'save' }], d);

--- a/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
@@ -329,3 +329,21 @@ test('failed waitVisible preserves source index, selector, elapsed wait, and sto
     false,
   );
 });
+
+test('waitVisible cannot pass from an oracle result completed after its deadline', async () => {
+  let reads = 0;
+  const dispatch = mockDispatch();
+  dispatch.visibility = async () => {
+    reads += 1;
+    if (reads === 1) return { visible: false, code: 'TESTID_NOT_FOUND' };
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    return { visible: true };
+  };
+  const startedAt = Date.now();
+  const result = await replayFlow([{ t: 'waitVisible', id: 'late', timeoutMs: 250 }], dispatch);
+  const elapsedMs = Date.now() - startedAt;
+  assert.equal(result.passed, false);
+  assert.equal(result.failureCode, 'TESTID_NOT_FOUND');
+  assert.equal(reads, 2);
+  assert.ok(elapsedMs >= 225 && elapsedMs < 500, `deadline completed after ${elapsedMs}ms`);
+});

--- a/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
@@ -347,3 +347,17 @@ test('waitVisible cannot pass from an oracle result completed after its deadline
   assert.equal(reads, 2);
   assert.ok(elapsedMs >= 225 && elapsedMs < 500, `deadline completed after ${elapsedMs}ms`);
 });
+
+test('waitVisible preserves finite timeouts above Node timer range', async () => {
+  const dispatch = mockDispatch();
+  dispatch.visibility = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    return { visible: true };
+  };
+  const result = await replayFlow(
+    [{ t: 'waitVisible', id: 'slow', timeoutMs: 3_000_000_000 }],
+    dispatch,
+  );
+  assert.equal(result.passed, true);
+  assert.ok(result.steps[0].durationMs >= 20);
+});

--- a/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
@@ -26,7 +26,7 @@ test('normalizeSteps maps the supported subset with ${VAR} interpolation', () =>
     { t: 'launch', stopApp: false },
     { t: 'tap', id: 'wizard-title-input' },
     { t: 'type', text: 'Ship it' },
-    { t: 'waitVisible', id: 'wizard-step-1', timeoutMs: 17_000 },
+    { t: 'waitVisible', id: 'wizard-step-1', timeoutMs: 17_000, evidenceType: 'assert' },
     { t: 'tap', id: 'wizard-priority-high' },
     { t: 'wait', timeoutMs: 400 },
     {
@@ -81,7 +81,7 @@ test('id visibility commands normalize to one timed wait operation', () => {
     [
       { t: 'waitVisible', id: 'otp', timeoutMs: 17_000 },
       { t: 'waitVisible', id: 'slow-otp', timeoutMs: 750 },
-      { t: 'waitVisible', id: 'complete', timeoutMs: 17_000 },
+      { t: 'waitVisible', id: 'complete', timeoutMs: 17_000, evidenceType: 'assert' },
     ],
   );
 });
@@ -301,7 +301,31 @@ test('id-based assertVisible uses the same timed polling semantics', async () =>
   );
   assert.equal(result.passed, true);
   assert.equal(reads, 2);
+  assert.equal(result.steps[0].t, 'assert');
   assert.ok(result.steps[0].durationMs >= 150);
+});
+
+test('waitVisible reports no observation distinctly and does not dispatch its suffix', async () => {
+  const dispatch = mockDispatch();
+  dispatch.visibility = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return { visible: false, code: 'TESTID_NOT_FOUND' };
+  };
+  const result = await replayFlow(
+    [
+      { t: 'waitVisible', id: 'unobserved', timeoutMs: 5 },
+      { t: 'tap', id: 'must-not-dispatch' },
+    ],
+    dispatch,
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.failureCode, 'RUNNER_TIMEOUT');
+  assert.equal(result.failureMeta?.failedSelector, 'unobserved');
+  assert.equal(result.steps[0].ok, false);
+  assert.equal(
+    dispatch.calls.some((call) => call[0] === 'press'),
+    false,
+  );
 });
 
 test('failed waitVisible preserves source index, selector, elapsed wait, and stops the suffix', async () => {

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -138,12 +138,39 @@ test('React replay propagates a component-tree transport envelope without select
   );
   assert.equal(replay.passed, false);
   assert.equal(replay.failureCode, 'RECONNECT_TIMEOUT');
-  assert.equal(replay.failureMeta?.failedSelector, undefined);
+  assert.equal(replay.failureMeta?.failedSelector, 'ready');
+  assert.equal(typeof replay.failureMeta?.waitedMs, 'number');
   assert.deepEqual(replay.failureMeta?.treeEnvelope, {
     ok: false,
     code: 'RECONNECT_TIMEOUT',
     error: 'Component tree connection timed out',
     meta: { reconnectAttempted: true },
+  });
+});
+
+test('React replay refuses a truncated component tree distinctly from readable absence', async () => {
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp' }, timeout: 250 } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async () =>
+        replayTreeData({
+          ok: true,
+          data: { __agent_truncated: true, originalLength: 75_000 },
+        }),
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, false);
+  assert.equal(replay.failureCode, 'EVAL_FAILED');
+  assert.equal(replay.failedStepIndex, 0);
+  assert.deepEqual(replay.failureMeta?.treeEnvelope, {
+    ok: true,
+    truncated: true,
+    originalLength: 75_000,
   });
 });
 

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -118,6 +118,28 @@ test('unwrapTree returns the bare node for a single match and the matches wrappe
   assert.deepEqual(unwrapTree({ testID: 'x', children: [] }), { testID: 'x', children: [] });
 });
 
+test('replayTreeData accepts complete filtered absence and exact interactive presence', () => {
+  assert.deepEqual(
+    replayTreeData({
+      ok: true,
+      data: { tree: null },
+      meta: { treeVerdict: { state: 'ok', path: 'filter', reasons: [] } },
+    }),
+    { tree: null },
+  );
+  assert.deepEqual(
+    replayTreeData(
+      {
+        ok: true,
+        data: { interactive: [{ testID: 'otp' }] },
+        meta: { treeVerdict: { state: 'ok', path: 'interactive', reasons: [] } },
+      },
+      'otp',
+    ),
+    { interactive: [{ testID: 'otp' }] },
+  );
+});
+
 test('React replay propagates a component-tree transport envelope without selector repair evidence', async () => {
   const replay = await runCdpReplayCommands(
     [{ assertVisible: { id: 'ready' } }],
@@ -172,6 +194,63 @@ test('React replay refuses a truncated component tree distinctly from readable a
     truncated: true,
     originalLength: 75_000,
   });
+});
+
+test('React replay refuses helper-truncated filtered evidence', async () => {
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp' }, timeout: 250 } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async () =>
+        replayTreeData({
+          ok: true,
+          data: { tree: { testID: 'otp' }, truncated: true },
+          meta: {
+            treeVerdict: {
+              state: 'degraded',
+              path: 'filter',
+              reasons: ['output-truncated'],
+            },
+          },
+        }),
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, false);
+  assert.equal(replay.failureCode, 'EVAL_FAILED');
+  assert.equal(replay.failureMeta?.treeEnvelope?.truncated, true);
+});
+
+test('React replay refuses budget-exhausted absence as incomplete evidence', async () => {
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp' }, timeout: 250 } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async () =>
+        replayTreeData({
+          ok: true,
+          data: { tree: null },
+          meta: {
+            treeVerdict: {
+              state: 'degraded',
+              path: 'filter',
+              reasons: ['scan-budget-exhausted'],
+            },
+          },
+        }),
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, false);
+  assert.equal(replay.failureCode, 'EVAL_FAILED');
+  assert.equal(replay.failureMeta?.treeEnvelope?.incomplete, true);
+  assert.equal(replay.failureMeta?.failedSelector, 'otp');
 });
 
 test('React replay propagates APP_HAS_REDBOX instead of reporting a missing testID', async () => {

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -76,6 +76,33 @@ test('buildCdpDispatch accepts propagated fiber matches collapsed by the frontmo
   assert.deepEqual(calls, ['welcome']);
 });
 
+test('buildCdpDispatch uses a complete interactive fallback only for visibility', async () => {
+  let mutations = 0;
+  const dispatch = buildCdpDispatch({
+    pressByTestId: async () => {
+      mutations += 1;
+    },
+    typeByTestId: async () => {},
+    treeFor: async () =>
+      unwrapTree(
+        replayTreeData(
+          {
+            ok: true,
+            data: { interactive: [{ testID: 'otp' }] },
+            meta: { treeVerdict: { state: 'ok', path: 'interactive', reasons: [] } },
+          },
+          'otp',
+        ),
+      ),
+    frontmostFor: async () => ({ visible: true }),
+    launchApp: async () => {},
+    settle: async () => {},
+  });
+  assert.deepEqual(await dispatch.visibility('otp'), { visible: true });
+  await assert.rejects(dispatch.press('otp'), /not present/);
+  assert.equal(mutations, 0);
+});
+
 test('buildCdpDispatch revalidates a retained input target before mutation', async () => {
   let mutations = 0;
   const dispatch = buildCdpDispatch({

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -265,6 +265,37 @@ test('React replay refuses a truncated component tree distinctly from readable a
   });
 });
 
+test('React replay refuses a serialization sentinel distinctly from exact-ID absence', async () => {
+  let oracleReads = 0;
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp' }, timeout: 250 } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async () =>
+        replayTreeData({
+          ok: true,
+          data: { __agent_error: 'Serialization failed: cyclic fiber value' },
+        }),
+      frontmostFor: async () => {
+        oracleReads += 1;
+        return { visible: false, matchCount: 0 };
+      },
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, false);
+  assert.equal(replay.failureCode, 'EVAL_FAILED');
+  assert.notEqual(replay.failureCode, 'TESTID_NOT_FOUND');
+  assert.equal(oracleReads, 0);
+  assert.deepEqual(replay.failureMeta?.treeEnvelope, {
+    ok: true,
+    agentError: 'Serialization failed: cyclic fiber value',
+  });
+});
+
 test('React replay refuses helper-truncated filtered evidence', async () => {
   const replay = await runCdpReplayCommands(
     [{ extendedWaitUntil: { visible: { id: 'otp' }, timeout: 250 } }],

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -160,6 +160,7 @@ test('replayTreeData accepts exact presence independently and complete filtered 
     path: 'filter',
     reasons: [],
     rootsSeeded: 1,
+    complete: true,
     droppedSubtrees: 0,
     collapsedChildLists: 0,
   };
@@ -168,7 +169,7 @@ test('replayTreeData accepts exact presence independently and complete filtered 
       {
         ok: true,
         data: { tree: { testID: 'otp', children: [] } },
-        meta: { treeVerdict: { ...completeFilterVerdict, droppedSubtrees: 1 } },
+        meta: { treeVerdict: { ...completeFilterVerdict, complete: false, droppedSubtrees: 1 } },
       },
       'otp',
     ),
@@ -215,6 +216,7 @@ test('replayTreeData accepts exact presence independently and complete filtered 
             treeVerdict: {
               ...completeFilterVerdict,
               state: 'degraded',
+              complete: false,
               reasons: ['scan-budget-exhausted'],
             },
           },
@@ -231,6 +233,7 @@ test('replayTreeData refuses filtered evidence that cannot prove exact-id absenc
     path: 'filter',
     reasons: [],
     rootsSeeded: 1,
+    complete: true,
     droppedSubtrees: 0,
     collapsedChildLists: 0,
   };
@@ -243,17 +246,22 @@ test('replayTreeData refuses filtered evidence that cannot prove exact-id absenc
     {
       ok: true,
       data: { tree: null },
-      meta: { treeVerdict: { ...treeVerdict, droppedSubtrees: 1 } },
+      meta: { treeVerdict: { ...treeVerdict, complete: false, droppedSubtrees: 1 } },
     },
     {
       ok: true,
       data: { tree: null },
-      meta: { treeVerdict: { ...treeVerdict, collapsedChildLists: 1 } },
+      meta: { treeVerdict: { ...treeVerdict, complete: false, collapsedChildLists: 1 } },
     },
     {
       ok: true,
       data: { tree: null },
       meta: { treeVerdict: { ...treeVerdict, rootsSeeded: 0 } },
+    },
+    {
+      ok: true,
+      data: { tree: null },
+      meta: { treeVerdict: { ...treeVerdict, complete: undefined } },
     },
     {
       ok: true,

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -129,6 +129,22 @@ test('buildCdpDispatch revalidates a retained input target before mutation', asy
   assert.equal(mutations, 0);
 });
 
+test('exact oracle disabled state refuses mutation when the readable tree omits the target', async () => {
+  let mutations = 0;
+  const dispatch = buildCdpDispatch({
+    pressByTestId: async () => {
+      mutations += 1;
+    },
+    typeByTestId: async () => {},
+    treeFor: async () => ({ tree: { name: 'CollapsedScreen', children: [] } }),
+    frontmostFor: async () => ({ visible: true, disabled: true, matchCount: 1 }),
+    launchApp: async () => {},
+    settle: async () => {},
+  });
+  await assert.rejects(dispatch.press('disabled-action'), /disabled|non-interactable/);
+  assert.equal(mutations, 0);
+});
+
 test('buildCdpDispatch refuses duplicate oracle matches as ambiguous', async () => {
   const dispatch = buildCdpDispatch({
     pressByTestId: async () => {},

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -154,7 +154,7 @@ test('unwrapTree returns the bare node for a single match and the matches wrappe
   assert.deepEqual(unwrapTree({ testID: 'x', children: [] }), { testID: 'x', children: [] });
 });
 
-test('replayTreeData accepts complete filtered proof and exact interactive presence', () => {
+test('replayTreeData accepts exact presence independently and complete filtered absence', () => {
   const completeFilterVerdict = {
     state: 'ok',
     path: 'filter',
@@ -168,7 +168,7 @@ test('replayTreeData accepts complete filtered proof and exact interactive prese
       {
         ok: true,
         data: { tree: { testID: 'otp', children: [] } },
-        meta: { treeVerdict: completeFilterVerdict },
+        meta: { treeVerdict: { ...completeFilterVerdict, droppedSubtrees: 1 } },
       },
       'otp',
     ),
@@ -192,9 +192,9 @@ test('replayTreeData accepts complete filtered proof and exact interactive prese
         data: { interactive: [{ testID: 'otp' }] },
         meta: {
           treeVerdict: {
-            state: 'ok',
+            state: 'degraded',
             path: 'interactive',
-            reasons: [],
+            reasons: ['scan-budget-exhausted'],
             rootsSeeded: 1,
             droppedSubtrees: 0,
             collapsedChildLists: 0,
@@ -204,6 +204,24 @@ test('replayTreeData accepts complete filtered proof and exact interactive prese
       'otp',
     ),
     { interactive: [{ testID: 'otp' }] },
+  );
+  assert.throws(
+    () =>
+      replayTreeData(
+        {
+          ok: true,
+          data: { tree: null },
+          meta: {
+            treeVerdict: {
+              ...completeFilterVerdict,
+              state: 'degraded',
+              reasons: ['scan-budget-exhausted'],
+            },
+          },
+        },
+        'missing',
+      ),
+    (error) => error.code === 'EVAL_FAILED' && error.meta?.treeEnvelope?.incomplete === true,
   );
 });
 

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -89,7 +89,16 @@ test('buildCdpDispatch uses a complete interactive fallback only for visibility'
           {
             ok: true,
             data: { interactive: [{ testID: 'otp' }] },
-            meta: { treeVerdict: { state: 'ok', path: 'interactive', reasons: [] } },
+            meta: {
+              treeVerdict: {
+                state: 'ok',
+                path: 'interactive',
+                reasons: [],
+                rootsSeeded: 1,
+                droppedSubtrees: 0,
+                collapsedChildLists: 0,
+              },
+            },
           },
           'otp',
         ),
@@ -145,13 +154,35 @@ test('unwrapTree returns the bare node for a single match and the matches wrappe
   assert.deepEqual(unwrapTree({ testID: 'x', children: [] }), { testID: 'x', children: [] });
 });
 
-test('replayTreeData accepts complete filtered absence and exact interactive presence', () => {
+test('replayTreeData accepts complete filtered proof and exact interactive presence', () => {
+  const completeFilterVerdict = {
+    state: 'ok',
+    path: 'filter',
+    reasons: [],
+    rootsSeeded: 1,
+    droppedSubtrees: 0,
+    collapsedChildLists: 0,
+  };
   assert.deepEqual(
-    replayTreeData({
-      ok: true,
-      data: { tree: null },
-      meta: { treeVerdict: { state: 'ok', path: 'filter', reasons: [] } },
-    }),
+    replayTreeData(
+      {
+        ok: true,
+        data: { tree: { testID: 'otp', children: [] } },
+        meta: { treeVerdict: completeFilterVerdict },
+      },
+      'otp',
+    ),
+    { tree: { testID: 'otp', children: [] } },
+  );
+  assert.deepEqual(
+    replayTreeData(
+      {
+        ok: true,
+        data: { tree: null },
+        meta: { treeVerdict: completeFilterVerdict },
+      },
+      'missing',
+    ),
     { tree: null },
   );
   assert.deepEqual(
@@ -159,12 +190,66 @@ test('replayTreeData accepts complete filtered absence and exact interactive pre
       {
         ok: true,
         data: { interactive: [{ testID: 'otp' }] },
-        meta: { treeVerdict: { state: 'ok', path: 'interactive', reasons: [] } },
+        meta: {
+          treeVerdict: {
+            state: 'ok',
+            path: 'interactive',
+            reasons: [],
+            rootsSeeded: 1,
+            droppedSubtrees: 0,
+            collapsedChildLists: 0,
+          },
+        },
       },
       'otp',
     ),
     { interactive: [{ testID: 'otp' }] },
   );
+});
+
+test('replayTreeData refuses filtered evidence that cannot prove exact-id absence', () => {
+  const treeVerdict = {
+    state: 'ok',
+    path: 'filter',
+    reasons: [],
+    rootsSeeded: 1,
+    droppedSubtrees: 0,
+    collapsedChildLists: 0,
+  };
+  for (const envelope of [
+    {
+      ok: true,
+      data: { tree: { name: 'otp-container', children: [] } },
+      meta: { treeVerdict },
+    },
+    {
+      ok: true,
+      data: { tree: null },
+      meta: { treeVerdict: { ...treeVerdict, droppedSubtrees: 1 } },
+    },
+    {
+      ok: true,
+      data: { tree: null },
+      meta: { treeVerdict: { ...treeVerdict, collapsedChildLists: 1 } },
+    },
+    {
+      ok: true,
+      data: { tree: null },
+      meta: { treeVerdict: { ...treeVerdict, rootsSeeded: 0 } },
+    },
+    {
+      ok: true,
+      data: {
+        tree: { matches: Array.from({ length: 10 }, () => ({ testID: 'otp' })) },
+      },
+      meta: { treeVerdict },
+    },
+  ]) {
+    assert.throws(
+      () => replayTreeData(envelope, 'otp'),
+      (error) => error.code === 'EVAL_FAILED' && error.meta?.treeEnvelope?.incomplete === true,
+    );
+  }
 });
 
 test('React replay propagates a component-tree transport envelope without selector repair evidence', async () => {
@@ -189,6 +274,7 @@ test('React replay propagates a component-tree transport envelope without select
   assert.equal(replay.failureCode, 'RECONNECT_TIMEOUT');
   assert.equal(replay.failureMeta?.failedSelector, 'ready');
   assert.equal(typeof replay.failureMeta?.waitedMs, 'number');
+  assert.equal(replay.steps[0].t, 'assert');
   assert.deepEqual(replay.failureMeta?.treeEnvelope, {
     ok: false,
     code: 'RECONNECT_TIMEOUT',

--- a/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-replay-dispatch.test.js
@@ -1,27 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  collectTestIds,
-  isExactPresent,
   buildCdpDispatch,
   replayTreeData,
   runCdpReplayCommands,
   unwrapTree,
 } from '../../dist/tools/cdp-replay-dispatch.js';
 
-const tree = {
-  name: 'View',
-  testID: 'screen',
-  children: [
-    { name: 'SubmitButton', testID: 'tab-tasks', children: [] },
-    { name: 'Text', accessibilityLabel: 'tab-tasks-label', children: [] },
-  ],
-};
-
 // Contract: the REAL __RN_AGENT.getTree() payload wraps the node under `.tree`
-// (single match) or `.tree.matches[]` (multi match). The oracle must see
-// testIDs through these wrappers — the boundary bug where it didn't made the
-// fallback inert in production despite a green unit suite.
+// (single match) or `.tree.matches[]` (multi match).
 const GETTREE_SINGLE = { tree: { testID: 'fab-create-task', children: [] }, totalNodes: 1 };
 const GETTREE_MULTI = {
   tree: {
@@ -32,33 +19,6 @@ const GETTREE_MULTI = {
   },
   totalNodes: 2,
 };
-
-test('isExactPresent sees a testID through the real getTree `{ tree: <node> }` wrapper', () => {
-  assert.equal(isExactPresent(GETTREE_SINGLE, 'fab-create-task'), true);
-  assert.equal(isExactPresent(GETTREE_SINGLE, 'nope'), false);
-});
-
-test('isExactPresent sees testIDs through the `{ tree: { matches: [...] } }` multi-match wrapper', () => {
-  assert.equal(isExactPresent(GETTREE_MULTI, 'tab-feed'), true);
-  assert.equal(isExactPresent(GETTREE_MULTI, 'tab-tasks'), true);
-  assert.equal(isExactPresent(GETTREE_MULTI, 'tab'), false); // substring, not verbatim
-});
-
-test('buildCdpDispatch counts the filtered tree once when the interactive digest repeats it', async () => {
-  const calls = [];
-  const dispatch = buildCdpDispatch({
-    pressByTestId: async (id) => calls.push(id),
-    typeByTestId: async () => {},
-    treeFor: async () => ({
-      tree: { testID: 'quick-add-fab', children: [] },
-      interactive: [{ testID: 'quick-add-fab' }],
-    }),
-    launchApp: async () => {},
-    settle: async () => {},
-  });
-  await dispatch.press('quick-add-fab');
-  assert.deepEqual(calls, ['quick-add-fab']);
-});
 
 test('buildCdpDispatch accepts propagated fiber matches collapsed by the frontmost oracle', async () => {
   const calls = [];
@@ -76,40 +36,81 @@ test('buildCdpDispatch accepts propagated fiber matches collapsed by the frontmo
   assert.deepEqual(calls, ['welcome']);
 });
 
-test('buildCdpDispatch uses a complete interactive fallback only for visibility', async () => {
-  let mutations = 0;
+test('visibility trusts the exact-ID oracle over substring-filtered tree evidence', async () => {
+  // A screen name substring-matches the selector, so the filtered tree is a
+  // complete non-null tree WITHOUT the exact testID. The pre-oracle gate threw
+  // EVAL_FAILED here and killed the timed wait on its first poll (review-22).
+  let mounted = false;
   const dispatch = buildCdpDispatch({
-    pressByTestId: async () => {
-      mutations += 1;
-    },
+    pressByTestId: async () => {},
     typeByTestId: async () => {},
     treeFor: async () =>
       unwrapTree(
-        replayTreeData(
-          {
-            ok: true,
-            data: { interactive: [{ testID: 'otp' }] },
-            meta: {
-              treeVerdict: {
-                state: 'ok',
-                path: 'interactive',
-                reasons: [],
-                rootsSeeded: 1,
-                droppedSubtrees: 0,
-                collapsedChildLists: 0,
-              },
+        replayTreeData({
+          ok: true,
+          data: { tree: { name: 'OtpScreen', children: [] } },
+          meta: {
+            treeVerdict: {
+              state: 'ok',
+              path: 'filter',
+              reasons: [],
+              rootsSeeded: 1,
+              complete: true,
+              droppedSubtrees: 0,
+              collapsedChildLists: 0,
             },
           },
-          'otp',
-        ),
+        }),
       ),
-    frontmostFor: async () => ({ visible: true }),
+    frontmostFor: async () =>
+      mounted
+        ? { visible: true, matchCount: 1 }
+        : { visible: false, matchCount: 0, reason: 'testID is not mounted' },
     launchApp: async () => {},
     settle: async () => {},
   });
+  const absent = await dispatch.visibility('otp');
+  assert.equal(absent.visible, false);
+  assert.equal(absent.code, 'TESTID_NOT_FOUND');
+  assert.equal(absent.meta?.failedSelector, 'otp');
+  mounted = true;
   assert.deepEqual(await dispatch.visibility('otp'), { visible: true });
-  await assert.rejects(dispatch.press('otp'), /not present/);
-  assert.equal(mutations, 0);
+});
+
+test('exact presence despite incomplete descendants proceeds to the frontmost decision', async () => {
+  const dispatch = buildCdpDispatch({
+    pressByTestId: async () => {},
+    typeByTestId: async () => {},
+    treeFor: async () =>
+      unwrapTree(
+        replayTreeData({
+          ok: true,
+          data: { tree: { testID: 'otp', children: [] } },
+          meta: {
+            treeVerdict: {
+              state: 'ok',
+              path: 'filter',
+              reasons: [],
+              rootsSeeded: 2,
+              complete: false,
+              droppedSubtrees: 1,
+              collapsedChildLists: 0,
+            },
+          },
+        }),
+      ),
+    frontmostFor: async () => ({
+      visible: false,
+      reason: 'testID is ambiguous across mounted React trees',
+      matchCount: 2,
+    }),
+    launchApp: async () => {},
+    settle: async () => {},
+  });
+  const verdict = await dispatch.visibility('otp');
+  assert.equal(verdict.visible, false);
+  assert.equal(verdict.code, 'AMBIGUOUS_TESTID');
+  assert.match(verdict.reason ?? '', /resolves to 2 mounted elements/);
 });
 
 test('buildCdpDispatch revalidates a retained input target before mutation', async () => {
@@ -128,12 +129,17 @@ test('buildCdpDispatch revalidates a retained input target before mutation', asy
   assert.equal(mutations, 0);
 });
 
-test('buildCdpDispatch refuses two distinct filtered tree matches as ambiguous', async () => {
+test('buildCdpDispatch refuses duplicate oracle matches as ambiguous', async () => {
   const dispatch = buildCdpDispatch({
     pressByTestId: async () => {},
     typeByTestId: async () => {},
     treeFor: async () => ({
       tree: { matches: [{ testID: 'duplicate' }, { testID: 'duplicate' }] },
+    }),
+    frontmostFor: async () => ({
+      visible: false,
+      reason: 'testID is ambiguous across mounted React trees',
+      matchCount: 2,
     }),
     launchApp: async () => {},
     settle: async () => {},
@@ -154,80 +160,9 @@ test('unwrapTree returns the bare node for a single match and the matches wrappe
   assert.deepEqual(unwrapTree({ testID: 'x', children: [] }), { testID: 'x', children: [] });
 });
 
-test('replayTreeData accepts exact presence independently and complete filtered absence', () => {
-  const completeFilterVerdict = {
-    state: 'ok',
-    path: 'filter',
-    reasons: [],
-    rootsSeeded: 1,
-    complete: true,
-    droppedSubtrees: 0,
-    collapsedChildLists: 0,
-  };
-  assert.deepEqual(
-    replayTreeData(
-      {
-        ok: true,
-        data: { tree: { testID: 'otp', children: [] } },
-        meta: { treeVerdict: { ...completeFilterVerdict, complete: false, droppedSubtrees: 1 } },
-      },
-      'otp',
-    ),
-    { tree: { testID: 'otp', children: [] } },
-  );
-  assert.deepEqual(
-    replayTreeData(
-      {
-        ok: true,
-        data: { tree: null },
-        meta: { treeVerdict: completeFilterVerdict },
-      },
-      'missing',
-    ),
-    { tree: null },
-  );
-  assert.deepEqual(
-    replayTreeData(
-      {
-        ok: true,
-        data: { interactive: [{ testID: 'otp' }] },
-        meta: {
-          treeVerdict: {
-            state: 'degraded',
-            path: 'interactive',
-            reasons: ['scan-budget-exhausted'],
-            rootsSeeded: 1,
-            droppedSubtrees: 0,
-            collapsedChildLists: 0,
-          },
-        },
-      },
-      'otp',
-    ),
-    { interactive: [{ testID: 'otp' }] },
-  );
-  assert.throws(
-    () =>
-      replayTreeData(
-        {
-          ok: true,
-          data: { tree: null },
-          meta: {
-            treeVerdict: {
-              ...completeFilterVerdict,
-              state: 'degraded',
-              complete: false,
-              reasons: ['scan-budget-exhausted'],
-            },
-          },
-        },
-        'missing',
-      ),
-    (error) => error.code === 'EVAL_FAILED' && error.meta?.treeEnvelope?.incomplete === true,
-  );
-});
-
-test('replayTreeData refuses filtered evidence that cannot prove exact-id absence', () => {
+test('replayTreeData returns readable envelopes without exact-id verdict gating', () => {
+  // Exact-ID presence/absence is oracle-owned; the substring-filtered tree may
+  // no longer refuse readable data based on verdict quality or match content.
   const treeVerdict = {
     state: 'ok',
     path: 'filter',
@@ -238,10 +173,20 @@ test('replayTreeData refuses filtered evidence that cannot prove exact-id absenc
     collapsedChildLists: 0,
   };
   for (const envelope of [
+    { ok: true, data: { tree: { testID: 'otp', children: [] } }, meta: { treeVerdict } },
+    { ok: true, data: { tree: { name: 'otp-container', children: [] } }, meta: { treeVerdict } },
+    { ok: true, data: { tree: null }, meta: { treeVerdict } },
     {
       ok: true,
-      data: { tree: { name: 'otp-container', children: [] } },
-      meta: { treeVerdict },
+      data: { tree: null },
+      meta: {
+        treeVerdict: {
+          ...treeVerdict,
+          state: 'degraded',
+          complete: false,
+          reasons: ['scan-budget-exhausted'],
+        },
+      },
     },
     {
       ok: true,
@@ -250,31 +195,16 @@ test('replayTreeData refuses filtered evidence that cannot prove exact-id absenc
     },
     {
       ok: true,
-      data: { tree: null },
-      meta: { treeVerdict: { ...treeVerdict, complete: false, collapsedChildLists: 1 } },
-    },
-    {
-      ok: true,
-      data: { tree: null },
-      meta: { treeVerdict: { ...treeVerdict, rootsSeeded: 0 } },
-    },
-    {
-      ok: true,
-      data: { tree: null },
-      meta: { treeVerdict: { ...treeVerdict, complete: undefined } },
-    },
-    {
-      ok: true,
-      data: {
-        tree: { matches: Array.from({ length: 10 }, () => ({ testID: 'otp' })) },
-      },
+      data: { tree: { matches: Array.from({ length: 10 }, () => ({ testID: 'otp' })) } },
       meta: { treeVerdict },
     },
+    {
+      ok: true,
+      data: { interactive: [{ testID: 'otp' }] },
+      meta: { treeVerdict: { ...treeVerdict, path: 'interactive' } },
+    },
   ]) {
-    assert.throws(
-      () => replayTreeData(envelope, 'otp'),
-      (error) => error.code === 'EVAL_FAILED' && error.meta?.treeEnvelope?.incomplete === true,
-    );
+    assert.deepEqual(replayTreeData(envelope), envelope.data);
   }
 });
 
@@ -363,7 +293,7 @@ test('React replay refuses helper-truncated filtered evidence', async () => {
   assert.equal(replay.failureMeta?.treeEnvelope?.truncated, true);
 });
 
-test('React replay refuses budget-exhausted absence as incomplete evidence', async () => {
+test('React replay refuses oracle budget exhaustion distinctly from absence', async () => {
   const replay = await runCdpReplayCommands(
     [{ extendedWaitUntil: { visible: { id: 'otp' }, timeout: 250 } }],
     {},
@@ -382,14 +312,41 @@ test('React replay refuses budget-exhausted absence as incomplete evidence', asy
             },
           },
         }),
+      frontmostFor: async () => ({
+        visible: false,
+        code: 'ASSERTION_FAILED',
+        reason: 'frontmost testID scan exceeded its bounded React-tree budget',
+      }),
       launchApp: async () => {},
       settle: async () => {},
     },
   );
   assert.equal(replay.passed, false);
-  assert.equal(replay.failureCode, 'EVAL_FAILED');
-  assert.equal(replay.failureMeta?.treeEnvelope?.incomplete, true);
+  assert.equal(replay.failureCode, 'ASSERTION_FAILED');
+  assert.match(replay.reason ?? '', /bounded React-tree budget/);
   assert.equal(replay.failureMeta?.failedSelector, 'otp');
+});
+
+test('React replay refuses oracle renderer-coverage gaps distinctly from absence', async () => {
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp' }, timeout: 250 } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async () => ({ tree: null }),
+      frontmostFor: async () => ({
+        visible: false,
+        code: 'ASSERTION_FAILED',
+        reason: 'frontmost proof cannot cover every mounted renderer',
+      }),
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, false);
+  assert.equal(replay.failureCode, 'ASSERTION_FAILED');
+  assert.match(replay.reason ?? '', /cannot cover every mounted renderer/);
 });
 
 test('React replay propagates APP_HAS_REDBOX instead of reporting a missing testID', async () => {
@@ -431,6 +388,7 @@ test('disabled-guard fires on a node found through the getTree `.tree` wrapper',
       tree: { testID: 'save', disabled: true, children: [] },
       totalNodes: 1,
     }),
+    frontmostFor: async () => ({ visible: true, matchCount: 1 }),
     launchApp: async () => {},
     settle: async () => {},
   };
@@ -443,6 +401,7 @@ test('press refuses a child beneath pointerEvents none or box-only ancestors', a
   const base = {
     pressByTestId: async () => calls.push('press'),
     typeByTestId: async () => calls.push('type'),
+    frontmostFor: async () => ({ visible: true, matchCount: 1 }),
     launchApp: async () => {},
     settle: async () => {},
   };
@@ -470,6 +429,7 @@ test('text input preserves box-none and auto ancestors but rejects hidden hit-te
       pressByTestId: async () => {},
       typeByTestId: async () => calls.push('type'),
       treeFor: async () => tree(value),
+      frontmostFor: async () => ({ visible: true, matchCount: 1 }),
       launchApp: async () => {},
       settle: async () => {},
     });
@@ -485,27 +445,13 @@ test('target box-none refuses press and type without dispatch', async () => {
     pressByTestId: async () => calls.push('press'),
     typeByTestId: async () => calls.push('type'),
     treeFor: async () => ({ tree: { testID: 'target', props: { pointerEvents: 'box-none' } } }),
+    frontmostFor: async () => ({ visible: true, matchCount: 1 }),
     launchApp: async () => {},
     settle: async () => {},
   });
   await assert.rejects(dispatch.press('target'), /target has pointerEvents="box-none"/);
   await assert.rejects(dispatch.type('target', 'value'), /target has pointerEvents="box-none"/);
   assert.deepEqual(calls, []);
-});
-
-test('isExactPresent: verbatim testID match → true', () => {
-  assert.equal(isExactPresent(tree, 'tab-tasks'), true);
-});
-test('isExactPresent: absent testID → false', () => {
-  assert.equal(isExactPresent(tree, 'tab-feed'), false);
-});
-test('isExactPresent: substring / label / name coincidence → false (not a filtered hit)', () => {
-  assert.equal(isExactPresent(tree, 'tab'), false); // substring of tab-tasks
-  assert.equal(isExactPresent(tree, 'tab-tasks-label'), false); // label, not testID
-  assert.equal(isExactPresent(tree, 'SubmitButton'), false); // component name
-});
-test('collectTestIds gathers nested testIDs', () => {
-  assert.deepEqual([...collectTestIds(tree)].sort(), ['screen', 'tab-tasks']);
 });
 
 // Regression test for #317: disabled-guard must resolve nativeID-identified nodes
@@ -518,6 +464,7 @@ function deps(tree) {
     },
     typeByTestId: async () => {},
     treeFor: async () => tree,
+    frontmostFor: async () => ({ visible: true, matchCount: 1 }),
     launchApp: async () => {},
     settle: async () => {},
   };

--- a/packages/rn-dev-agent-core/test/unit/gh-708-mid-flow-relaunch.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-708-mid-flow-relaunch.test.ts
@@ -248,5 +248,6 @@ test('GH#708: maestro_run reports a passing relaunch flow as passing', async () 
 
   assert.equal(envelope.ok, true, `expected a passing run, got: ${JSON.stringify(envelope)}`);
   assert.equal(envelope.data.passed, true);
-  assert.equal(reproves, 1);
+  // Once for the failed relaunch, once before completing the deferred target.
+  assert.equal(reproves, 2);
 });

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -242,7 +242,10 @@ test('an omitted-timeout wait polls readable absence until the React target appe
       pressByTestId: async () => {},
       typeByTestId: async () => {},
       treeFor: async (id) => (++treeReads >= 3 ? { testID: id } : null),
-      frontmostFor: async () => ({ visible: true }),
+      frontmostFor: async () =>
+        treeReads >= 3
+          ? { visible: true, matchCount: 1 }
+          : { visible: false, matchCount: 0, reason: 'testID is not mounted' },
       launchApp: async () => {},
       settle: async () => {},
     },
@@ -266,6 +269,7 @@ test('an omitted-timeout wait preserves unreadable component-tree evidence', asy
           error: 'Component tree connection timed out',
           meta: { reconnectAttempted: true },
         }),
+      frontmostFor: async () => ({ visible: false }),
       launchApp: async () => {},
       settle: async () => {},
     },
@@ -290,7 +294,7 @@ test('ordinary missing React testID stays TESTID_NOT_FOUND without WDA', async (
       pressByTestId: async () => {},
       typeByTestId: async () => {},
       treeFor: async () => null,
-      frontmostFor: async () => ({ visible: false }),
+      frontmostFor: async () => ({ visible: false, matchCount: 0 }),
       launchApp: async () => {},
       settle: async () => {},
     }),
@@ -321,7 +325,8 @@ test('React stage failures retain completed tap and launch evidence', async () =
       pressByTestId: async (id) => calls.push(`press:${id}`),
       typeByTestId: async () => {},
       treeFor: async (id) => (id === 'missing' ? { tree: {} } : { testID: id }),
-      frontmostFor: async () => ({ visible: true }),
+      frontmostFor: async (id) =>
+        id === 'missing' ? { visible: false, matchCount: 0 } : { visible: true },
       launchApp: async () => calls.push('launch'),
       settle: async () => {},
     }),
@@ -1326,7 +1331,10 @@ test('a partitioned saved flow resumes at an omitted-timeout wait without replay
         treeReads += 1;
         return treeReads >= 3 ? { testID: id } : null;
       },
-      frontmostFor: async () => ({ visible: true }),
+      frontmostFor: async () =>
+        treeReads >= 3
+          ? { visible: true, matchCount: 1 }
+          : { visible: false, matchCount: 0, reason: 'testID is not mounted' },
       launchApp: async () => {},
       settle: async () => {},
     }),
@@ -1914,7 +1922,7 @@ test('partitioned React failures retain prior native proof evidence', async () =
       pressByTestId: async () => {},
       typeByTestId: async () => {},
       treeFor: async () => null,
-      frontmostFor: async () => ({ visible: false }),
+      frontmostFor: async () => ({ visible: false, matchCount: 0 }),
       launchApp: async () => {},
       settle: async () => {},
     }),

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -942,6 +942,19 @@ test('current-route ID is frontmost', () => {
   assert.equal(verdict.activeRoute, 'home');
 });
 
+test('frontmost exact-ID oracle carries disabled state from the matched fiber', () => {
+  const root = routeTree('save', 'home');
+  root.child.child.memoizedProps.accessibilityState = { disabled: true };
+  const sandbox = makeFrontmostSandbox(root, {
+    index: 0,
+    routes: [{ name: 'home' }],
+  });
+  const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost('save'));
+  assert.equal(verdict.visible, true);
+  assert.equal(verdict.disabled, true);
+  assert.equal(verdict.matchCount, 1);
+});
+
 test('frontmost exact matches refuse incomplete renderer coverage', () => {
   const root = routeTree('coverage', 'home');
   const rootWithoutTarget = routeTree('other', 'home');

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -14,7 +14,7 @@ import {
   executeMaestroAuthorityStages,
   runFlowParked,
 } from '../../dist/tools/maestro-run.js';
-import { runCdpReplayCommands } from '../../dist/tools/cdp-replay-dispatch.js';
+import { replayTreeData, runCdpReplayCommands } from '../../dist/tools/cdp-replay-dispatch.js';
 import { performReactTreeInput } from '../../dist/tools/device-interact.js';
 import { chooseMaestroDispatch } from '../../dist/tools/maestro-dispatch.js';
 import { buildReplayEngineStatus, MAESTRO_RUNNER_PIN } from '../../dist/domain/engine-pin.js';
@@ -233,6 +233,54 @@ test('mounted hidden extendedWaitUntil target is an assertion failure, not absen
   assert.match(replay.reason ?? '', /clipped/);
 });
 
+test('an omitted-timeout wait polls readable absence until the React target appears', async () => {
+  let treeReads = 0;
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp' } } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async (id) => (++treeReads >= 3 ? { testID: id } : null),
+      frontmostFor: async () => ({ visible: true }),
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, true);
+  assert.equal(treeReads, 3);
+  assert.ok(replay.steps[0]!.durationMs >= 350);
+});
+
+test('an omitted-timeout wait preserves unreadable component-tree evidence', async () => {
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp' } } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async () =>
+        replayTreeData({
+          ok: false,
+          code: 'RECONNECT_TIMEOUT',
+          error: 'Component tree connection timed out',
+          meta: { reconnectAttempted: true },
+        }),
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, false);
+  assert.equal(replay.failureCode, 'RECONNECT_TIMEOUT');
+  assert.equal(replay.failedStepIndex, 0);
+  assert.deepEqual(replay.failureMeta?.treeEnvelope, {
+    ok: false,
+    code: 'RECONNECT_TIMEOUT',
+    error: 'Component tree connection timed out',
+    meta: { reconnectAttempted: true },
+  });
+});
+
 test('ordinary missing React testID stays TESTID_NOT_FOUND without WDA', async () => {
   const handler = createMaestroRunHandler({
     chooseDispatch: () => {
@@ -252,8 +300,10 @@ test('ordinary missing React testID stays TESTID_NOT_FOUND without WDA', async (
       platform: 'ios',
       inlineYaml: `appId: com.example.app
 ---
-- assertVisible:
-    id: genuinely-missing
+- extendedWaitUntil:
+    visible:
+      id: genuinely-missing
+    timeout: 0
 `,
       ...callbacks,
     }),
@@ -284,8 +334,10 @@ test('React stage failures retain completed tap and launch evidence', async () =
 - tapOn:
     id: continue
 - launchApp: null
-- assertVisible:
-    id: missing
+- extendedWaitUntil:
+    visible:
+      id: missing
+    timeout: 0
 `,
     claimNativeOrigin: async () => {},
     completeNativeOrigin: async () => {},
@@ -302,7 +354,7 @@ test('React stage failures retain completed tap and launch evidence', async () =
   assert.deepEqual(calls, ['press:continue']);
   assert.deepEqual(
     env.meta?.steps?.map((step: { name: string }) => step.name),
-    ['launch', 'tap', 'launch', 'assert'],
+    ['launch', 'tap', 'launch', 'waitVisible'],
   );
 });
 
@@ -351,6 +403,19 @@ test('the real login shape partitions native prefix from exact React suffix', ()
       { domain: 'xctest-native', sourceIndices: [0, 1] },
       { domain: 'react-tree', sourceIndices: [2, 3, 4] },
     ],
+  );
+});
+
+test('an exact-id extended wait with omitted timeout plans in the React proof domain', () => {
+  const plan = planIosProofDomains(
+    [{ extendedWaitUntil: { visible: { id: 'otp_email-pressable' } } }],
+    {},
+  );
+  assert.equal(plan.ok, true);
+  if (!plan.ok) return;
+  assert.deepEqual(
+    plan.segments.map(({ domain, sourceIndices }) => ({ domain, sourceIndices })),
+    [{ domain: 'react-tree', sourceIndices: [0] }],
   );
 });
 
@@ -1189,6 +1254,75 @@ function nativeHandler(
   });
 }
 
+test('a partitioned saved flow resumes at an omitted-timeout wait without replaying its native prefix', async () => {
+  let nativeRuns = 0;
+  let treeReads = 0;
+  const mutations: string[] = [];
+  const handler = createMaestroRunHandler({
+    getActiveSession: () => ({
+      name: 'partitioned-otp-resume',
+      platform: 'ios',
+      deviceId: IOS_UDID,
+      appId: 'com.example.app',
+      openedAt: new Date(0).toISOString(),
+    }),
+    replayDeps: () => ({
+      pressByTestId: async (id) => mutations.push(id),
+      typeByTestId: async () => {},
+      treeFor: async (id) => {
+        treeReads += 1;
+        return treeReads >= 3 ? { testID: id } : null;
+      },
+      frontmostFor: async () => ({ visible: true }),
+      launchApp: async () => {},
+      settle: async () => {},
+    }),
+    chooseDispatch: () => nativeDispatch(),
+    parkFlow: async (run) => run(),
+    resolveEngineStatus: async () =>
+      buildReplayEngineStatus('pinned-ok', MAESTRO_RUNNER_PIN.version, false),
+    execFile: async () => {
+      nativeRuns += 1;
+      return {
+        stdout: nativeRunnerOutput('    ✓ assertVisible (0.1s)'),
+        stderr: '',
+      };
+    },
+  });
+  const env = envelope(
+    await handler({
+      platform: 'ios',
+      deviceId: IOS_UDID,
+      inlineYaml: `appId: com.example.app
+---
+- assertVisible: Native prefix
+- extendedWaitUntil:
+    visible:
+      id: otp_email-pressable
+- tapOn:
+    id: otp_email-pressable
+`,
+      ...callbacks,
+    }),
+  );
+  assert.equal(env.ok, true);
+  assert.equal(env.data?.proofDomain, 'partitioned');
+  assert.equal(nativeRuns, 1);
+  assert.deepEqual(mutations, ['otp_email-pressable']);
+  assert.deepEqual(
+    env.data?.steps.map((step: { index: number; verb: string; status: string }) => [
+      step.index,
+      step.verb,
+      step.status,
+    ]),
+    [
+      [0, 'assertVisible', 'pass'],
+      [1, 'waitVisible', 'pass'],
+      [2, 'tap', 'pass'],
+    ],
+  );
+});
+
 test('native-only blindness requires a WDA miss and same-screen native visibility', async () => {
   let comparisonRunnerStopped = false;
   const env = envelope(
@@ -1744,7 +1878,7 @@ test('partitioned React failures retain prior native proof evidence', async () =
     await handler({
       platform: 'ios',
       deviceId: IOS_UDID,
-      inlineYaml: `appId: com.example.app\n---\n- assertVisible: Native status\n- assertVisible:\n    id: missing-react-status\n`,
+      inlineYaml: `appId: com.example.app\n---\n- assertVisible: Native status\n- extendedWaitUntil:\n    visible:\n      id: missing-react-status\n    timeout: 0\n`,
       ...callbacks,
     }),
   );

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -1164,6 +1164,151 @@ test('stacked visible modal roots fail closed when ordering is unavailable', () 
   assert.equal(verdict.modalCount, 2);
 });
 
+// React double-buffers fibers: after a commit, a child collected from the
+// current tree can carry a .return pointing at an ancestor's alternate.
+function modalAlternateSubtree(root: any, testID: string) {
+  const modalHost: any = {
+    type: { displayName: 'RCTModalHostView' },
+    memoizedProps: { visible: true },
+    return: root,
+    child: null,
+    sibling: null,
+  };
+  const modalHostAlternate: any = {
+    type: { displayName: 'RCTModalHostView' },
+    memoizedProps: { visible: true },
+    return: root,
+    child: null,
+    sibling: null,
+  };
+  modalHost.alternate = modalHostAlternate;
+  modalHostAlternate.alternate = modalHost;
+  modalHost.child = {
+    type: { displayName: 'View' },
+    memoizedProps: { testID },
+    return: modalHostAlternate,
+    child: null,
+    sibling: null,
+  };
+  return modalHost;
+}
+
+function modalAlternateTree(testID: string) {
+  const root: any = {
+    type: { displayName: 'Root' },
+    memoizedProps: {},
+    return: null,
+    child: null,
+    sibling: null,
+  };
+  root.child = modalAlternateSubtree(root, testID);
+  return root;
+}
+
+test('a modal-hosted target reached through the host fiber alternate is frontmost', () => {
+  const root = modalAlternateTree('otp_email-pressable');
+  const sandbox = makeFrontmostSandbox(root, { index: 0, routes: [{ name: 'Home' }] });
+  const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost('otp_email-pressable'));
+  assert.equal(verdict.visible, true);
+  assert.equal(verdict.modalCount, 1);
+  assert.equal(verdict.matchCount, 1);
+});
+
+test('a target genuinely behind the active modal stays refused when the host has an alternate', () => {
+  const root = modalAlternateTree('otp_email-pressable');
+  root.child.sibling = {
+    type: { displayName: 'View' },
+    memoizedProps: { testID: 'behind_the_modal' },
+    return: root,
+    child: null,
+    sibling: null,
+  };
+  const sandbox = makeFrontmostSandbox(root, { index: 0, routes: [{ name: 'Home' }] });
+  const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost('behind_the_modal'));
+  assert.equal(verdict.visible, false);
+  assert.match(verdict.reason, /behind the active modal/);
+  assert.equal(verdict.matchCount, 1);
+});
+
+test('an ordinary non-modal target is unaffected by ancestor alternates', () => {
+  const root = routeTree('coverage', 'home');
+  const screen = root.child;
+  const screenAlternate: any = {
+    type: { displayName: 'Screen' },
+    memoizedProps: { route: { name: 'home' } },
+    return: root,
+    child: null,
+    sibling: null,
+  };
+  screen.alternate = screenAlternate;
+  screenAlternate.alternate = screen;
+  screen.child.return = screenAlternate;
+  const sandbox = makeFrontmostSandbox(root, { index: 0, routes: [{ name: 'home' }] });
+  const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost('coverage'));
+  assert.equal(verdict.visible, true);
+  assert.equal(verdict.matchCount, 1);
+});
+
+test('duplicate IDs in separate subtrees stay ambiguous when ancestors have alternates', () => {
+  const root = modalAlternateTree('otp_email-pressable');
+  const duplicate: any = {
+    type: { displayName: 'View' },
+    memoizedProps: { testID: 'otp_email-pressable' },
+    return: root,
+    child: null,
+    sibling: null,
+  };
+  root.child.sibling = duplicate;
+  const sandbox = makeFrontmostSandbox(root, { index: 0, routes: [{ name: 'Home' }] });
+  const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost('otp_email-pressable'));
+  assert.equal(verdict.visible, false);
+  assert.match(verdict.reason, /ambiguous across mounted React trees/);
+  assert.equal(verdict.matchCount, 2);
+});
+
+test('a delayed modal-hosted target becomes frontmost through the timed wait', async () => {
+  const root: any = {
+    type: { displayName: 'Root' },
+    memoizedProps: {},
+    return: null,
+    child: null,
+    sibling: null,
+  };
+  const home: any = {
+    type: { displayName: 'View' },
+    memoizedProps: { testID: 'open_otp' },
+    return: root,
+    child: null,
+    sibling: null,
+  };
+  root.child = home;
+  const modalHost = modalAlternateSubtree(root, 'otp_email-pressable');
+  const sandbox = makeFrontmostSandbox(root, { index: 0, routes: [{ name: 'Home' }] });
+  let polls = 0;
+  const absentVerdicts: string[] = [];
+  const replay = await runCdpReplayCommands(
+    [{ extendedWaitUntil: { visible: { id: 'otp_email-pressable' }, timeout: 2000 } }],
+    {},
+    {
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async (id: string) => JSON.parse(sandbox.__RN_AGENT.getTree({ filter: id })),
+      frontmostFor: async (id: string) => {
+        polls++;
+        if (polls === 3) home.sibling = modalHost;
+        const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost(id));
+        if (!verdict.visible) absentVerdicts.push(verdict.reason);
+        return verdict;
+      },
+      launchApp: async () => {},
+      settle: async () => {},
+    },
+  );
+  assert.equal(replay.passed, true);
+  assert.ok(polls >= 3, `expected the wait to poll through absence, saw ${polls} polls`);
+  assert.deepEqual([...new Set(absentVerdicts)], ['testID is not mounted']);
+});
+
 test('a matching route returned after the replay deadline cannot report success', async () => {
   let clock = 0;
   const handler = createMaestroRunHandler({

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -939,6 +939,7 @@ test('current-route ID is frontmost', () => {
 
 test('frontmost exact matches refuse incomplete renderer coverage', () => {
   const root = routeTree('coverage', 'home');
+  const rootWithoutTarget = routeTree('other', 'home');
   const sandbox = makeFrontmostSandbox(root, {
     index: 0,
     routes: [{ name: 'home' }],
@@ -965,13 +966,18 @@ test('frontmost exact matches refuse incomplete renderer coverage', () => {
   };
   const unscannedRegistry = {
     renderers: {
-      keys: () => new Map([[1, {}]]).keys(),
+      keys: () => new Map([[40, {}]]).keys(),
       forEach: (callback: (value: object, id: number) => void) => {
         callback({}, 1);
+        callback({}, 30);
         callback({}, 40);
       },
     },
-    getFiberRoots: (id: number) => (id === 1 ? new Set([{ current: root }]) : new Set()),
+    getFiberRoots: (id: number) => {
+      if (id === 1) return new Set([{ current: rootWithoutTarget }]);
+      if (id === 30) return new Set([{ current: root }]);
+      return new Set();
+    },
   };
   for (const hook of [incompleteRegistry, rendererError, unscannedRegistry]) {
     sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -217,7 +217,7 @@ test('React-only learned replay ignores native runtime pin drift', async () => {
 
 test('mounted hidden extendedWaitUntil target is an assertion failure, not absence', async () => {
   const replay = await runCdpReplayCommands(
-    [{ extendedWaitUntil: { visible: { id: 'clipped' }, timeout: 0 } }],
+    [{ extendedWaitUntil: { visible: { id: 'clipped' }, timeout: 250 } }],
     {},
     {
       pressByTestId: async () => {},
@@ -303,7 +303,7 @@ test('ordinary missing React testID stays TESTID_NOT_FOUND without WDA', async (
 - extendedWaitUntil:
     visible:
       id: genuinely-missing
-    timeout: 0
+    timeout: 250
 `,
       ...callbacks,
     }),
@@ -337,7 +337,7 @@ test('React stage failures retain completed tap and launch evidence', async () =
 - extendedWaitUntil:
     visible:
       id: missing
-    timeout: 0
+    timeout: 250
 `,
     claimNativeOrigin: async () => {},
     completeNativeOrigin: async () => {},
@@ -935,6 +935,53 @@ test('current-route ID is frontmost', () => {
   const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost('coverage'));
   assert.equal(verdict.visible, true);
   assert.equal(verdict.activeRoute, 'home');
+});
+
+test('frontmost exact matches refuse incomplete renderer coverage', () => {
+  const root = routeTree('coverage', 'home');
+  const sandbox = makeFrontmostSandbox(root, {
+    index: 0,
+    routes: [{ name: 'home' }],
+  });
+  const incompleteRegistry = {
+    renderers: {
+      keys: () => {
+        throw new Error('renderer registry is incomplete');
+      },
+      forEach: () => {},
+    },
+    getFiberRoots: (id: number) => (id === 1 ? new Set([{ current: root }]) : new Set()),
+  };
+  const rendererError = {
+    renderers: new Map([
+      [1, {}],
+      [2, {}],
+    ]),
+    getFiberRoots: (id: number) => {
+      if (id === 1) return new Set([{ current: root }]);
+      if (id === 2) throw new Error('renderer teardown');
+      return new Set();
+    },
+  };
+  const unscannedRegistry = {
+    renderers: {
+      keys: () => new Map([[1, {}]]).keys(),
+      forEach: (callback: (value: object, id: number) => void) => {
+        callback({}, 1);
+        callback({}, 40);
+      },
+    },
+    getFiberRoots: (id: number) => (id === 1 ? new Set([{ current: root }]) : new Set()),
+  };
+  for (const hook of [incompleteRegistry, rendererError, unscannedRegistry]) {
+    sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;
+    const verdict = JSON.parse(sandbox.__RN_AGENT.isTestIdFrontmost('coverage'));
+    assert.deepEqual(verdict, {
+      visible: false,
+      code: 'ASSERTION_FAILED',
+      reason: 'frontmost proof cannot cover every mounted renderer',
+    });
+  }
 });
 
 test('a target owned by an active ancestor route remains frontmost', () => {
@@ -1878,7 +1925,7 @@ test('partitioned React failures retain prior native proof evidence', async () =
     await handler({
       platform: 'ios',
       deviceId: IOS_UDID,
-      inlineYaml: `appId: com.example.app\n---\n- assertVisible: Native status\n- extendedWaitUntil:\n    visible:\n      id: missing-react-status\n    timeout: 0\n`,
+      inlineYaml: `appId: com.example.app\n---\n- assertVisible: Native status\n- extendedWaitUntil:\n    visible:\n      id: missing-react-status\n    timeout: 250\n`,
       ...callbacks,
     }),
   );

--- a/packages/rn-dev-agent-core/test/unit/partitioned-replay-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/partitioned-replay-authority.test.ts
@@ -412,11 +412,13 @@ function partitionedHandoffFixture(opts: {
     platform: 'ios' as const,
     deviceId: DEVICE_ID,
     appId: APP_ID,
+    timeoutMs: 5_000,
     inlineYaml: `appId: ${APP_ID}\n---\n- assertVisible: Native status\n- assertVisible:\n    id: react-status\n`,
     claimNativeOrigin: async () => {
       events.push('claim');
     },
-    completeNativeOrigin: async (targetExpected: boolean) => {
+    completeNativeOrigin: async (targetExpected: boolean, signal?: AbortSignal) => {
+      if (targetExpected) assert.equal(signal?.aborted, false);
       events.push(`complete:${targetExpected}`);
       if (targetExpected && !exactTargetConnected) {
         throw (
@@ -428,8 +430,9 @@ function partitionedHandoffFixture(opts: {
       }
     },
     relaunchManagedApp: async () => {},
-    reproveManagedOrigin: async ({ signal } = {}) => {
+    reproveManagedOrigin: async ({ readinessTimeoutMs, signal } = {}) => {
       assert.equal(signal?.aborted, false);
+      assert.ok(readinessTimeoutMs && readinessTimeoutMs <= 5_000);
       events.push('reprove');
       if (opts.reproveRestoresTarget) exactTargetConnected = true;
     },

--- a/packages/rn-dev-agent-core/test/unit/partitioned-replay-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/partitioned-replay-authority.test.ts
@@ -428,7 +428,8 @@ function partitionedHandoffFixture(opts: {
       }
     },
     relaunchManagedApp: async () => {},
-    reproveManagedOrigin: async () => {
+    reproveManagedOrigin: async ({ signal } = {}) => {
+      assert.equal(signal?.aborted, false);
       events.push('reprove');
       if (opts.reproveRestoresTarget) exactTargetConnected = true;
     },

--- a/packages/rn-dev-agent-core/test/unit/partitioned-replay-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/partitioned-replay-authority.test.ts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import type { CDPClient } from '../../dist/cdp-client.js';
 import { buildReplayEngineStatus, MAESTRO_RUNNER_PIN } from '../../dist/domain/engine-pin.js';
 import { createAuthorityGate } from '../../dist/session/authority-gate.js';
+import { SessionAuthorityError } from '../../dist/session/registry.js';
 import { withRecoveredAuthoritativeRuntime } from '../../dist/session/runtime-connection-recovery.js';
 import { chooseMaestroDispatch } from '../../dist/tools/maestro-dispatch.js';
 import { createMaestroRunHandler } from '../../dist/tools/maestro-run.js';
@@ -350,4 +351,172 @@ test('ungated mixed replay does not acquire nested native authority', async () =
     (error: { code?: string }) => error.code === 'METRO_ORIGIN_MISMATCH',
   );
   assert.equal(nativeDispatches, 0);
+});
+
+// The live gate contract for the partitioned native leg: completing the
+// deferred origin with a target expected re-proves the exact CDP session
+// target, and only reproveManagedOrigin (connectExactSessionTarget with a
+// readiness wait) restores it after a WDA-driven segment dropped it.
+function partitionedHandoffFixture(opts: {
+  reproveRestoresTarget: boolean;
+  execFile?: () => Promise<{ stdout: string; stderr: string }>;
+  droppedTargetError?: () => Error;
+}) {
+  const events: string[] = [];
+  const reactSuffixRan = () => events.some((event) => event.startsWith('react:'));
+  let exactTargetConnected = true;
+  const handler = createMaestroRunHandler({
+    getActiveSession: () => ({
+      name: 'partitioned-handoff',
+      platform: 'ios',
+      deviceId: DEVICE_ID,
+      appId: APP_ID,
+      openedAt: new Date(0).toISOString(),
+    }),
+    replayDeps: () => ({
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async (id: string) => ({ testID: id }),
+      frontmostFor: async (id: string) => {
+        assert.equal(exactTargetConnected, true, 'React replay ran on a dropped target');
+        events.push(`react:${id}`);
+        return { visible: true };
+      },
+      launchApp: async () => {},
+      settle: async () => {},
+    }),
+    chooseDispatch: () => dispatch(),
+    parkFlow: async (run, options) => {
+      events.push('park');
+      assert.ok(options.completeRunnerPark, 'nested run must forward completeRunnerPark');
+      await options.completeRunnerPark(options.signal);
+      try {
+        return await run();
+      } finally {
+        events.push('resume');
+      }
+    },
+    stopFastRunner: async () => {},
+    fastHealthCheck: async () => false,
+    resolveEngineStatus: async () =>
+      buildReplayEngineStatus('pinned-ok', MAESTRO_RUNNER_PIN.version, false),
+    execFile:
+      opts.execFile ??
+      (async () => {
+        events.push('execute');
+        exactTargetConnected = false;
+        return { stdout: runnerOutput(), stderr: '' };
+      }),
+  });
+  const args = {
+    platform: 'ios' as const,
+    deviceId: DEVICE_ID,
+    appId: APP_ID,
+    inlineYaml: `appId: ${APP_ID}\n---\n- assertVisible: Native status\n- assertVisible:\n    id: react-status\n`,
+    claimNativeOrigin: async () => {
+      events.push('claim');
+    },
+    completeNativeOrigin: async (targetExpected: boolean) => {
+      events.push(`complete:${targetExpected}`);
+      if (targetExpected && !exactTargetConnected) {
+        throw (
+          opts.droppedTargetError?.() ??
+          new Error(
+            'CDP_TARGET_AUTHORITY_MISMATCH: runtime reset did not reconnect the exact session target',
+          )
+        );
+      }
+    },
+    relaunchManagedApp: async () => {},
+    reproveManagedOrigin: async () => {
+      events.push('reprove');
+      if (opts.reproveRestoresTarget) exactTargetConnected = true;
+    },
+    completeRunnerPark: async () => {
+      events.push('runner-park');
+    },
+  };
+  return { handler, args, events, reactSuffixRan };
+}
+
+test('a partitioned native prefix survives park/resume and the React suffix completes', async () => {
+  const { handler, args, events } = partitionedHandoffFixture({
+    reproveRestoresTarget: true,
+  });
+  const envelope = JSON.parse((await handler(args)).content[0]!.text);
+
+  assert.equal(envelope.ok, true, envelope.error);
+  assert.equal(envelope.data?.passed, true);
+  assert.equal(envelope.data?.proofDomain, 'partitioned');
+  assert.deepEqual(envelope.data?.proofDomains, ['xctest-native', 'react-tree']);
+  assert.match(envelope.data?.output, /assertVisible/);
+  assert.deepEqual(
+    envelope.data?.steps.map((step: { index: number; status: string }) => [
+      step.index,
+      step.status,
+    ]),
+    [
+      [0, 'pass'],
+      [1, 'pass'],
+    ],
+  );
+  assert.deepEqual(events, [
+    'claim',
+    'park',
+    'runner-park',
+    'execute',
+    'resume',
+    'reprove',
+    'complete:true',
+    'claim',
+    'react:react-status',
+    'complete:true',
+  ]);
+});
+
+test('a residual handoff failure keeps the nested cause instead of the generic mask', async () => {
+  const { handler, args, events, reactSuffixRan } = partitionedHandoffFixture({
+    reproveRestoresTarget: false,
+  });
+  const envelope = JSON.parse((await handler(args)).content[0]!.text);
+
+  assert.equal(envelope.ok, false);
+  assert.match(envelope.error, /CDP_TARGET_AUTHORITY_MISMATCH/);
+  assert.equal(reactSuffixRan(), false);
+  assert.ok(events.includes('reprove'));
+});
+
+test('a session authority loss during the handoff escapes as a typed throw', async () => {
+  const authorityError = new SessionAuthorityError(
+    'CDP_TARGET_AUTHORITY_MISMATCH',
+    'session authority was lost during the handoff',
+  );
+  const { handler, args, reactSuffixRan } = partitionedHandoffFixture({
+    reproveRestoresTarget: false,
+    droppedTargetError: () => authorityError,
+  });
+  await assert.rejects(
+    () => handler(args),
+    (error: unknown) => error === authorityError && error instanceof SessionAuthorityError,
+  );
+  assert.equal(reactSuffixRan(), false);
+});
+
+test('a native prefix that genuinely fails before its first step is not rewritten', async () => {
+  const { handler, args, events, reactSuffixRan } = partitionedHandoffFixture({
+    reproveRestoresTarget: true,
+    execFile: async () => {
+      const error = new Error('maestro-runner exited 1 before any step output');
+      Object.assign(error, { code: 1, stdout: '', stderr: '' });
+      throw error;
+    },
+  });
+  const envelope = JSON.parse((await handler(args)).content[0]!.text);
+
+  assert.equal(envelope.ok, false);
+  assert.match(envelope.error, /exited 1 before any step output/);
+  assert.equal(envelope.meta?.terminal?.exitClass, 'before-first-step');
+  assert.equal(envelope.meta?.terminal?.completedSteps, 0);
+  assert.equal(reactSuffixRan(), false);
+  assert.deepEqual(events, ['claim', 'park', 'runner-park', 'complete:false', 'resume']);
 });

--- a/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
+++ b/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
@@ -215,16 +215,21 @@ test('run-action: first-attempt pass appends RunRecord with no auto-repair', asy
   );
 });
 
-test('run-action: forwards reprove abort options to session authority', async () => {
+test('run-action: forwards handoff cancellation to session authority', async () => {
   project.seedAction('demo', fixtureYaml({ id: 'demo', selectors: ['fab-create-task'] }));
   const flowAbort = new AbortController();
+  let receivedCompletion;
   let receivedReprove;
   const handler = createRunActionHandler({
     maestroRun: async (args) => {
       await args.reproveManagedOrigin({ signal: flowAbort.signal, readinessTimeoutMs: 123 });
+      await args.completeNativeOrigin(true, flowAbort.signal);
       return {
         content: [{ type: 'text', text: JSON.stringify(PASS_ENV) }],
       };
+    },
+    completeNativeOrigin: async (args, targetExpected, signal) => {
+      receivedCompletion = { args, targetExpected, signal };
     },
     reproveManagedOrigin: async (args, options) => {
       receivedReprove = { args, options };
@@ -237,6 +242,9 @@ test('run-action: forwards reprove abort options to session authority', async ()
   assert.equal(receivedReprove.args.actionId, 'demo');
   assert.equal(receivedReprove.options.signal, flowAbort.signal);
   assert.equal(receivedReprove.options.readinessTimeoutMs, 123);
+  assert.equal(receivedCompletion.args.actionId, 'demo');
+  assert.equal(receivedCompletion.targetExpected, true);
+  assert.equal(receivedCompletion.signal, flowAbort.signal);
 });
 
 test('cdp_run_action preserves a typed native-blind refusal', async () => {

--- a/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
+++ b/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
@@ -215,6 +215,29 @@ test('run-action: first-attempt pass appends RunRecord with no auto-repair', asy
   );
 });
 
+test('run-action: forwards reprove abort options to session authority', async () => {
+  project.seedAction('demo', fixtureYaml({ id: 'demo', selectors: ['fab-create-task'] }));
+  const flowAbort = new AbortController();
+  let receivedReprove;
+  const handler = createRunActionHandler({
+    maestroRun: async (args) => {
+      await args.reproveManagedOrigin({ signal: flowAbort.signal });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(PASS_ENV) }],
+      };
+    },
+    reproveManagedOrigin: async (args, options) => {
+      receivedReprove = { args, options };
+    },
+  });
+
+  const result = await handler({ actionId: 'demo', projectRoot: project.root });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(receivedReprove.args.actionId, 'demo');
+  assert.equal(receivedReprove.options.signal, flowAbort.signal);
+});
+
 test('cdp_run_action preserves a typed native-blind refusal', async () => {
   project.seedAction('demo', fixtureYaml({ id: 'demo', selectors: ['fab-create-task'] }));
   const handler = createRunActionHandler({

--- a/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
+++ b/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
@@ -221,7 +221,7 @@ test('run-action: forwards reprove abort options to session authority', async ()
   let receivedReprove;
   const handler = createRunActionHandler({
     maestroRun: async (args) => {
-      await args.reproveManagedOrigin({ signal: flowAbort.signal });
+      await args.reproveManagedOrigin({ signal: flowAbort.signal, readinessTimeoutMs: 123 });
       return {
         content: [{ type: 'text', text: JSON.stringify(PASS_ENV) }],
       };
@@ -236,6 +236,7 @@ test('run-action: forwards reprove abort options to session authority', async ()
   assert.equal(result.isError, undefined);
   assert.equal(receivedReprove.args.actionId, 'demo');
   assert.equal(receivedReprove.options.signal, flowAbort.signal);
+  assert.equal(receivedReprove.options.readinessTimeoutMs, 123);
 });
 
 test('cdp_run_action preserves a typed native-blind refusal', async () => {

--- a/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
@@ -82,6 +82,7 @@ test('getTree: healthy full walk carries verdict.state ok', () => {
   assert.equal(result.verdict.path, 'full');
   assert.deepEqual(result.verdict.reasons, []);
   assert.equal(result.verdict.rootsSeeded, 1);
+  assert.equal(result.verdict.rendererErrors, 0);
   assert.equal(result.verdict.complete, true);
 });
 
@@ -102,6 +103,7 @@ test('getTree: a throwing renderer degrades the verdict (renderer-error)', () =>
   const result = JSON.parse(sandbox.__RN_AGENT.getTree({ maxDepth: 4 }));
   assert.equal(result.verdict.state, 'degraded');
   assert.ok(result.verdict.reasons.includes('renderer-error'));
+  assert.equal(result.verdict.rendererErrors, 1);
   assert.equal(result.verdict.complete, false);
   assert.ok(result.tree, 'partial tree is still returned, just marked degraded');
 });

--- a/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
@@ -82,6 +82,7 @@ test('getTree: healthy full walk carries verdict.state ok', () => {
   assert.equal(result.verdict.path, 'full');
   assert.deepEqual(result.verdict.reasons, []);
   assert.equal(result.verdict.rootsSeeded, 1);
+  assert.equal(result.verdict.complete, true);
 });
 
 test('getTree: a throwing renderer degrades the verdict (renderer-error)', () => {
@@ -101,7 +102,7 @@ test('getTree: a throwing renderer degrades the verdict (renderer-error)', () =>
   const result = JSON.parse(sandbox.__RN_AGENT.getTree({ maxDepth: 4 }));
   assert.equal(result.verdict.state, 'degraded');
   assert.ok(result.verdict.reasons.includes('renderer-error'));
-  assert.ok(result.verdict.rendererErrors >= 1);
+  assert.equal(result.verdict.complete, false);
   assert.ok(result.tree, 'partial tree is still returned, just marked degraded');
 });
 
@@ -120,11 +121,12 @@ test('getTree: renderer registered beyond the legacy early-exit window is scanne
   );
   assert.ok(result.tree, 'tree from the high-id renderer is returned');
   assert.equal(result.verdict.state, 'ok');
+  assert.equal(result.verdict.complete, true);
   assert.ok(!result.verdict.reasons.includes('renderers-unscanned'));
   assert.deepEqual(result.verdict.unscannedRendererIds ?? [], []);
 });
 
-test('getTree: early root enumeration marks filtered absence incomplete', () => {
+test('getTree: exact renderer membership marks an unvisited target renderer incomplete', () => {
   const earlyFiber = userComp('EarlyRenderer', null);
   const lateFiber = {
     tag: 1,
@@ -136,14 +138,16 @@ test('getTree: early root enumeration marks filtered absence incomplete', () => 
   };
   const hook = {
     renderers: {
-      keys: () => {
-        throw new Error('renderer registry is incomplete');
+      keys: () => new Map([[40, {}]]).keys(),
+      forEach: (callback: (value: object, id: number) => void) => {
+        callback({}, 1);
+        callback({}, 30);
+        callback({}, 40);
       },
-      forEach: () => {},
     },
     getFiberRoots: (id: number) => {
       if (id === 1) return new Set([{ current: earlyFiber }]);
-      if (id === 9) return new Set([{ current: lateFiber }]);
+      if (id === 30) return new Set([{ current: lateFiber }]);
       return new Set();
     },
   };
@@ -151,7 +155,38 @@ test('getTree: early root enumeration marks filtered absence incomplete', () => 
   const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'late-target' }));
   assert.equal(result.tree, null);
   assert.equal(result.verdict.state, 'degraded');
-  assert.deepEqual(result.verdict.reasons, ['root-enumeration-incomplete']);
+  assert.deepEqual(result.verdict.reasons, ['renderers-unscanned']);
+  assert.deepEqual(result.verdict.unscannedRendererIds, [30]);
+  assert.equal(result.verdict.complete, false);
+});
+
+test('getTree: an unenumerable renderer registry refuses complete absence', () => {
+  const root = userComp('App', null);
+  const hook = {
+    renderers: {
+      keys: () => {
+        throw new Error('renderer registry is unreadable');
+      },
+      forEach: () => {},
+    },
+    getFiberRoots: (id: number) => (id === 1 ? new Set([{ current: root }]) : new Set()),
+  };
+  const sandbox = createSandbox({ hook });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'missing' }));
+  assert.equal(result.tree, null);
+  assert.equal(result.verdict.state, 'degraded');
+  assert.ok(result.verdict.reasons.includes('renderer-error'));
+  assert.equal(result.verdict.complete, false);
+});
+
+test('getTree: a fully scanned filtered absence is complete', () => {
+  const sandbox = createSandbox({ fiberRoot: userComp('App', null) });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'missing' }));
+  assert.equal(result.tree, null);
+  assert.equal(result.verdict.state, 'ok');
+  assert.deepEqual(result.verdict.reasons, []);
+  assert.equal(result.verdict.rootsSeeded, 1);
+  assert.equal(result.verdict.complete, true);
 });
 
 test('getTree: filter no-match after budget exhaustion is degraded, not a clean empty', () => {
@@ -165,6 +200,7 @@ test('getTree: filter no-match after budget exhaustion is degraded, not a clean 
   assert.equal(result.verdict.state, 'degraded');
   assert.ok(result.verdict.reasons.includes('scan-budget-exhausted'));
   assert.equal(result.verdict.path, 'filter');
+  assert.equal(result.verdict.complete, false);
 });
 
 test('getTree: depth-cap drops are counted in the verdict without flipping state', () => {
@@ -177,6 +213,7 @@ test('getTree: depth-cap drops are counted in the verdict without flipping state
   assert.equal(result.verdict.state, 'ok', 'a requested depth cap is not degradation');
   assert.ok(result.verdict.droppedSubtrees >= 1, 'but the drop must be visible');
   assert.equal(result.verdict.effectiveDepth, 2);
+  assert.equal(result.verdict.complete, false);
 });
 
 test('getTree: interactiveOnly cap marks the verdict degraded (scan-budget-exhausted)', () => {
@@ -207,6 +244,7 @@ test('getTree: interactiveOnly cap marks the verdict degraded (scan-budget-exhau
   assert.equal(result.verdict.state, 'degraded');
   assert.ok(result.verdict.reasons.includes('scan-budget-exhausted'));
   assert.equal(result.verdict.path, 'interactive');
+  assert.equal(result.verdict.complete, false);
 });
 
 test('getTree: missing hook fails with a no-renderer verdict', () => {
@@ -215,6 +253,7 @@ test('getTree: missing hook fails with a no-renderer verdict', () => {
   assert.ok(result.error);
   assert.equal(result.verdict.state, 'failed');
   assert.ok(result.verdict.reasons.includes('no-renderer'));
+  assert.equal(result.verdict.complete, false);
 });
 
 // ── cdp_component_tree renders the verdict as meta.treeVerdict ───────
@@ -224,7 +263,7 @@ test('component_tree: lifts the capture verdict into meta.treeVerdict', async ()
     tree: { component: 'App' },
     totalNodes: 12,
     rootsSeeded: 1,
-    verdict: { state: 'degraded', path: 'full', reasons: ['renderer-error'], rendererErrors: 1 },
+    verdict: { state: 'degraded', path: 'full', reasons: ['renderer-error'], complete: false },
   };
   const client = createMockClient({
     evaluate: async () => ({ value: JSON.stringify(payload) }),
@@ -235,6 +274,7 @@ test('component_tree: lifts the capture verdict into meta.treeVerdict', async ()
   assert.equal(env.ok, true);
   assert.equal(env.meta?.treeVerdict?.state, 'degraded');
   assert.deepEqual(env.meta?.treeVerdict?.reasons, ['renderer-error']);
+  assert.equal(env.meta?.treeVerdict?.complete, false);
   assert.equal(env.data.verdict, undefined, 'verdict renders once, in meta');
 });
 

--- a/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
@@ -124,6 +124,36 @@ test('getTree: renderer registered beyond the legacy early-exit window is scanne
   assert.deepEqual(result.verdict.unscannedRendererIds ?? [], []);
 });
 
+test('getTree: early root enumeration marks filtered absence incomplete', () => {
+  const earlyFiber = userComp('EarlyRenderer', null);
+  const lateFiber = {
+    tag: 1,
+    type: { displayName: 'LateRenderer' },
+    memoizedProps: { testID: 'late-target' },
+    child: null,
+    sibling: null,
+    return: null,
+  };
+  const hook = {
+    renderers: {
+      keys: () => {
+        throw new Error('renderer registry is incomplete');
+      },
+      forEach: () => {},
+    },
+    getFiberRoots: (id: number) => {
+      if (id === 1) return new Set([{ current: earlyFiber }]);
+      if (id === 9) return new Set([{ current: lateFiber }]);
+      return new Set();
+    },
+  };
+  const sandbox = createSandbox({ hook });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'late-target' }));
+  assert.equal(result.tree, null);
+  assert.equal(result.verdict.state, 'degraded');
+  assert.deepEqual(result.verdict.reasons, ['root-enumeration-incomplete']);
+});
+
 test('getTree: filter no-match after budget exhaustion is degraded, not a clean empty', () => {
   let node = null;
   for (let i = 0; i < 2500; i++) {

--- a/test-fixtures/managed-metro-expo55-dev-client/.rn-agent/actions/otp-omitted-timeout.yaml
+++ b/test-fixtures/managed-metro-expo55-dev-client/.rn-agent/actions/otp-omitted-timeout.yaml
@@ -4,7 +4,7 @@ appId: com.rndevagent.expo55devclient
 # intent: Complete the delayed OTP modal through an id-based wait with Maestro's default timeout.
 # tags: [auth, login, otp, regression]
 # mutates: false
-# status: active
+# status: experimental
 # enginePin: maestro-runner@1.1.24
 # appId: com.rndevagent.expo55devclient
 - assertVisible: Expo 55 dev client manifest fixture

--- a/test-fixtures/managed-metro-expo55-dev-client/.rn-agent/actions/otp-omitted-timeout.yaml
+++ b/test-fixtures/managed-metro-expo55-dev-client/.rn-agent/actions/otp-omitted-timeout.yaml
@@ -1,0 +1,21 @@
+appId: com.rndevagent.expo55devclient
+---
+# id: otp-omitted-timeout
+# intent: Complete the delayed OTP modal through an id-based wait with Maestro's default timeout.
+# tags: [auth, login, otp, regression]
+# mutates: false
+# status: active
+# enginePin: maestro-runner@1.1.24
+# appId: com.rndevagent.expo55devclient
+- assertVisible: Expo 55 dev client manifest fixture
+- tapOn: Open OTP
+- extendedWaitUntil:
+    visible:
+      id: otp_email-pressable
+- tapOn:
+    id: otp_email-pressable
+- inputText: "0451"
+- tapOn:
+    id: otp_submit
+- assertVisible:
+    id: otp_done

--- a/test-fixtures/managed-metro-expo55-dev-client/App.tsx
+++ b/test-fixtures/managed-metro-expo55-dev-client/App.tsx
@@ -9,6 +9,16 @@ import {
   type TextInput as TextInputHandle,
 } from 'react-native';
 
+(globalThis as typeof globalThis & {
+  __NAV_REF__: {
+    navigate: () => void;
+    getRootState: () => { index: number; routes: { name: string }[] };
+  };
+}).__NAV_REF__ = {
+  navigate: () => {},
+  getRootState: () => ({ index: 0, routes: [{ name: 'Home' }] }),
+};
+
 export default function App() {
   const [code, setCode] = useState('');
   const [done, setDone] = useState(false);

--- a/test-fixtures/managed-metro-expo55-dev-client/App.tsx
+++ b/test-fixtures/managed-metro-expo55-dev-client/App.tsx
@@ -9,12 +9,14 @@ import {
   type TextInput as TextInputHandle,
 } from 'react-native';
 
-(globalThis as typeof globalThis & {
-  __NAV_REF__: {
-    navigate: () => void;
-    getRootState: () => { index: number; routes: { name: string }[] };
-  };
-}).__NAV_REF__ = {
+(
+  globalThis as typeof globalThis & {
+    __NAV_REF__: {
+      navigate: () => void;
+      getRootState: () => { index: number; routes: { name: string }[] };
+    };
+  }
+).__NAV_REF__ = {
   navigate: () => {},
   getRootState: () => ({ index: 0, routes: [{ name: 'Home' }] }),
 };

--- a/test-fixtures/managed-metro-expo55-dev-client/App.tsx
+++ b/test-fixtures/managed-metro-expo55-dev-client/App.tsx
@@ -1,9 +1,87 @@
-import { Text, View } from 'react-native';
+import { useRef, useState } from 'react';
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type TextInput as TextInputHandle,
+} from 'react-native';
 
 export default function App() {
+  const [code, setCode] = useState('');
+  const [done, setDone] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
+  const inputRef = useRef<TextInputHandle>(null);
+
+  const openOtp = () => {
+    setCode('');
+    setDone(false);
+    setModalVisible(false);
+    setTimeout(() => setModalVisible(true), 5_000);
+  };
+
+  const submitOtp = () => {
+    if (code !== '0451') return;
+    setModalVisible(false);
+    setDone(true);
+  };
+
   return (
-    <View>
-      <Text>Expo 55 dev client manifest fixture</Text>
+    <View style={styles.screen}>
+      <Text style={styles.title}>Expo 55 dev client manifest fixture</Text>
+      <Pressable testID="open_otp" onPress={openOtp} style={styles.button}>
+        <Text style={styles.buttonText}>Open OTP</Text>
+      </Pressable>
+      {done ? <Text testID="otp_done">OTP complete</Text> : null}
+      <Modal visible={modalVisible} transparent animationType="none">
+        <View style={styles.backdrop}>
+          <View style={styles.card}>
+            <Text>Enter one-time code</Text>
+            <Pressable
+              testID="otp_email-pressable"
+              accessibilityLabel="otp_email-pressable"
+              onPress={() => inputRef.current?.focus()}
+              style={styles.inputWrapper}
+            >
+              <TextInput
+                ref={inputRef}
+                testID="otp_email"
+                value={code}
+                onChangeText={setCode}
+                keyboardType="number-pad"
+              />
+            </Pressable>
+            <Pressable testID="otp_submit" onPress={submitOtp} style={styles.button}>
+              <Text style={styles.buttonText}>Submit</Text>
+            </Pressable>
+            <Pressable testID="otp_cancel" onPress={() => setModalVisible(false)}>
+              <Text>Cancel</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
+  title: { fontSize: 18 },
+  backdrop: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+  },
+  card: { width: 280, gap: 16, padding: 24, borderRadius: 16, backgroundColor: 'white' },
+  inputWrapper: { minHeight: 48, justifyContent: 'center', padding: 12, borderWidth: 1 },
+  button: {
+    minHeight: 48,
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+    backgroundColor: 'black',
+  },
+  buttonText: { color: 'white', textAlign: 'center' },
+});


### PR DESCRIPTION
## Intent

Fix the candidate-side partitioned native-segment result loss that keeps rn-dev-agent PR 882 ('fix(core): resume id-based iOS waits through React-tree replay') from completing a genuine saved login action, shipping a new superseding PR whose branch starts from origin/main and advances to PR 882's exact head 090b4e018604853ba3d3dc55d155ec9c219f6d1f only by clean fast-forward; PR 881 and PR 882 must remain open and byte-untouched, and every PR 882 commit and pipeline fix is preserved beneath the new commit. Never merge the PR; the final exact remote head remains subject to independent Claude Opus 5 high local-Mac QA before merge. Independent QA proved the byte-identical six-step native flow passes standalone immediately before and after, while cdp_run_action's partitioned run executes the native prefix in the app but reports empty output, completedSteps 0, exitClass before-first-step across the runner park/resume handoff in packages/rn-dev-agent-core/src/tools/maestro-run.ts. Root cause localized before editing: the nested native-only handler (createMaestroRunHandler with replayDeps stripped) skipped reproveManagedOrigin because the deferred-origin guard required the local replayFactory; after the parked WDA-driven segment the exact CDP session target is dropped, so completeNativeOrigin(true) -> gate claimOrigin -> rebindSessionRuntime throws the plain 'CDP_TARGET_AUTHORITY_MISMATCH: runtime reset did not reconnect the exact session target', the catch discards the successful stage output (only MaestroStageExecutionError carries completedResults), and partialNativeFailureMessage masks the real cause with the generic 'Maestro flow failed: Native replay segment failed.'. The implemented minimum shared correction is exactly two changes in maestro-run.ts: (1) the deferred-origin guard now admits a caller-supplied reprove (args/deps reproveManagedOrigin) even without a local replayFactory, keeping the gate-symbol-derived reprove fenced behind replayFactory; (2) partialNativeFailureMessage takes the nested envelope's own error as the fallback headline (stripping one leading 'Maestro flow failed: ' prefix) so residual handoff failures stay attributable. Deliberate scope decisions: no catch-path rework to preserve successful stage output after a post-flow authority throw (pre-existing shared behavior on main's standalone path, deferred with written verdict); no launchApp-led drop/relaunch fixture case and no target-identity modeling in the new test fixture (owned by the PR 841 and authority-gate suites); no change to React input walk-up or WDA caching (separate owners); no new dependency or generalized orchestration layer; no external/upstream issues filed. Never fabricate completed steps from app state; preserve typed native failures, cancellation/timeout, cleanup, install receipts, runner ownership, empty-ledger truthfulness, and non-partitioned maestro_run behavior. Acceptance embodied in tests: the causal executable regression in test/unit/partitioned-replay-authority.test.ts fails at exact PR 882 head (verbatim reproducing the QA envelope error) and passes after the fix - a native prefix returns a successful non-empty result across park/resume, then the React-tree suffix runs to completion; controls keep a genuine before-first-step native failure truthful (numeric-exit error, empty output), assert a SessionAuthorityError escapes by object identity, pin runner-park forwarding before execute, and keep standalone native flows without result rewriting. The existing gh-708 mid-flow-relaunch reprove-count pin was deliberately updated from 1 to 2: the failed-relaunch recovery reprove plus the new deferred-target reprove (a redundant reprove is a safe reconnect; suppressing it risks reintroducing the mismatch). The commit also includes the required one-sentence changeset (patch bumps rn-dev-agent-core and rn-dev-agent-plugin), regenerated committed host runtime bundles for claude-plugin and codex-plugin, and an AGENTS.md bullet recording the handoff contract.

## What Changed

- Replay `assertVisible` and `extendedWaitUntil` through deadline-bounded React-tree polling with Maestro-compatible timeout semantics and structured failure diagnostics.
- Use the injected exact-ID oracle for presence and frontmost proof, including fail-closed renderer coverage and modal-host fiber alternate handling.
- Re-prove the exact CDP target after partitioned native runner handoffs, forwarding the remaining deadline and cancellation so successful native prefixes continue into React-tree suffixes.

## Risk Assessment

✅ Low: No source-verifiable defect or intent contradiction remains; target reproof, deadline propagation, completion cancellation, error attribution, ancestry, and untouched open PR heads all align with the required contract.

## Testing

No prior baseline results were supplied; focused core tests, executable API evidence, ancestry checks, and open-PR checks all passed. No screenshot was captured because this is non-visual authority-handoff behavior and the rn-dev-agent session had no bound device; the direct `maestro_run`-handler transcript is the reviewer-visible product evidence.

<details>
<summary>Evidence: Partitioned handoff API transcript</summary>

```text
{
  "interface": "createMaestroRunHandler / maestro_run response",
  "requestFlow": [
    "native assertVisible text",
    "React-tree assertVisible id=react-status"
  ],
  "response": {
    "ok": true,
    "data": {
      "passed": true,
      "flowFile": "/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/rn-maestro-run-1788090926125-qgqgss.yaml",
      "platform": "ios",
      "runner": "partitioned",
      "transport": "partitioned",
      "transportVersion": "1.1.24",
      "proofDomain": "partitioned",
      "proofDomains": [
        "xctest-native",
        "react-tree"
      ],
      "maestroCertified": false,
      "reactTreeProof": {
        "nativeInteractionFidelity": false,
        "covers": [
          "exact-react-identity",
          "controlled-fiber-text-readback"
        ],
        "excludes": [
          "ime-composition",
          "password-autofill",
          "keyboard-occlusion"
        ]
      },
      "steps": [
        {
          "index": 0,
          "name": "assertVisible",
          "verb": "assertVisible",
          "status": "pass",
          "durationMs": 100
        },
        {
          "index": 1,
          "name": "assert",
          "verb": "assert",
          "status": "pass",
          "durationMs": 0
        }
      ],
      "output": "Single device execution mode\nUsing specified iOS device: EVIDENCE-IOS-SIMULATOR\nBuilding WDA for device EVIDENCE-IOS-SIMULATOR (team ID: )\nStarting WDA on device EVIDENCE-IOS-SIMULATOR (port: 8447)\n    ✓ assertVisible (0.1s)",
      "timedOut": false,
      "outputTruncated": false
    }
  },
  "handoffEvents": [
    "native origin claimed",
    "runner parked",
    "runner park authority completed",
    "native prefix executed",
    "runner resumed",
    "exact CDP target re-proved (budget=4998ms)",
    "native origin completed (targetExpected=true)",
    "native origin claimed",
    "react-tree suffix: react-status",
    "native origin completed (targetExpected=true)"
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"561a4be78b0214102a6902261f672a5c79ce9ef2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `packages/rn-dev-agent-core/src/tools/maestro-run.ts:1592` - Bound the newly admitted nested re-prove by the flow deadline. This call supplies no AbortSignal, and cdp_run_action wraps reproveManagedOrigin as a zero-argument callback, so if the exact target remains absent, reconnectSessionRuntime can wait its full 120-second readiness budget after a much shorter action timeout has expired. Forward flowAbort.signal here and preserve the options through run-action.ts callbacks.

🔧 Fix: Bound deferred origin reproof to flow deadline
2 errors still open:

- 🚨 `packages/rn-dev-agent-core/src/tools/maestro-run.ts:1596` - The new signal bounds only the caller&#39;s await. `reconnectSessionRuntime` races the signal but leaves `connectExactSessionTarget` running with its default platform readiness budget. With 100 ms remaining and no target, the flow times out and invalidates origin while the reconnect can continue for roughly 120 seconds and later mutate the global CDP client during another operation. Propagate the remaining flow budget through `readinessTimeoutMs`, or make exact-target discovery genuinely abortable at its shared boundary.
- 🚨 `packages/rn-dev-agent-core/src/tools/maestro-run.ts:1598` - Forward `flowAbort.signal` to `completeOrigin`. If re-proving finishes just before the deadline and the timer fires before completion, `completeOrigin(true)` invokes the authority claim without a signal, allowing postflight probes and binding refresh to outlive the flow deadline and potentially return a passing result after timeout. Call `completeOrigin(true, flowAbort.signal)`.

🔧 Fix: Bound deferred handoff to flow deadline
2 errors still open:

- 🚨 `packages/rn-dev-agent-core/src/tools/maestro-run.ts:1599` - `readinessTimeoutMs` does not bound an in-flight iOS target probe: `listTargetsExact` calls `discoverExactPort`, whose fetch can run for 3 seconds independently of this deadline. With 100 ms remaining, the flow can time out while that reconnect continues against the newly installed global CDP client and later mutates it during another operation. Make exact-target discovery genuinely abortable or generation-fenced at the shared connection boundary.
- 🚨 `packages/rn-dev-agent-core/src/tools/run-action.ts:784` - The new `completeOrigin(true, flowAbort.signal)` signal is discarded by both `cdp_run_action` wrappers, which call `completeNativeOrigin(args, targetExpected)` without forwarding it. If the deadline fires during postflight origin probes or binding refresh, completion can outlive the flow and still return success. Add the optional signal to `RunActionDeps.completeNativeOrigin` and forward it in both wrappers.

🔧 Fix: Forwarded run-action completion cancellation
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `corepack yarn build:core`
- `node --test --test-concurrency=1 packages/rn-dev-agent-core/test/unit/partitioned-replay-authority.test.ts packages/rn-dev-agent-core/test/unit/gh-708-mid-flow-relaunch.test.ts packages/rn-dev-agent-core/test/unit/run-action-handler.test.js`
- <code>Executed a `node --input-type=module` harness against the compiled `createMaestroRunHandler` interface and captured its API response plus handoff event order</code>
- <code>Validated the evidence JSON with `jq`, including `ok: true`, both proof domains, and two passing steps</code>
- <code>`cdp_status(platform=&#34;ios&#34;)` confirmed no device or runtime was bound for live-device verification</code>
- <code>Verified commit ancestry from PR 882’s exact head with `git merge-base --is-ancestor` and `git rev-list`; inspected PR 881 and PR 882 using `gh-axi pr view` and confirmed both remain open and unmerged</code>
- <code>Removed generated `packages/rn-dev-agent-core/dist/` output and confirmed the worktree is clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
