### PR TITLE
fix(core): reuse WebDriverAgent builds across runner spawns

### DIFF
--- a/.changeset/wda-cache-store-reuse.md
+++ b/.changeset/wda-cache-store-reuse.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Reuse completed WebDriverAgent builds across maestro-runner spawns through a toolchain-fingerprinted persistent store with atomic publication, removing the ~75 s per-invocation WDA rebuild while keeping per-spawn cache isolation, corruption fallback, and cold-build behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,10 +212,13 @@ alive for such callers.
   persistent store
   `.wda-store-<runner>/<host platform-architecture>/<xcode fingerprint>/`
   beside the pin-cache (atomic staged-rename publication; delete the store to
-  force a cold build). Seeding must stay AFTER the snapshot seal walk: recursive
-  `readdirSync` descends through the `cache` symlink, and sealed seed content
-  breaks the runner's warm-path xctestrun port rewrite (EACCES, four retries,
-  bootstrap failure).
+  force a cold build). Persist only contained `DerivedData/Build/Products`;
+  normalize the xctestrun port and exclude logs and other run-owned state.
+  Completeness is the runner-selected WDA target with its referenced products
+  and executable present. Seeding must stay AFTER the snapshot seal walk:
+  recursive `readdirSync` descends through the `cache` symlink, and sealed seed
+  content breaks the runner's warm-path xctestrun port rewrite (EACCES, four
+  retries, bootstrap failure).
 - Claude-only host behavior: edit `packages/claude-plugin/`.
 - Codex-only host behavior: edit `packages/codex-plugin/`.
 - Host-neutral workflow knowledge: edit `packages/shared-agent-knowledge/`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,9 +209,10 @@ alive for such callers.
   failure) withhold the qualifier regardless of row states.
 - WDA build persistence has one owner: the best-effort seed/publish pair around
   the per-spawn runner cache in `src/domain/engine-pin.ts`, backed by the
-  persistent store `.wda-store-<runner>/<xcode fingerprint>/` beside the
-  pin-cache (atomic staged-rename publication; delete the store to force a cold
-  build). Seeding must stay AFTER the snapshot seal walk: recursive
+  persistent store
+  `.wda-store-<runner>/<host platform-architecture>/<xcode fingerprint>/`
+  beside the pin-cache (atomic staged-rename publication; delete the store to
+  force a cold build). Seeding must stay AFTER the snapshot seal walk: recursive
   `readdirSync` descends through the `cache` symlink, and sealed seed content
   breaks the runner's warm-path xctestrun port rewrite (EACCES, four retries,
   bootstrap failure).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,14 @@ alive for such callers.
   ledger evidence and any unclean or incomplete termination provenance
   (unfinalized artifact, truncation, signal, timeout, bootstrap/transport
   failure) withhold the qualifier regardless of row states.
+- WDA build persistence has one owner: the best-effort seed/publish pair around
+  the per-spawn runner cache in `src/domain/engine-pin.ts`, backed by the
+  persistent store `.wda-store-<runner>/<xcode fingerprint>/` beside the
+  pin-cache (atomic staged-rename publication; delete the store to force a cold
+  build). Seeding must stay AFTER the snapshot seal walk: recursive
+  `readdirSync` descends through the `cache` symlink, and sealed seed content
+  breaks the runner's warm-path xctestrun port rewrite (EACCES, four retries,
+  bootstrap failure).
 - Claude-only host behavior: edit `packages/claude-plugin/`.
 - Codex-only host behavior: edit `packages/codex-plugin/`.
 - Host-neutral workflow knowledge: edit `packages/shared-agent-knowledge/`,

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -477,9 +477,10 @@ per-spawn WDA cache and removes it with the runner snapshot after the attempt.
 Completed WDA builds are kept in a persistent store next to the pin-cache
 (`.wda-store-<runner version>/<host platform-architecture>/<xcode fingerprint>/`)
 and seed later compatible spawns best-effort, so subsequent invocations can
-reuse a completed build instead of rebuilding. A seeding failure falls back to
-a cold build; a publication failure leaves the current run result intact but
-may make a later invocation build cold again. If a reused build misbehaves,
+reuse a completed build instead of rebuilding. Incomplete, corrupt, or
+incompatible entries are skipped and rebuild cold. A seeding failure also falls
+back to a cold build; a publication failure leaves the current run result intact
+but may make a later invocation build cold again. If a reused build misbehaves,
 delete that store directory to force a cold rebuild.
 Re-run the replay (bootstrap retries itself), check network access, and re-run
 setup to verify the pin-cache maestro-runner. If the failure detail includes

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -474,6 +474,12 @@ The iOS Maestro driver (WebDriverAgent) failed to bootstrap before the
 first replay step ran, so the flow was refused and no self-repair was attempted.
 The verified runner payload remains sealed; rn-dev-agent provisions a separate
 per-spawn WDA cache and removes it with the runner snapshot after the attempt.
+Completed WDA builds are kept in a persistent store next to the pin-cache
+(`.wda-store-<runner version>/<xcode fingerprint>/`) and seed later compatible
+spawns best-effort, so subsequent invocations can reuse a completed build
+instead of rebuilding; a run that cannot seed or publish falls back to a cold
+build. If a reused build misbehaves, delete that store directory to force a
+cold rebuild.
 Re-run the replay (bootstrap retries itself), check network access, and re-run
 setup to verify the pin-cache maestro-runner. If the failure detail includes
 `RUNNER_CACHE_UNAVAILABLE`, verify that the runner cache parent is writable;

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -475,8 +475,8 @@ first replay step ran, so the flow was refused and no self-repair was attempted.
 The verified runner payload remains sealed; rn-dev-agent provisions a separate
 per-spawn WDA cache and removes it with the runner snapshot after the attempt.
 Completed WDA builds are kept in a persistent store next to the pin-cache
-(`.wda-store-<runner version>/<xcode fingerprint>/`) and seed later compatible
-spawns best-effort, so subsequent invocations can reuse a completed build
+(`.wda-store-<runner version>/<host platform-architecture>/<xcode fingerprint>/`)
+and seed later compatible spawns best-effort, so subsequent invocations can reuse a completed build
 instead of rebuilding; a run that cannot seed or publish falls back to a cold
 build. If a reused build misbehaves, delete that store directory to force a
 cold rebuild.

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -476,10 +476,11 @@ The verified runner payload remains sealed; rn-dev-agent provisions a separate
 per-spawn WDA cache and removes it with the runner snapshot after the attempt.
 Completed WDA builds are kept in a persistent store next to the pin-cache
 (`.wda-store-<runner version>/<host platform-architecture>/<xcode fingerprint>/`)
-and seed later compatible spawns best-effort, so subsequent invocations can reuse a completed build
-instead of rebuilding; a run that cannot seed or publish falls back to a cold
-build. If a reused build misbehaves, delete that store directory to force a
-cold rebuild.
+and seed later compatible spawns best-effort, so subsequent invocations can
+reuse a completed build instead of rebuilding. A seeding failure falls back to
+a cold build; a publication failure leaves the current run result intact but
+may make a later invocation build cold again. If a reused build misbehaves,
+delete that store directory to force a cold rebuild.
 Re-run the replay (bootstrap retries itself), check network access, and re-run
 setup to verify the pin-cache maestro-runner. If the failure detail includes
 `RUNNER_CACHE_UNAVAILABLE`, verify that the runner cache parent is writable;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -59311,15 +59311,16 @@ function wdaToolchainFingerprint() {
   }
   return memoizedWdaToolchainFingerprint;
 }
-function persistentWdaStoreBuildsRoot() {
+function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
-  if (!fingerprint)
+  if (!fingerprint || !pinArchiveCoords(platformKey))
     return null;
   const versionsRoot = runnerCacheVersionsRoot();
   const components = [
     join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
-    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
-    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint, "wda-builds")
   ];
   for (const component of components) {
     try {
@@ -59330,7 +59331,7 @@ function persistentWdaStoreBuildsRoot() {
       break;
     }
   }
-  return components[2];
+  return components[3];
 }
 function isCompleteWdaBuild(keyDir) {
   try {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -58727,7 +58727,7 @@ import { spawnSync } from "node:child_process";
 import { createHash as createHash7 } from "node:crypto";
 import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { basename as basename5, dirname as dirname11, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
+import { basename as basename5, dirname as dirname11, isAbsolute as isAbsolute5, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 // packages/rn-dev-agent-core/dist/experience/runner-diagnostics.js
@@ -59354,28 +59354,50 @@ function readWdaXctestrun(xctestrunPath) {
     return null;
   }
 }
+function asWdaPlistRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
 function forEachWdaTestTarget(plist, visit) {
   const configurations = plist.TestConfigurations;
   if (Array.isArray(configurations)) {
     for (const configuration of configurations) {
-      if (configuration === null || typeof configuration !== "object")
+      const configurationRecord = asWdaPlistRecord(configuration);
+      if (!configurationRecord)
         continue;
-      const targets = configuration.TestTargets;
+      const targets = configurationRecord.TestTargets;
       if (!Array.isArray(targets))
         continue;
       for (const target of targets) {
-        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
-          visit(target);
-        }
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord)
+          visit(targetRecord);
       }
     }
     return;
   }
   for (const [key, target] of Object.entries(plist)) {
-    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
-      visit(target);
-    }
+    const targetRecord = asWdaPlistRecord(target);
+    if (key !== "__xctestrun_metadata__" && targetRecord)
+      visit(targetRecord);
   }
+}
+function findWdaTestTarget(plist) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      const targets = asWdaPlistRecord(configuration)?.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord && (targetRecord.TestTargetName === "WebDriverAgentRunner" || targetRecord.BlueprintName === "WebDriverAgentRunner")) {
+          return targetRecord;
+        }
+      }
+    }
+    return null;
+  }
+  return asWdaPlistRecord(plist.WebDriverAgentRunner);
 }
 function hasInjectedWdaPort(plist) {
   let found = false;
@@ -59387,24 +59409,79 @@ function hasInjectedWdaPort(plist) {
   });
   return found;
 }
-function isCompleteWdaBuild(keyDir) {
-  try {
-    const products = join25(keyDir, "DerivedData", "Build", "Products");
-    const entries = readdirSync7(products, { withFileTypes: true });
-    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join25(products, entry.name)) !== null) && entries.some((entry) => {
-      if (!entry.isDirectory())
-        return false;
-      try {
-        const executable = lstatSync7(join25(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
-        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
-      } catch {
+function isWithinWdaKey(keyDir, candidate) {
+  const path = relative3(keyDir, candidate);
+  return path === "" || path !== ".." && !path.startsWith(`..${sep4}`) && !isAbsolute5(path);
+}
+function isContainedWdaProductTree(keyDir, products) {
+  const lexicalKey = resolve4(keyDir);
+  const realKey = realpathSync7(keyDir);
+  const visit = (directory) => {
+    for (const entry of readdirSync7(directory, { withFileTypes: true })) {
+      const path = join25(directory, entry.name);
+      const stat2 = lstatSync7(path);
+      if (stat2.isSymbolicLink()) {
+        const target = readlinkSync3(path);
+        if (isAbsolute5(target) || !isWithinWdaKey(lexicalKey, resolve4(directory, target)) || !isWithinWdaKey(realKey, realpathSync7(path))) {
+          return false;
+        }
+      } else if (stat2.isDirectory() && !visit(path)) {
         return false;
       }
-    });
-  } catch {
-    return false;
+    }
+    return true;
+  };
+  return visit(products);
+}
+function resolveWdaProductReference(reference, products, testHost) {
+  if (typeof reference !== "string")
+    return null;
+  if (reference.startsWith("__TESTROOT__/")) {
+    return resolve4(products, reference.slice("__TESTROOT__/".length));
   }
+  if (testHost && reference.startsWith("__TESTHOST__/")) {
+    return resolve4(testHost, reference.slice("__TESTHOST__/".length));
+  }
+  return null;
+}
+function readCompleteWdaBuildManifest(keyDir) {
+  try {
+    const derivedData = join25(keyDir, "DerivedData");
+    const build = join25(derivedData, "Build");
+    const products = join25(build, "Products");
+    if (!isRealDirectory(keyDir) || !isRealDirectory(derivedData) || !isRealDirectory(build) || !isRealDirectory(products) || !isContainedWdaProductTree(keyDir, products)) {
+      return null;
+    }
+    const selected = readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)[0];
+    if (!selected?.isFile())
+      return null;
+    const selectedXctestrun = join25(products, selected.name);
+    const plist = readWdaXctestrun(selectedXctestrun);
+    const target = plist && findWdaTestTarget(plist);
+    if (!target)
+      return null;
+    const testHost = resolveWdaProductReference(target.TestHostPath, products);
+    if (!testHost)
+      return null;
+    const hostPath = relative3(products, testHost).split(sep4);
+    if (hostPath.length !== 2 || hostPath[1] !== "WebDriverAgentRunner-Runner.app" || !isRealDirectory(join25(products, hostPath[0])) || !isRealDirectory(testHost)) {
+      return null;
+    }
+    const executable = lstatSync7(join25(testHost, "WebDriverAgentRunner-Runner"));
+    if (!executable.isFile() || executable.isSymbolicLink() || (executable.mode & 73) === 0) {
+      return null;
+    }
+    const testBundle = resolveWdaProductReference(target.TestBundlePath, products, testHost);
+    if (!testBundle || !isWithinWdaKey(resolve4(keyDir), testBundle) || !existsSync18(testBundle)) {
+      return null;
+    }
+    return { products, selectedXctestrun };
+  } catch {
+    return null;
+  }
+}
+function isCompleteWdaBuild(keyDir) {
+  return readCompleteWdaBuildManifest(keyDir) !== null;
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const plist = readWdaXctestrun(xctestrunPath);
@@ -59428,10 +59505,10 @@ function isRealDirectory(path) {
   }
 }
 function copyReusableWdaBuild(sourceKey, stagedKey) {
-  const sourceProducts = join25(sourceKey, "DerivedData", "Build", "Products");
-  if (!isRealDirectory(sourceKey) || !isRealDirectory(join25(sourceKey, "DerivedData")) || !isRealDirectory(join25(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+  const manifest = readCompleteWdaBuildManifest(sourceKey);
+  if (!manifest)
     return false;
-  }
+  const sourceProducts = manifest.products;
   const stagedProducts = join25(stagedKey, "DerivedData", "Build", "Products");
   mkdirSync12(dirname11(stagedProducts), { recursive: true });
   cpSync2(sourceProducts, stagedProducts, {
@@ -62246,7 +62323,7 @@ init_process_birth();
 import { execFileSync as execFileSync10, spawn as spawn6 } from "node:child_process";
 import { createHash as createHash10, createHmac as createHmac2, timingSafeEqual as timingSafeEqual4 } from "node:crypto";
 import { closeSync as closeSync5, existsSync as existsSync22, fstatSync as fstatSync3, mkdirSync as mkdirSync15, openSync as openSync5, readFileSync as readFileSync22, readSync as readSync2, realpathSync as realpathSync10, rmSync as rmSync10 } from "node:fs";
-import { dirname as dirname13, isAbsolute as isAbsolute5, join as join29, relative as relative4, resolve as resolve7 } from "node:path";
+import { dirname as dirname13, isAbsolute as isAbsolute6, join as join29, relative as relative4, resolve as resolve7 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/authority-json.js
 var intrinsicJsonStringify = JSON.stringify;
@@ -64348,7 +64425,7 @@ async function stopManagedMetroWithEvidence(binding, input, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/package-integration.js
 import { closeSync as closeSync6, constants as constants5, fstatSync as fstatSync4, lstatSync as lstatSync10, openSync as openSync6, readFileSync as readFileSync23 } from "node:fs";
-import { basename as basename6, isAbsolute as isAbsolute6, join as join30, relative as relative5, resolve as resolve8, sep as sep5 } from "node:path";
+import { basename as basename6, isAbsolute as isAbsolute7, join as join30, relative as relative5, resolve as resolve8, sep as sep5 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/metro-authority.js
 import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
@@ -68265,7 +68342,7 @@ function assertBoundCleanup(result) {
 }
 function assertNoSymlinkPath(root, candidate) {
   const child = relative5(root, candidate);
-  if (child === ".." || child.startsWith(`..${sep5}`) || isAbsolute6(child)) {
+  if (child === ".." || child.startsWith(`..${sep5}`) || isAbsolute7(child)) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration path escapes the app root");
   }
   let current = root;
@@ -68717,7 +68794,7 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname15, isAbsolute as isAbsolute8, join as join34, resolve as resolve11 } from "node:path";
+import { dirname as dirname15, isAbsolute as isAbsolute9, join as join34, resolve as resolve11 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { createHash as createHash13 } from "node:crypto";
 
@@ -68726,7 +68803,7 @@ init_metro_cwd();
 import { createHash as createHash11, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
 import { execFileSync as execFileSync11 } from "node:child_process";
 import { closeSync as closeSync7, constants as constants6, existsSync as existsSync23, fstatSync as fstatSync5, lstatSync as lstatSync11, openSync as openSync7, readdirSync as readdirSync8, readFileSync as readFileSync24, readlinkSync as readlinkSync4, readSync as readSync3, realpathSync as realpathSync11 } from "node:fs";
-import { dirname as dirname14, isAbsolute as isAbsolute7, join as join31, relative as relative6, resolve as resolve9 } from "node:path";
+import { dirname as dirname14, isAbsolute as isAbsolute8, join as join31, relative as relative6, resolve as resolve9 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
   const hash = createHash11("sha256");
@@ -68903,7 +68980,7 @@ function updateDependencyPath(hash, path, label, state) {
 }
 function isContained(root, candidate) {
   const child = relative6(root, candidate);
-  return child !== ".." && !child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) && !isAbsolute7(child);
+  return child !== ".." && !child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) && !isAbsolute8(child);
 }
 function isExcludedRuntimePath(root, candidate) {
   const entry = relative6(root, candidate).split("\\").join("/");
@@ -69288,7 +69365,7 @@ ${stderr}`.toLowerCase().includes("not a git repository");
 }
 function assertContained(root, candidate, code) {
   const child = relative6(root, candidate);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute7(child)) {
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute8(child)) {
     throw new Error(`${code}: path is outside the declared content root`);
   }
 }
@@ -69331,7 +69408,7 @@ function resolveSourceIdentity(inputRoot, dependencies = {}) {
     const contentRoot = canonicalize(git2(appRoot, ["rev-parse", "--show-toplevel"]));
     assertContained(contentRoot, appRoot, "APP_ROOT_OUTSIDE_WORKTREE");
     const commonRaw = git2(appRoot, ["rev-parse", "--git-common-dir"]);
-    const commonDirectory = canonicalize(isAbsolute7(commonRaw) ? commonRaw : join31(appRoot, commonRaw));
+    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join31(appRoot, commonRaw));
     const head = git2(appRoot, ["rev-parse", "HEAD"]);
     const appRelative = relative6(contentRoot, appRoot) || ".";
     return {
@@ -70270,7 +70347,7 @@ function sessionSourceResolver(status, dependencies) {
   return (root) => resolveSourceIdentity(root, stored?.kind === "declared-root" ? { declaredRoot: stored.contentRoot, declaredManifests: stored.declaredManifests } : {});
 }
 function anchorDeclaredProjectRoot(status, projectRoot) {
-  if (isAbsolute8(projectRoot))
+  if (isAbsolute9(projectRoot))
     return projectRoot;
   const boundAppRoot = status.source?.appRoot;
   return typeof boundAppRoot === "string" && boundAppRoot.length > 0 ? resolve11(boundAppRoot, projectRoot) : projectRoot;
@@ -72857,7 +72934,7 @@ init_rn_android_runner_client();
 
 // packages/rn-dev-agent-core/dist/observability/recorder.js
 import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSync6, openSync as openSync8, readSync as readSync4 } from "node:fs";
-import { isAbsolute as isAbsolute9 } from "node:path";
+import { isAbsolute as isAbsolute10 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/util/redact.js
 import { homedir as homedir7 } from "node:os";
@@ -73146,7 +73223,7 @@ var SHOT_REGISTRY_CAP = 64;
 function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute9(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+  return typeof p === "string" && isAbsolute10(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
 }
 function readShotBounded(p) {
   let fd;
@@ -73230,7 +73307,7 @@ var Recorder = class {
    * whatever path the pipeline actually captured to.
    */
   registerCapturedScreenshot(p) {
-    if (typeof p !== "string" || !isAbsolute9(p))
+    if (typeof p !== "string" || !isAbsolute10(p))
       return;
     this.trustedShotPaths.delete(p);
     this.trustedShotPaths.add(p);
@@ -74397,7 +74474,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/action-store.js
 import { existsSync as existsSync26, lstatSync as lstatSync15, readFileSync as readFileSync27, statSync as statSync13, unlinkSync as unlinkSync12 } from "node:fs";
-import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute12, join as join38, relative as relative8, resolve as resolve15, sep as sep8 } from "node:path";
+import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute13, join as join38, relative as relative8, resolve as resolve15, sep as sep8 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
@@ -74851,7 +74928,7 @@ var atomicWriter = {
 init_process_birth();
 import { execFileSync as execFileSync14 } from "node:child_process";
 import { lstatSync as lstatSync13 } from "node:fs";
-import { isAbsolute as isAbsolute10, join as join36 } from "node:path";
+import { isAbsolute as isAbsolute11, join as join36 } from "node:path";
 function createUnfollowedFileSnapshot(directoryPath, directoryIdentity) {
   return { directoryPath, directoryIdentity, fileIdentities: /* @__PURE__ */ new Map() };
 }
@@ -75037,7 +75114,7 @@ function readUnfollowedFiles(directoryPath, identity2, relativePaths, expectedId
       throw new Error("Selected file identities did not match the requested paths.");
     }
     const entries = relativePaths.map((relativePath, index) => {
-      if (isAbsolute10(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
+      if (isAbsolute11(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
         throw new Error(`Invalid relative path: ${relativePath}.`);
       }
       if (expectedIdentities) {
@@ -75134,7 +75211,7 @@ init_maestro_validator();
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
 import { spawnSync as spawnSync3 } from "node:child_process";
 import { closeSync as closeSync10, constants as constants9, existsSync as existsSync25, fstatSync as fstatSync8, lstatSync as lstatSync14, mkdirSync as mkdirSync18, openSync as openSync10, readFileSync as readFileSync26, readlinkSync as readlinkSync5, realpathSync as realpathSync12, renameSync as renameSync8, statSync as statSync12, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
-import { dirname as dirname18, isAbsolute as isAbsolute11, join as join37, relative as relative7, resolve as resolve14, sep as sep7 } from "node:path";
+import { dirname as dirname18, isAbsolute as isAbsolute12, join as join37, relative as relative7, resolve as resolve14, sep as sep7 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
 var WORKTREE_REPAIR_ENTRY = '"${CLAUDE_PLUGIN_ROOT:-${RN_DEV_AGENT_CODEX_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:?set it to the installed rn-dev-agent plugin root, then re-run}}}/rn-dev-agent-core/dist/worktree-inheritance.js"';
@@ -75193,7 +75270,7 @@ function contained(parent, child) {
   if (parent === child)
     return true;
   const rel = relative7(parent, child);
-  return rel !== "" && !rel.startsWith(`..${sep7}`) && rel !== ".." && !isAbsolute11(rel);
+  return rel !== "" && !rel.startsWith(`..${sep7}`) && rel !== ".." && !isAbsolute12(rel);
 }
 function toPosix(path) {
   return sep7 === "/" ? path : path.split(sep7).join("/");
@@ -75329,7 +75406,7 @@ function resolveWorktreeLayout(input) {
 }
 function classifySource(path, type, boundary) {
   const rel = relative7(boundary, path);
-  if (rel === ".." || rel.startsWith(`..${sep7}`) || isAbsolute11(rel)) {
+  if (rel === ".." || rel.startsWith(`..${sep7}`) || isAbsolute12(rel)) {
     return { state: "WRONG_TYPE" };
   }
   const paths = [boundary];
@@ -75943,11 +76020,11 @@ function ownedActionPathIdentityMatches(entries) {
   }
 }
 function referencedActionPath(parentFile, reference) {
-  if (isAbsolute12(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
+  if (isAbsolute13(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
     return null;
   }
   const child = join38(dirname19(parentFile), reference);
-  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child))
+  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child))
     return null;
   return child;
 }
@@ -76182,7 +76259,7 @@ function captureActionFromContext(context, actionId) {
       flowRoot: snapshot.directory,
       readFileFn: (path) => {
         const child = relative8(snapshot.directory, path);
-        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child)) {
+        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child)) {
           throw new Error(`Refusing action flow outside ${snapshot.directory}.`);
         }
         const text2 = context.fileContents.get(child);
@@ -78427,7 +78504,7 @@ function maestroAuthorityRefusal(authority, underlyingError) {
 import { existsSync as existsSync28, readFileSync as readFileSync28, readdirSync as readdirSync11, realpathSync as realpathSync14, rmSync as rmSync11 } from "node:fs";
 import { createHash as createHash14 } from "node:crypto";
 import { tmpdir as tmpdir8 } from "node:os";
-import { isAbsolute as isAbsolute13, join as join41, sep as sep9 } from "node:path";
+import { isAbsolute as isAbsolute14, join as join41, sep as sep9 } from "node:path";
 var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
 var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
 var WEAK_DEVICE_ID_KEYS = ["id"];
@@ -78578,7 +78655,7 @@ function readStructuredFlowArtifact(reportDir, previous) {
     if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
       return unfinalized;
     const normalizedDataFile = flow.dataFile;
-    if (isAbsolute13(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
       return unfinalized;
     }
     const realDataFile = realpathSync14(join41(reportDir, normalizedDataFile));
@@ -85815,7 +85892,7 @@ function createDeviceRecordHandler(deps = {}) {
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
 import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute14, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
+import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute15, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
@@ -86344,7 +86421,7 @@ function readStartupIntegrityAttestation() {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-var absolutePathSchema = external_exports.string().min(1).refine(isAbsolute14, "path must be absolute");
+var absolutePathSchema = external_exports.string().min(1).refine(isAbsolute15, "path must be absolute");
 var beginRehearsalSchema = external_exports.object({
   action: external_exports.literal("begin_rehearsal"),
   projectRoot: absolutePathSchema,
@@ -86469,7 +86546,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let loadedCoreBundlePath = null;
   let coreBundleSha256 = null;
   try {
-    if (typeof argv[1] === "string" && isAbsolute14(argv[1])) {
+    if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
       executedEntrypointPath = realpathSync15(argv[1]);
     }
   } catch {
@@ -86507,7 +86584,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   const authorityArg = argv[1];
-  if (typeof authorityArg !== "string" || !isAbsolute14(authorityArg))
+  if (typeof authorityArg !== "string" || !isAbsolute15(authorityArg))
     return null;
   let arg;
   try {
@@ -86556,7 +86633,7 @@ function proofCandidateStartupMatches(entrypoint, startup, headCoreBundleSha256)
 }
 function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   const normalizedOverride = (value) => {
-    if (!value || !isAbsolute14(value))
+    if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
       return realpathSync15(value);
@@ -86695,11 +86772,11 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
   }
 }
 function isNormalizedDescendant(root, path) {
-  if (!isAbsolute14(root) || !isAbsolute14(path) || resolve17(root) !== root || resolve17(path) !== path) {
+  if (!isAbsolute15(root) || !isAbsolute15(path) || resolve17(root) !== root || resolve17(path) !== path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute14(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
   const parts = relative9(root, path).split(sep10);
@@ -86748,7 +86825,7 @@ function proofRootExists(args) {
   }
 }
 function resolveProofWorktreeRoot(detectedProjectRoot) {
-  if (!detectedProjectRoot || !isAbsolute14(detectedProjectRoot) || resolve17(detectedProjectRoot) !== detectedProjectRoot) {
+  if (!detectedProjectRoot || !isAbsolute15(detectedProjectRoot) || resolve17(detectedProjectRoot) !== detectedProjectRoot) {
     return null;
   }
   try {
@@ -86756,7 +86833,7 @@ function resolveProofWorktreeRoot(detectedProjectRoot) {
       cwd: detectedProjectRoot,
       encoding: "utf8"
     }).trim();
-    return root && isAbsolute14(root) && resolve17(root) === root ? root : null;
+    return root && isAbsolute15(root) && resolve17(root) === root ? root : null;
   } catch {
     return null;
   }
@@ -87083,7 +87160,7 @@ function createProofCaptureHandler(deps) {
     ].map((path) => repositoryPath(active, path));
     const requiredOutputs = new Set(phase === "finalized" ? [...proofOutputs, repositoryPath(active, active.context.receiptPath)] : proofOutputs);
     const allowedOutputs = phase === "setup" ? observedSetupScreenshots(active) : phase === "clean" ? /* @__PURE__ */ new Set() : requiredOutputs;
-    const invalidChange = git2.changes.some((change) => isAbsolute14(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
+    const invalidChange = git2.changes.some((change) => isAbsolute15(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
     const changedPaths = new Set(git2.changes.map((change) => change.path.replaceAll("\\", "/")));
     const unrelated = [...changedPaths].some((path) => !allowedOutputs.has(path));
     const missing = (phase === "validation" || phase === "finalized") && [...requiredOutputs].some((path) => !changedPaths.has(path));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -58723,8 +58723,9 @@ function projectRootFromYaml(yamlFilePath) {
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
 init_process_birth();
+import { spawnSync } from "node:child_process";
 import { createHash as createHash7 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9 } from "node:fs";
+import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename5, dirname as dirname11, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -59297,6 +59298,135 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error2));
   }
 }
+var memoizedWdaToolchainFingerprint;
+function wdaToolchainFingerprint() {
+  if (memoizedWdaToolchainFingerprint !== void 0)
+    return memoizedWdaToolchainFingerprint;
+  try {
+    const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
+    const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
+    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+  } catch {
+    memoizedWdaToolchainFingerprint = null;
+  }
+  return memoizedWdaToolchainFingerprint;
+}
+function persistentWdaStoreBuildsRoot() {
+  const fingerprint = wdaToolchainFingerprint();
+  if (!fingerprint)
+    return null;
+  const versionsRoot = runnerCacheVersionsRoot();
+  const components = [
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+  ];
+  for (const component of components) {
+    try {
+      const stat2 = lstatSync7(component);
+      if (!stat2.isDirectory() || stat2.isSymbolicLink())
+        return null;
+    } catch {
+      break;
+    }
+  }
+  return components[2];
+}
+function isCompleteWdaBuild(keyDir) {
+  try {
+    const products = join25(keyDir, "DerivedData", "Build", "Products");
+    const entries = readdirSync7(products, { withFileTypes: true });
+    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
+      if (!name.endsWith(".app"))
+        return false;
+      try {
+        const executable = lstatSync7(join25(products, entry.name, name, name.slice(0, -".app".length)));
+        return executable.isFile() && !executable.isSymbolicLink();
+      } catch {
+        return false;
+      }
+    }));
+  } catch {
+    return false;
+  }
+}
+function copyWdaBuildKey(sourceKey, stagedKey) {
+  cpSync2(sourceKey, stagedKey, {
+    recursive: true,
+    mode: constants2.COPYFILE_FICLONE,
+    verbatimSymlinks: true
+  });
+  return isCompleteWdaBuild(stagedKey);
+}
+function seedRunnerSnapshotCacheFromStore(cacheRoot) {
+  let seeded = 0;
+  try {
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    const target = join25(cacheRoot, "wda-builds");
+    for (const entry of readdirSync7(storeBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory())
+        continue;
+      const sourceKey = join25(storeBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      mkdirSync12(target, { recursive: true });
+      const stagedKey = join25(target, `.seed-${entry.name}`);
+      try {
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          renameSync4(stagedKey, join25(target, entry.name));
+          seeded += 1;
+        } else {
+          rmSync6(stagedKey, { recursive: true, force: true });
+        }
+      } catch {
+        try {
+          rmSync6(stagedKey, { recursive: true, force: true });
+        } catch {
+        }
+      }
+    }
+  } catch {
+  }
+  return seeded;
+}
+function publishRunnerSnapshotCacheToStore(cacheRoot) {
+  let published = 0;
+  try {
+    const spawnBuilds = join25(cacheRoot, "wda-builds");
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    for (const entry of readdirSync7(spawnBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith("."))
+        continue;
+      const sourceKey = join25(spawnBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      const storeKey = join25(storeBuilds, entry.name);
+      if (isCompleteWdaBuild(storeKey))
+        continue;
+      mkdirSync12(storeBuilds, { recursive: true, mode: 448 });
+      const stage = mkdtempSync(join25(storeBuilds, ".stage-"));
+      try {
+        const stagedKey = join25(stage, entry.name);
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          if (existsSync18(storeKey)) {
+            const evicted = join25(stage, "evicted");
+            renameSync4(storeKey, evicted);
+          }
+          renameSync4(stagedKey, storeKey);
+          published += 1;
+        }
+      } finally {
+        rmSync6(stage, { recursive: true, force: true });
+      }
+    }
+  } catch {
+  }
+  return published;
+}
 function provisionRunnerSnapshotCache(snapshotRoot, testHooks = {}, setOwnedCacheRoot = () => {
 }) {
   const cacheRoot = expectedRunnerCacheRoot(snapshotRoot);
@@ -59417,8 +59547,12 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       }
     }
     chmodSync4(snapshotRoot, 320);
-    if (cacheRoot)
+    if (cacheRoot) {
       assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+      recordRunnerDiagnostic("cache-seed", {
+        seededBuilds: seedRunnerSnapshotCacheFromStore(cacheRoot)
+      });
+    }
     const openedRunner = lstatSync7(snapshotRunner);
     recordRunnerDiagnostic("runner-exec-begin", { runnerPinVersion: MAESTRO_RUNNER_PIN.version });
     if (platform === "ios") {
@@ -59444,6 +59578,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync4(entryPath, 384);
       }
     } catch {
+    }
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
@@ -59607,14 +59746,14 @@ import { join as join28 } from "node:path";
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn5 } from "node:child_process";
 import { randomUUID as randomUUID7 } from "node:crypto";
-import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync5, rmSync as rmSync8, writeFileSync as writeFileSync10 } from "node:fs";
+import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync6, rmSync as rmSync8, writeFileSync as writeFileSync10 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
 import { join as join27 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync4, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync9 } from "node:fs";
+import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync5, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync9 } from "node:fs";
 import { join as join26, resolve as resolve5 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
@@ -61003,7 +61142,7 @@ function sendOperation(directory, request2, timeoutMs) {
   const requestPath2 = join27(directory.worker.controlPath, `${prefix}.request`);
   const responsePath = join27(directory.worker.controlPath, `${prefix}.response`);
   writeFileSync10(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
-  renameSync5(pendingPath, requestPath2);
+  renameSync6(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
     throw new Error("SESSION_INTEGRATION_WORKER_TIMEOUT");
   }
@@ -62080,7 +62219,7 @@ function canonicalAuthorityJson(value) {
 }
 
 // packages/rn-dev-agent-core/dist/session/managed-metro-enforcement.js
-import { spawnSync } from "node:child_process";
+import { spawnSync as spawnSync2 } from "node:child_process";
 import { createHash as createHash9 } from "node:crypto";
 import { closeSync as closeSync4, constants as constants4, existsSync as existsSync21, mkdirSync as mkdirSync14, openSync as openSync4, readFileSync as readFileSync21, realpathSync as realpathSync9, rmSync as rmSync9, statSync as statSync9, symlinkSync as symlinkSync2, writeSync as writeSync2 } from "node:fs";
 import { dirname as dirname12, resolve as resolve6 } from "node:path";
@@ -62090,7 +62229,7 @@ function sha256(value) {
   return createHash9("sha256").update(value).digest("hex");
 }
 function defaultRun2(command, args) {
-  const result = spawnSync(command, [...args], {
+  const result = spawnSync2(command, [...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     timeout: 25e3
@@ -74142,7 +74281,7 @@ import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute12
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync11, renameSync as renameSync6, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
+import { writeFileSync as writeFileSync11, renameSync as renameSync7, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
 import { dirname as dirname17, basename as basename7 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -74446,7 +74585,7 @@ var atomicWriter = {
   },
   /** Underlying `fs.renameSync(from, to)`. */
   _rename(from, to) {
-    renameSync6(from, to);
+    renameSync7(from, to);
   },
   /** Underlying `fs.statSync(path).mtimeMs`. */
   _statMtimeMs(path) {
@@ -74873,8 +75012,8 @@ function listUnfollowedDirectory(directoryPath, identity2) {
 init_maestro_validator();
 
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
-import { spawnSync as spawnSync2 } from "node:child_process";
-import { closeSync as closeSync10, constants as constants9, existsSync as existsSync25, fstatSync as fstatSync8, lstatSync as lstatSync14, mkdirSync as mkdirSync18, openSync as openSync10, readFileSync as readFileSync26, readlinkSync as readlinkSync5, realpathSync as realpathSync12, renameSync as renameSync7, statSync as statSync12, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
+import { spawnSync as spawnSync3 } from "node:child_process";
+import { closeSync as closeSync10, constants as constants9, existsSync as existsSync25, fstatSync as fstatSync8, lstatSync as lstatSync14, mkdirSync as mkdirSync18, openSync as openSync10, readFileSync as readFileSync26, readlinkSync as readlinkSync5, realpathSync as realpathSync12, renameSync as renameSync8, statSync as statSync12, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
 import { dirname as dirname18, isAbsolute as isAbsolute11, join as join37, relative as relative7, resolve as resolve14, sep as sep7 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
@@ -74913,7 +75052,7 @@ function gitEnvironment() {
   return env;
 }
 function git(cwd, args) {
-  const result = spawnSync2("git", args, {
+  const result = spawnSync3("git", args, {
     cwd,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -75423,7 +75562,7 @@ function isTracked(worktreeRoot, relativePath) {
   return listed.ok && listed.stdout.trim().length > 0;
 }
 function isIgnoreSafe(worktreeRoot, relativePath) {
-  const result = spawnSync2("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
+  const result = spawnSync3("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
     cwd: worktreeRoot,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -82201,7 +82340,7 @@ import { promisify as promisify19 } from "node:util";
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash16, randomBytes as randomBytes7, randomUUID as randomUUID10 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync8, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync13 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync13 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname22, join as join43 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -82502,7 +82641,7 @@ var ExperienceRecorder = class {
         flag: "wx",
         mode: 384
       });
-      renameSync8(temp, this.path);
+      renameSync9(temp, this.path);
       chmodSync7(this.path, 384);
     } catch (error2) {
       try {
@@ -82831,7 +82970,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   }
   const temporary = join43(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
   writeFileSync13(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
-  renameSync8(temporary, outputPath);
+  renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
@@ -85555,7 +85694,7 @@ function createDeviceRecordHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync9, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
 import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute14, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
@@ -86639,7 +86778,7 @@ function writeProofReceiptAtomic(path, receipt2) {
     fsyncSync(descriptor);
     closeSync11(descriptor);
     descriptor = null;
-    renameSync9(temporary, path);
+    renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -92258,7 +92397,7 @@ init_sources();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname30, join as join56 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash22 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
@@ -92310,7 +92449,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
   };
   const tmp = `${filePath}.tmp`;
   writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
+  renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
@@ -92513,7 +92652,7 @@ function createLockE2eTestHandler(deps = {}) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join58 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -92574,7 +92713,7 @@ function writeJsonAtomic(file, value) {
   mkdirSync23(join58(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync11(tmp, file);
+  renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
   const file = join58(e2eRunsDirFor(projectRoot), "index.json");
@@ -92622,7 +92761,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -92641,7 +92780,7 @@ function writeRequest(projectRoot, req) {
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync12(tmp, file);
+  renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -58725,7 +58725,7 @@ function projectRootFromYaml(yamlFilePath) {
 init_process_birth();
 import { spawnSync } from "node:child_process";
 import { createHash as createHash7 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9 } from "node:fs";
+import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename5, dirname as dirname11, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -59350,13 +59350,68 @@ function isCompleteWdaBuild(keyDir) {
     return false;
   }
 }
-function copyWdaBuildKey(sourceKey, stagedKey) {
-  cpSync2(sourceKey, stagedKey, {
+function removeInjectedWdaPort(xctestrunPath) {
+  const source = readFileSync17(xctestrunPath, "utf8");
+  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
+  if (normalized.includes("USE_PORT"))
+    return false;
+  if (normalized !== source)
+    writeFileSync9(xctestrunPath, normalized);
+  return true;
+}
+function isRealDirectory(path) {
+  try {
+    const stat2 = lstatSync7(path);
+    return stat2.isDirectory() && !stat2.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function copyReusableWdaBuild(sourceKey, stagedKey) {
+  const sourceProducts = join25(sourceKey, "DerivedData", "Build", "Products");
+  if (!isRealDirectory(sourceKey) || !isRealDirectory(join25(sourceKey, "DerivedData")) || !isRealDirectory(join25(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+    return false;
+  }
+  const stagedProducts = join25(stagedKey, "DerivedData", "Build", "Products");
+  mkdirSync12(dirname11(stagedProducts), { recursive: true });
+  cpSync2(sourceProducts, stagedProducts, {
     recursive: true,
     mode: constants2.COPYFILE_FICLONE,
     verbatimSymlinks: true
   });
+  for (const entry of readdirSync7(stagedProducts, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".xctestrun") && !removeInjectedWdaPort(join25(stagedProducts, entry.name))) {
+      return false;
+    }
+  }
   return isCompleteWdaBuild(stagedKey);
+}
+function isReusableStoredWdaBuild(keyDir) {
+  try {
+    if (!isCompleteWdaBuild(keyDir))
+      return false;
+    const keyEntries = readdirSync7(keyDir, { withFileTypes: true });
+    const derivedData = keyEntries[0];
+    if (keyEntries.length !== 1 || derivedData?.name !== "DerivedData" || !derivedData.isDirectory()) {
+      return false;
+    }
+    const derivedDataEntries = readdirSync7(join25(keyDir, "DerivedData"), { withFileTypes: true });
+    const build = derivedDataEntries[0];
+    if (derivedDataEntries.length !== 1 || build?.name !== "Build" || !build.isDirectory()) {
+      return false;
+    }
+    const buildEntries = readdirSync7(join25(keyDir, "DerivedData", "Build"), {
+      withFileTypes: true
+    });
+    const productsEntry = buildEntries[0];
+    if (buildEntries.length !== 1 || productsEntry?.name !== "Products" || !productsEntry.isDirectory()) {
+      return false;
+    }
+    const products = join25(keyDir, "DerivedData", "Build", "Products");
+    return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync17(join25(products, entry.name), "utf8").includes("USE_PORT"));
+  } catch {
+    return false;
+  }
 }
 function seedRunnerSnapshotCacheFromStore(cacheRoot) {
   let seeded = 0;
@@ -59374,7 +59429,7 @@ function seedRunnerSnapshotCacheFromStore(cacheRoot) {
       mkdirSync12(target, { recursive: true });
       const stagedKey = join25(target, `.seed-${entry.name}`);
       try {
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           renameSync4(stagedKey, join25(target, entry.name));
           seeded += 1;
         } else {
@@ -59405,13 +59460,13 @@ function publishRunnerSnapshotCacheToStore(cacheRoot) {
       if (!isCompleteWdaBuild(sourceKey))
         continue;
       const storeKey = join25(storeBuilds, entry.name);
-      if (isCompleteWdaBuild(storeKey))
+      if (isReusableStoredWdaBuild(storeKey))
         continue;
       mkdirSync12(storeBuilds, { recursive: true, mode: 448 });
       const stage = mkdtempSync(join25(storeBuilds, ".stage-"));
       try {
         const stagedKey = join25(stage, entry.name);
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           if (existsSync18(storeKey)) {
             const evicted = join25(stage, "evicted");
             renameSync4(storeKey, evicted);
@@ -59746,14 +59801,14 @@ import { join as join28 } from "node:path";
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn5 } from "node:child_process";
 import { randomUUID as randomUUID7 } from "node:crypto";
-import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync6, rmSync as rmSync8, writeFileSync as writeFileSync10 } from "node:fs";
+import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync6, rmSync as rmSync8, writeFileSync as writeFileSync11 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
 import { join as join27 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync5, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync9 } from "node:fs";
+import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync5, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync10 } from "node:fs";
 import { join as join26, resolve as resolve5 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
@@ -59827,7 +59882,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
   const temporary = join26(layout.root, `.bound-directory.${randomUUID6()}.key`);
   try {
     try {
-      writeFileSync9(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
+      writeFileSync10(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
       try {
         linkSync(temporary, path);
       } catch (error2) {
@@ -60965,7 +61020,7 @@ function stopWorker(worker, signal = "SIGTERM") {
   const stoppedPath = join27(worker.controlPath, "stopped");
   if (signal === "SIGTERM") {
     try {
-      writeFileSync10(join27(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
+      writeFileSync11(join27(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
     } catch {
     }
     if (waitForFile(stoppedPath, 1e3)) {
@@ -60976,7 +61031,7 @@ function stopWorker(worker, signal = "SIGTERM") {
     }
   }
   try {
-    writeFileSync10(join27(worker.controlPath, "terminate"), JSON.stringify({
+    writeFileSync11(join27(worker.controlPath, "terminate"), JSON.stringify({
       lifecycleCapability: worker.lifecycleCapability,
       signal: "SIGKILL"
     }), { flag: "wx", mode: 384 });
@@ -61141,7 +61196,7 @@ function sendOperation(directory, request2, timeoutMs) {
   const pendingPath = join27(directory.worker.controlPath, `${prefix}.pending`);
   const requestPath2 = join27(directory.worker.controlPath, `${prefix}.request`);
   const responsePath = join27(directory.worker.controlPath, `${prefix}.response`);
-  writeFileSync10(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
+  writeFileSync11(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
   renameSync6(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
     throw new Error("SESSION_INTEGRATION_WORKER_TIMEOUT");
@@ -74281,7 +74336,7 @@ import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute12
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync11, renameSync as renameSync7, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
+import { writeFileSync as writeFileSync12, renameSync as renameSync7, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
 import { dirname as dirname17, basename as basename7 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -74331,7 +74386,7 @@ function withPairWriteLock(yamlPath, operation, acquisitionPrecondition) {
   const ownerPath = `${dirname17(yamlPath)}/.rn-action-write-owner.${generateTmpStamp()}`;
   const owner = currentLockOwner();
   const lockFd = openSync9(ownerPath, "wx", 384);
-  writeFileSync11(lockFd, `${JSON.stringify(owner)}
+  writeFileSync12(lockFd, `${JSON.stringify(owner)}
 `, "utf8");
   const deadline = Date.now() + ACTION_WRITE_LOCK_TIMEOUT_MS;
   let acquired = false;
@@ -74573,12 +74628,12 @@ function cleanupOrphans(yamlPath, sidecarPath) {
 var atomicWriter = {
   /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
   _writeFile(path, content) {
-    writeFileSync11(path, content, "utf8");
+    writeFileSync12(path, content, "utf8");
   },
   _writeFileWithMode(path, content, mode) {
     const fd = openSync9(path, "wx", mode);
     try {
-      writeFileSync11(fd, content, "utf8");
+      writeFileSync12(fd, content, "utf8");
     } finally {
       closeSync9(fd);
     }
@@ -77973,7 +78028,7 @@ function outputIndicatesFlowFailure(output) {
 init_utils();
 import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { existsSync as existsSync29, readFileSync as readFileSync29, writeFileSync as writeFileSync12 } from "node:fs";
+import { existsSync as existsSync29, readFileSync as readFileSync29, writeFileSync as writeFileSync13 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
 import { basename as basename10, join as join42, dirname as dirname21 } from "node:path";
 init_agent_device_wrapper();
@@ -79957,7 +80012,7 @@ function createMaestroRunHandler(deps = {}) {
           proofDomain: reactOnlyProof ? "react-tree" : "partitioned"
         });
       }
-      writeFileSync12(flowFile, validatedContent, "utf-8");
+      writeFileSync13(flowFile, validatedContent, "utf-8");
       if (isLoginMetadata(semanticActionMeta) && !loginPostconditionId(validatedCommands)) {
         return failResult("Refusing login replay without a final positive post-submit testID assertion. End the flow with assertVisible.id or extendedWaitUntil.visible.id.", "ASSERTION_FAILED", { proofDomain: "react-tree", postcondition: "missing" });
       }
@@ -80191,7 +80246,7 @@ function createMaestroRunHandler(deps = {}) {
         clearTimeout(deadlineTimer);
       }
     }
-    writeFileSync12(flowFile, validatedContent, "utf-8");
+    writeFileSync13(flowFile, validatedContent, "utf-8");
     const dispatch = selectDispatch({ platform, flowHasHideKeyboard });
     if ("error" in dispatch) {
       return failResult(dispatch.error);
@@ -80379,7 +80434,7 @@ function createMaestroRunHandler(deps = {}) {
         };
         try {
           const stageResult = await (async () => {
-            writeFileSync12(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+            writeFileSync13(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
             const executeOnce = async (beforeDispatch) => {
               if (flowDeadline - now() <= 0) {
                 const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -80788,7 +80843,7 @@ function createMaestroRunHandler(deps = {}) {
     } finally {
       clearTimeout(flowAbortTimer);
       try {
-        writeFileSync12(flowFile, validatedContent, "utf-8");
+        writeFileSync13(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -82340,7 +82395,7 @@ import { promisify as promisify19 } from "node:util";
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash16, randomBytes as randomBytes7, randomUUID as randomUUID10 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync13 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname22, join as join43 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -82635,7 +82690,7 @@ var ExperienceRecorder = class {
         redactionVersion: REDACTION_RULES_VERSION
       });
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-      writeFileSync13(temp, contents.length > 0 ? `${contents}
+      writeFileSync14(temp, contents.length > 0 ? `${contents}
 ` : "", {
         encoding: "utf8",
         flag: "wx",
@@ -82935,7 +82990,7 @@ function readOrCreateRunnerDiagnosticsSalt(directory) {
   }
   const salt = randomBytes7(32);
   try {
-    writeFileSync13(path, salt, { flag: "wx", mode: 384 });
+    writeFileSync14(path, salt, { flag: "wx", mode: 384 });
     return salt;
   } catch {
     const raced = readFileSync30(path);
@@ -82969,7 +83024,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
   const temporary = join43(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
-  writeFileSync13(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
+  writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
@@ -83070,7 +83125,7 @@ function exportLatestRunnerDiagnosticsBundle(outputPath, sessionId, directory = 
   const source = latestRunnerDiagnosticsPath(sessionId, directory);
   if (!source)
     throw new Error("No runner diagnostics bundle is available for the exact session.");
-  writeFileSync13(outputPath, readFileSync30(source), { flag: "wx", mode: 384 });
+  writeFileSync14(outputPath, readFileSync30(source), { flag: "wx", mode: 384 });
   chmodSync7(outputPath, 384);
   return outputPath;
 }
@@ -84473,7 +84528,7 @@ init_utils();
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 init_project_config();
 init_maestro_validator();
-import { writeFileSync as writeFileSync14 } from "node:fs";
+import { writeFileSync as writeFileSync15 } from "node:fs";
 import { join as join44 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
 init_agent_device_wrapper();
@@ -84773,7 +84828,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync14(flowFile, content, "utf-8");
+    writeFileSync15(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -85694,7 +85749,7 @@ function createDeviceRecordHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
 import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute14, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
@@ -86773,7 +86828,7 @@ function writeProofReceiptAtomic(path, receipt2) {
   let descriptor = null;
   try {
     descriptor = openSync11(temporary, "wx", 384);
-    writeFileSync15(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync11(descriptor);
@@ -89764,7 +89819,7 @@ function buildGracefulShutdown(deps) {
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
 import { createHash as createHash21 } from "node:crypto";
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { closeSync as closeSync12, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16, writeSync as writeSync3 } from "node:fs";
+import { closeSync as closeSync12, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
 import { join as join49, resolve as resolve19 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
@@ -89927,7 +89982,7 @@ var Lockfile = class {
       return false;
     body.lastHeartbeat = this.opts.clock();
     try {
-      writeFileSync16(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
+      writeFileSync17(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
     } catch {
     }
     return true;
@@ -90212,7 +90267,7 @@ init_agent_device_wrapper();
 init_storage();
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
 import { basename as basename13, dirname as dirname28, join as join51, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 init_maestro_validator();
@@ -90465,7 +90520,7 @@ function createMaestroTestAllHandler(deps = {}) {
         continue;
       }
       const safeFlowFile = join51(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
+      writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -90488,7 +90543,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync18(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -92397,7 +92452,7 @@ init_sources();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname30, join as join56 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash22 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
@@ -92448,7 +92503,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
+  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
   renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
@@ -92652,7 +92707,7 @@ function createLockE2eTestHandler(deps = {}) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join58 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -92712,7 +92767,7 @@ function e2eRunsDirFor(projectRoot) {
 function writeJsonAtomic(file, value) {
   mkdirSync23(join58(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
+  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
@@ -92761,7 +92816,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -92779,7 +92834,7 @@ function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
+  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
   renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -59567,6 +59567,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       "--"
     ]);
   } finally {
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
+    }
     try {
       chmodSync4(snapshotRoot, 448);
       for (const entry of readdirSync7(snapshotRoot, { recursive: true, withFileTypes: true })) {
@@ -59579,11 +59584,6 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync4(entryPath, 384);
       }
     } catch {
-    }
-    if (cacheRoot) {
-      recordRunnerDiagnostic("cache-publish", {
-        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
-      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -59298,18 +59298,17 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error2));
   }
 }
-var memoizedWdaToolchainFingerprint;
+var testWdaToolchainFingerprint;
 function wdaToolchainFingerprint() {
-  if (memoizedWdaToolchainFingerprint !== void 0)
-    return memoizedWdaToolchainFingerprint;
+  if (testWdaToolchainFingerprint !== void 0)
+    return testWdaToolchainFingerprint;
   try {
     const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
     const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
-    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+    return probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
   } catch {
-    memoizedWdaToolchainFingerprint = null;
+    return null;
   }
-  return memoizedWdaToolchainFingerprint;
 }
 function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
@@ -59342,7 +59341,7 @@ function isCompleteWdaBuild(keyDir) {
         return false;
       try {
         const executable = lstatSync7(join25(products, entry.name, name, name.slice(0, -".app".length)));
-        return executable.isFile() && !executable.isSymbolicLink();
+        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -59332,11 +59332,146 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
+function parseAndNormalizeWdaXctestrun(source) {
+  let cursor = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(source[cursor] ?? ""))
+      cursor += 1;
+  };
+  const consume = (token2) => {
+    if (!source.startsWith(token2, cursor))
+      return false;
+    cursor += token2.length;
+    return true;
+  };
+  const consumePattern = (pattern) => {
+    const match = pattern.exec(source.slice(cursor));
+    if (!match || match.index !== 0)
+      return false;
+    cursor += match[0].length;
+    return true;
+  };
+  const parseTextElement = (tag) => {
+    if (consume(`<${tag}/>`))
+      return "";
+    if (!consume(`<${tag}>`))
+      return null;
+    const close = `</${tag}>`;
+    const end = source.indexOf(close, cursor);
+    if (end < 0)
+      return null;
+    const text = source.slice(cursor, end);
+    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
+      return null;
+    }
+    cursor = end + close.length;
+    return text;
+  };
+  const validScalar = (tag, value) => {
+    if (tag === "string")
+      return true;
+    if (tag === "integer")
+      return /^[+-]?\d+$/.test(value);
+    if (tag === "real") {
+      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
+    }
+    if (tag === "date")
+      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
+    const compact = value.replace(/\s/g, "");
+    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
+  };
+  const parseValue = () => {
+    skipWhitespace();
+    const start = cursor;
+    if (consume("<dict/>"))
+      return { kind: "dict", start, end: cursor, entries: [] };
+    if (consume("<dict>")) {
+      const entries = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</dict>"))
+          return { kind: "dict", start, end: cursor, entries };
+        const entryStart = cursor;
+        const key = parseTextElement("key");
+        if (key === null)
+          return null;
+        const value = parseValue();
+        if (!value)
+          return null;
+        entries.push({ key, start: entryStart, end: value.end, value });
+      }
+    }
+    if (consume("<array/>"))
+      return { kind: "array", start, end: cursor, values: [] };
+    if (consume("<array>")) {
+      const values = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</array>"))
+          return { kind: "array", start, end: cursor, values };
+        const value = parseValue();
+        if (!value)
+          return null;
+        values.push(value);
+      }
+    }
+    if (consume("<true/>") || consume("<false/>"))
+      return { kind: "scalar", start, end: cursor };
+    for (const tag of ["string", "integer", "real", "date", "data"]) {
+      const before = cursor;
+      const value = parseTextElement(tag);
+      if (value !== null) {
+        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
+      }
+      cursor = before;
+    }
+    return null;
+  };
+  skipWhitespace();
+  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+    return null;
+  skipWhitespace();
+  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
+    return null;
+  skipWhitespace();
+  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
+    return null;
+  const root = parseValue();
+  if (!root || root.kind !== "dict")
+    return null;
+  skipWhitespace();
+  if (!consume("</plist>"))
+    return null;
+  skipWhitespace();
+  if (cursor !== source.length)
+    return null;
+  const portEntries = [];
+  const collectPortEntries = (value) => {
+    if (value.kind === "dict") {
+      for (const entry of value.entries) {
+        if (entry.key === "USE_PORT")
+          portEntries.push(entry);
+        else
+          collectPortEntries(entry.value);
+      }
+    } else if (value.kind === "array") {
+      for (const child of value.values)
+        collectPortEntries(child);
+    }
+  };
+  collectPortEntries(root);
+  let normalized = source;
+  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
+    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
+  }
+  return normalized;
+}
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join25(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync7(products, { withFileTypes: true });
-    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
+    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync17(join25(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
       if (!name.endsWith(".app"))
         return false;
       try {
@@ -59352,8 +59487,8 @@ function isCompleteWdaBuild(keyDir) {
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const source = readFileSync17(xctestrunPath, "utf8");
-  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
-  if (normalized.includes("USE_PORT"))
+  const normalized = parseAndNormalizeWdaXctestrun(source);
+  if (normalized === null)
     return false;
   if (normalized !== source)
     writeFileSync9(xctestrunPath, normalized);
@@ -59408,7 +59543,12 @@ function isReusableStoredWdaBuild(keyDir) {
       return false;
     }
     const products = join25(keyDir, "DerivedData", "Build", "Products");
-    return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync17(join25(products, entry.name), "utf8").includes("USE_PORT"));
+    return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
+      if (!entry.isFile())
+        return false;
+      const source = readFileSync17(join25(products, entry.name), "utf8");
+      return parseAndNormalizeWdaXctestrun(source) === source;
+    });
   } catch {
     return false;
   }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -59332,167 +59332,92 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
-function parseAndNormalizeWdaXctestrun(source) {
-  let cursor = 0;
-  const skipWhitespace = () => {
-    while (/\s/.test(source[cursor] ?? ""))
-      cursor += 1;
-  };
-  const consume = (token2) => {
-    if (!source.startsWith(token2, cursor))
-      return false;
-    cursor += token2.length;
-    return true;
-  };
-  const consumePattern = (pattern) => {
-    const match = pattern.exec(source.slice(cursor));
-    if (!match || match.index !== 0)
-      return false;
-    cursor += match[0].length;
-    return true;
-  };
-  const parseTextElement = (tag) => {
-    if (consume(`<${tag}/>`))
-      return "";
-    if (!consume(`<${tag}>`))
-      return null;
-    const close = `</${tag}>`;
-    const end = source.indexOf(close, cursor);
-    if (end < 0)
-      return null;
-    const text = source.slice(cursor, end);
-    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
-      return null;
-    }
-    cursor = end + close.length;
-    return text;
-  };
-  const validScalar = (tag, value) => {
-    if (tag === "string")
-      return true;
-    if (tag === "integer")
-      return /^[+-]?\d+$/.test(value);
-    if (tag === "real") {
-      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
-    }
-    if (tag === "date")
-      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
-    const compact = value.replace(/\s/g, "");
-    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
-  };
-  const parseValue = () => {
-    skipWhitespace();
-    const start = cursor;
-    if (consume("<dict/>"))
-      return { kind: "dict", start, end: cursor, entries: [] };
-    if (consume("<dict>")) {
-      const entries = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</dict>"))
-          return { kind: "dict", start, end: cursor, entries };
-        const entryStart = cursor;
-        const key = parseTextElement("key");
-        if (key === null)
-          return null;
-        const value = parseValue();
-        if (!value)
-          return null;
-        entries.push({ key, start: entryStart, end: value.end, value });
-      }
-    }
-    if (consume("<array/>"))
-      return { kind: "array", start, end: cursor, values: [] };
-    if (consume("<array>")) {
-      const values = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</array>"))
-          return { kind: "array", start, end: cursor, values };
-        const value = parseValue();
-        if (!value)
-          return null;
-        values.push(value);
-      }
-    }
-    if (consume("<true/>") || consume("<false/>"))
-      return { kind: "scalar", start, end: cursor };
-    for (const tag of ["string", "integer", "real", "date", "data"]) {
-      const before = cursor;
-      const value = parseTextElement(tag);
-      if (value !== null) {
-        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
-      }
-      cursor = before;
-    }
+var testWdaPlutil;
+function runWdaPlutil(args) {
+  if (process.platform !== "darwin" && !testWdaPlutil)
     return null;
-  };
-  skipWhitespace();
-  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+  try {
+    const result = testWdaPlutil ? testWdaPlutil(args) : spawnSync("plutil", [...args], { encoding: "utf8", timeout: 15e3 });
+    return result.status === 0 ? result.stdout ?? "" : null;
+  } catch {
     return null;
-  skipWhitespace();
-  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
-    return null;
-  skipWhitespace();
-  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
-    return null;
-  const root = parseValue();
-  if (!root || root.kind !== "dict")
-    return null;
-  skipWhitespace();
-  if (!consume("</plist>"))
-    return null;
-  skipWhitespace();
-  if (cursor !== source.length)
-    return null;
-  const portEntries = [];
-  const collectPortEntries = (value) => {
-    if (value.kind === "dict") {
-      for (const entry of value.entries) {
-        if (entry.key === "USE_PORT")
-          portEntries.push(entry);
-        else
-          collectPortEntries(entry.value);
-      }
-    } else if (value.kind === "array") {
-      for (const child of value.values)
-        collectPortEntries(child);
-    }
-  };
-  collectPortEntries(root);
-  let normalized = source;
-  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
-    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
   }
-  return normalized;
+}
+function readWdaXctestrun(xctestrunPath) {
+  const json = runWdaPlutil(["-convert", "json", "-o", "-", xctestrunPath]);
+  if (json === null)
+    return null;
+  try {
+    const plist = JSON.parse(json);
+    return plist !== null && typeof plist === "object" && !Array.isArray(plist) ? plist : null;
+  } catch {
+    return null;
+  }
+}
+function forEachWdaTestTarget(plist, visit) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      if (configuration === null || typeof configuration !== "object")
+        continue;
+      const targets = configuration.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
+          visit(target);
+        }
+      }
+    }
+    return;
+  }
+  for (const [key, target] of Object.entries(plist)) {
+    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
+      visit(target);
+    }
+  }
+}
+function hasInjectedWdaPort(plist) {
+  let found = false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment) && Object.hasOwn(environment, "USE_PORT")) {
+      found = true;
+    }
+  });
+  return found;
 }
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join25(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync7(products, { withFileTypes: true });
     const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync17(join25(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
-      if (!name.endsWith(".app"))
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join25(products, entry.name)) !== null) && entries.some((entry) => {
+      if (!entry.isDirectory())
         return false;
       try {
-        const executable = lstatSync7(join25(products, entry.name, name, name.slice(0, -".app".length)));
+        const executable = lstatSync7(join25(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
         return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
-    }));
+    });
   } catch {
     return false;
   }
 }
 function removeInjectedWdaPort(xctestrunPath) {
-  const source = readFileSync17(xctestrunPath, "utf8");
-  const normalized = parseAndNormalizeWdaXctestrun(source);
-  if (normalized === null)
+  const plist = readWdaXctestrun(xctestrunPath);
+  if (!plist)
     return false;
-  if (normalized !== source)
-    writeFileSync9(xctestrunPath, normalized);
-  return true;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment)) {
+      delete environment.USE_PORT;
+    }
+  });
+  writeFileSync9(xctestrunPath, JSON.stringify(plist, null, 2));
+  return runWdaPlutil(["-convert", "xml1", xctestrunPath]) !== null;
 }
 function isRealDirectory(path) {
   try {
@@ -59546,8 +59471,8 @@ function isReusableStoredWdaBuild(keyDir) {
     return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
       if (!entry.isFile())
         return false;
-      const source = readFileSync17(join25(products, entry.name), "utf8");
-      return parseAndNormalizeWdaXctestrun(source) === source;
+      const plist = readWdaXctestrun(join25(products, entry.name));
+      return plist !== null && !hasInjectedWdaPort(plist);
     });
   } catch {
     return false;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -8354,7 +8354,7 @@ var init_keyboard_guard = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/util/secure-state-file.js
-import { readFileSync as readFileSync10, writeFileSync as writeFileSync3, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
+import { readFileSync as readFileSync10, writeFileSync as writeFileSync4, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
 import { join as join12, dirname as dirname12 } from "node:path";
 import { homedir as homedir3 } from "node:os";
 function getStateDir() {
@@ -8383,7 +8383,7 @@ function readJsonStateFile(path) {
 function writeJsonStateFileAtomic(path, value) {
   mkdirSync8(dirname12(path), { recursive: true });
   const tmpPath = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmpPath, JSON.stringify(value), { encoding: "utf8", mode: 384 });
+  writeFileSync4(tmpPath, JSON.stringify(value), { encoding: "utf8", mode: 384 });
   renameSync4(tmpPath, path);
 }
 function deleteStateFile(path) {
@@ -8820,7 +8820,7 @@ var init_declared_source_contract = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/nav-graph/storage.js
-import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
+import { readFileSync as readFileSync11, writeFileSync as writeFileSync5, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
 import { join as join15, dirname as dirname13 } from "node:path";
 function isRnProject(dir) {
   const pkgPath = join15(dir, "package.json");
@@ -10412,7 +10412,7 @@ import { fileURLToPath as fileURLToPath2 } from "node:url";
 init_process_birth();
 import { spawnSync } from "node:child_process";
 import { createHash as createHash2 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2 } from "node:fs";
+import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname as dirname2, join as join2, relative, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -11014,13 +11014,68 @@ function isCompleteWdaBuild(keyDir) {
     return false;
   }
 }
-function copyWdaBuildKey(sourceKey, stagedKey) {
-  cpSync(sourceKey, stagedKey, {
+function removeInjectedWdaPort(xctestrunPath) {
+  const source = readFileSync2(xctestrunPath, "utf8");
+  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
+  if (normalized.includes("USE_PORT"))
+    return false;
+  if (normalized !== source)
+    writeFileSync(xctestrunPath, normalized);
+  return true;
+}
+function isRealDirectory(path) {
+  try {
+    const stat = lstatSync2(path);
+    return stat.isDirectory() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function copyReusableWdaBuild(sourceKey, stagedKey) {
+  const sourceProducts = join2(sourceKey, "DerivedData", "Build", "Products");
+  if (!isRealDirectory(sourceKey) || !isRealDirectory(join2(sourceKey, "DerivedData")) || !isRealDirectory(join2(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+    return false;
+  }
+  const stagedProducts = join2(stagedKey, "DerivedData", "Build", "Products");
+  mkdirSync(dirname2(stagedProducts), { recursive: true });
+  cpSync(sourceProducts, stagedProducts, {
     recursive: true,
     mode: constants2.COPYFILE_FICLONE,
     verbatimSymlinks: true
   });
+  for (const entry of readdirSync(stagedProducts, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".xctestrun") && !removeInjectedWdaPort(join2(stagedProducts, entry.name))) {
+      return false;
+    }
+  }
   return isCompleteWdaBuild(stagedKey);
+}
+function isReusableStoredWdaBuild(keyDir) {
+  try {
+    if (!isCompleteWdaBuild(keyDir))
+      return false;
+    const keyEntries = readdirSync(keyDir, { withFileTypes: true });
+    const derivedData = keyEntries[0];
+    if (keyEntries.length !== 1 || derivedData?.name !== "DerivedData" || !derivedData.isDirectory()) {
+      return false;
+    }
+    const derivedDataEntries = readdirSync(join2(keyDir, "DerivedData"), { withFileTypes: true });
+    const build = derivedDataEntries[0];
+    if (derivedDataEntries.length !== 1 || build?.name !== "Build" || !build.isDirectory()) {
+      return false;
+    }
+    const buildEntries = readdirSync(join2(keyDir, "DerivedData", "Build"), {
+      withFileTypes: true
+    });
+    const productsEntry = buildEntries[0];
+    if (buildEntries.length !== 1 || productsEntry?.name !== "Products" || !productsEntry.isDirectory()) {
+      return false;
+    }
+    const products = join2(keyDir, "DerivedData", "Build", "Products");
+    return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync2(join2(products, entry.name), "utf8").includes("USE_PORT"));
+  } catch {
+    return false;
+  }
 }
 function seedRunnerSnapshotCacheFromStore(cacheRoot) {
   let seeded = 0;
@@ -11038,7 +11093,7 @@ function seedRunnerSnapshotCacheFromStore(cacheRoot) {
       mkdirSync(target, { recursive: true });
       const stagedKey = join2(target, `.seed-${entry.name}`);
       try {
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           renameSync(stagedKey, join2(target, entry.name));
           seeded += 1;
         } else {
@@ -11069,13 +11124,13 @@ function publishRunnerSnapshotCacheToStore(cacheRoot) {
       if (!isCompleteWdaBuild(sourceKey))
         continue;
       const storeKey = join2(storeBuilds, entry.name);
-      if (isCompleteWdaBuild(storeKey))
+      if (isReusableStoredWdaBuild(storeKey))
         continue;
       mkdirSync(storeBuilds, { recursive: true, mode: 448 });
       const stage = mkdtempSync(join2(storeBuilds, ".stage-"));
       try {
         const stagedKey = join2(stage, entry.name);
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           if (existsSync3(storeKey)) {
             const evicted = join2(stage, "evicted");
             renameSync(storeKey, evicted);
@@ -11471,7 +11526,7 @@ import { existsSync as existsSync9, lstatSync as lstatSync7, readFileSync as rea
 import { basename as basename4, dirname as dirname9, isAbsolute as isAbsolute4, join as join10, relative as relative3, resolve as resolve5, sep as sep6 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
-import { existsSync as existsSync4, readFileSync as readFileSync4, writeFileSync, mkdirSync as mkdirSync3, statSync } from "node:fs";
+import { existsSync as existsSync4, readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, statSync } from "node:fs";
 import { join as join5, dirname as dirname4 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/runtime-paths.js
@@ -11533,7 +11588,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync2, renameSync as renameSync2, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
+import { writeFileSync as writeFileSync3, renameSync as renameSync2, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
 import { dirname as dirname5, basename as basename2 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -11583,7 +11638,7 @@ function withPairWriteLock(yamlPath, operation, acquisitionPrecondition) {
   const ownerPath = `${dirname5(yamlPath)}/.rn-action-write-owner.${generateTmpStamp()}`;
   const owner = currentLockOwner();
   const lockFd = openSync2(ownerPath, "wx", 384);
-  writeFileSync2(lockFd, `${JSON.stringify(owner)}
+  writeFileSync3(lockFd, `${JSON.stringify(owner)}
 `, "utf8");
   const deadline = Date.now() + ACTION_WRITE_LOCK_TIMEOUT_MS;
   let acquired = false;
@@ -11825,12 +11880,12 @@ function cleanupOrphans(yamlPath, sidecarPath) {
 var atomicWriter = {
   /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
   _writeFile(path, content) {
-    writeFileSync2(path, content, "utf8");
+    writeFileSync3(path, content, "utf8");
   },
   _writeFileWithMode(path, content, mode) {
     const fd = openSync2(path, "wx", mode);
     try {
-      writeFileSync2(fd, content, "utf8");
+      writeFileSync3(fd, content, "utf8");
     } finally {
       closeSync2(fd);
     }
@@ -14163,7 +14218,7 @@ function filterWithBoundedRegex(candidates, pattern, timeoutMs = 500) {
 init_utils();
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
-import { existsSync as existsSync17, readFileSync as readFileSync15, writeFileSync as writeFileSync5 } from "node:fs";
+import { existsSync as existsSync17, readFileSync as readFileSync15, writeFileSync as writeFileSync6 } from "node:fs";
 import { tmpdir as tmpdir4 } from "node:os";
 import { basename as basename8, join as join23, dirname as dirname14 } from "node:path";
 init_agent_device_wrapper();
@@ -16333,7 +16388,7 @@ function createMaestroRunHandler(deps = {}) {
           proofDomain: reactOnlyProof ? "react-tree" : "partitioned"
         });
       }
-      writeFileSync5(flowFile, validatedContent, "utf-8");
+      writeFileSync6(flowFile, validatedContent, "utf-8");
       if (isLoginMetadata(semanticActionMeta) && !loginPostconditionId(validatedCommands)) {
         return failResult("Refusing login replay without a final positive post-submit testID assertion. End the flow with assertVisible.id or extendedWaitUntil.visible.id.", "ASSERTION_FAILED", { proofDomain: "react-tree", postcondition: "missing" });
       }
@@ -16567,7 +16622,7 @@ function createMaestroRunHandler(deps = {}) {
         clearTimeout(deadlineTimer);
       }
     }
-    writeFileSync5(flowFile, validatedContent, "utf-8");
+    writeFileSync6(flowFile, validatedContent, "utf-8");
     const dispatch = selectDispatch({ platform, flowHasHideKeyboard });
     if ("error" in dispatch) {
       return failResult(dispatch.error);
@@ -16755,7 +16810,7 @@ function createMaestroRunHandler(deps = {}) {
         };
         try {
           const stageResult = await (async () => {
-            writeFileSync5(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+            writeFileSync6(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
             const executeOnce = async (beforeDispatch) => {
               if (flowDeadline - now() <= 0) {
                 const error = new Error("Maestro flow timeout exhausted before the next stage");
@@ -17164,7 +17219,7 @@ function createMaestroRunHandler(deps = {}) {
     } finally {
       clearTimeout(flowAbortTimer);
       try {
-        writeFileSync5(flowFile, validatedContent, "utf-8");
+        writeFileSync6(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -7884,7 +7884,7 @@ var require_dist = __commonJS({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-validator.js
-import { join as join3, dirname as dirname3, isAbsolute, sep as sep2 } from "node:path";
+import { join as join3, dirname as dirname3, isAbsolute as isAbsolute2, sep as sep2 } from "node:path";
 import { readFileSync as readFileSync3, realpathSync as realpathSync3 } from "node:fs";
 function isValidBundleId(s) {
   if (typeof s !== "string")
@@ -8062,7 +8062,7 @@ function resolveRunFlowTarget(file, opts) {
   if (!opts.flowDir || !opts.flowRoot) {
     throw new MaestroValidationError(`runFlow file ref "${file}" requires a flow root context (flowDir + flowRoot)`);
   }
-  if (isAbsolute(file)) {
+  if (isAbsolute2(file)) {
     throw new MaestroValidationError(`runFlow file ref must be relative, got absolute: ${file}`);
   }
   if (file.split(/[\\/]/).includes("..")) {
@@ -10414,7 +10414,7 @@ import { spawnSync } from "node:child_process";
 import { createHash as createHash2 } from "node:crypto";
 import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname as dirname2, join as join2, relative, resolve, sep } from "node:path";
+import { basename, dirname as dirname2, isAbsolute, join as join2, relative, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 // packages/rn-dev-agent-core/dist/experience/runner-diagnostics.js
@@ -11018,28 +11018,50 @@ function readWdaXctestrun(xctestrunPath) {
     return null;
   }
 }
+function asWdaPlistRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
 function forEachWdaTestTarget(plist, visit) {
   const configurations = plist.TestConfigurations;
   if (Array.isArray(configurations)) {
     for (const configuration of configurations) {
-      if (configuration === null || typeof configuration !== "object")
+      const configurationRecord = asWdaPlistRecord(configuration);
+      if (!configurationRecord)
         continue;
-      const targets = configuration.TestTargets;
+      const targets = configurationRecord.TestTargets;
       if (!Array.isArray(targets))
         continue;
       for (const target of targets) {
-        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
-          visit(target);
-        }
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord)
+          visit(targetRecord);
       }
     }
     return;
   }
   for (const [key, target] of Object.entries(plist)) {
-    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
-      visit(target);
-    }
+    const targetRecord = asWdaPlistRecord(target);
+    if (key !== "__xctestrun_metadata__" && targetRecord)
+      visit(targetRecord);
   }
+}
+function findWdaTestTarget(plist) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      const targets = asWdaPlistRecord(configuration)?.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord && (targetRecord.TestTargetName === "WebDriverAgentRunner" || targetRecord.BlueprintName === "WebDriverAgentRunner")) {
+          return targetRecord;
+        }
+      }
+    }
+    return null;
+  }
+  return asWdaPlistRecord(plist.WebDriverAgentRunner);
 }
 function hasInjectedWdaPort(plist) {
   let found = false;
@@ -11051,24 +11073,79 @@ function hasInjectedWdaPort(plist) {
   });
   return found;
 }
-function isCompleteWdaBuild(keyDir) {
-  try {
-    const products = join2(keyDir, "DerivedData", "Build", "Products");
-    const entries = readdirSync(products, { withFileTypes: true });
-    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join2(products, entry.name)) !== null) && entries.some((entry) => {
-      if (!entry.isDirectory())
-        return false;
-      try {
-        const executable = lstatSync2(join2(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
-        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
-      } catch {
+function isWithinWdaKey(keyDir, candidate) {
+  const path = relative(keyDir, candidate);
+  return path === "" || path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path);
+}
+function isContainedWdaProductTree(keyDir, products) {
+  const lexicalKey = resolve(keyDir);
+  const realKey = realpathSync2(keyDir);
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join2(directory, entry.name);
+      const stat = lstatSync2(path);
+      if (stat.isSymbolicLink()) {
+        const target = readlinkSync(path);
+        if (isAbsolute(target) || !isWithinWdaKey(lexicalKey, resolve(directory, target)) || !isWithinWdaKey(realKey, realpathSync2(path))) {
+          return false;
+        }
+      } else if (stat.isDirectory() && !visit(path)) {
         return false;
       }
-    });
-  } catch {
-    return false;
+    }
+    return true;
+  };
+  return visit(products);
+}
+function resolveWdaProductReference(reference, products, testHost) {
+  if (typeof reference !== "string")
+    return null;
+  if (reference.startsWith("__TESTROOT__/")) {
+    return resolve(products, reference.slice("__TESTROOT__/".length));
   }
+  if (testHost && reference.startsWith("__TESTHOST__/")) {
+    return resolve(testHost, reference.slice("__TESTHOST__/".length));
+  }
+  return null;
+}
+function readCompleteWdaBuildManifest(keyDir) {
+  try {
+    const derivedData = join2(keyDir, "DerivedData");
+    const build = join2(derivedData, "Build");
+    const products = join2(build, "Products");
+    if (!isRealDirectory(keyDir) || !isRealDirectory(derivedData) || !isRealDirectory(build) || !isRealDirectory(products) || !isContainedWdaProductTree(keyDir, products)) {
+      return null;
+    }
+    const selected = readdirSync(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)[0];
+    if (!selected?.isFile())
+      return null;
+    const selectedXctestrun = join2(products, selected.name);
+    const plist = readWdaXctestrun(selectedXctestrun);
+    const target = plist && findWdaTestTarget(plist);
+    if (!target)
+      return null;
+    const testHost = resolveWdaProductReference(target.TestHostPath, products);
+    if (!testHost)
+      return null;
+    const hostPath = relative(products, testHost).split(sep);
+    if (hostPath.length !== 2 || hostPath[1] !== "WebDriverAgentRunner-Runner.app" || !isRealDirectory(join2(products, hostPath[0])) || !isRealDirectory(testHost)) {
+      return null;
+    }
+    const executable = lstatSync2(join2(testHost, "WebDriverAgentRunner-Runner"));
+    if (!executable.isFile() || executable.isSymbolicLink() || (executable.mode & 73) === 0) {
+      return null;
+    }
+    const testBundle = resolveWdaProductReference(target.TestBundlePath, products, testHost);
+    if (!testBundle || !isWithinWdaKey(resolve(keyDir), testBundle) || !existsSync3(testBundle)) {
+      return null;
+    }
+    return { products, selectedXctestrun };
+  } catch {
+    return null;
+  }
+}
+function isCompleteWdaBuild(keyDir) {
+  return readCompleteWdaBuildManifest(keyDir) !== null;
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const plist = readWdaXctestrun(xctestrunPath);
@@ -11092,10 +11169,10 @@ function isRealDirectory(path) {
   }
 }
 function copyReusableWdaBuild(sourceKey, stagedKey) {
-  const sourceProducts = join2(sourceKey, "DerivedData", "Build", "Products");
-  if (!isRealDirectory(sourceKey) || !isRealDirectory(join2(sourceKey, "DerivedData")) || !isRealDirectory(join2(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+  const manifest = readCompleteWdaBuildManifest(sourceKey);
+  if (!manifest)
     return false;
-  }
+  const sourceProducts = manifest.products;
   const stagedProducts = join2(stagedKey, "DerivedData", "Build", "Products");
   mkdirSync(dirname2(stagedProducts), { recursive: true });
   cpSync(sourceProducts, stagedProducts, {
@@ -11588,7 +11665,7 @@ function parseProducesMap(raw) {
 
 // packages/rn-dev-agent-core/dist/domain/action-store.js
 import { existsSync as existsSync9, lstatSync as lstatSync7, readFileSync as readFileSync8, statSync as statSync4, unlinkSync as unlinkSync5 } from "node:fs";
-import { basename as basename4, dirname as dirname9, isAbsolute as isAbsolute4, join as join10, relative as relative3, resolve as resolve5, sep as sep6 } from "node:path";
+import { basename as basename4, dirname as dirname9, isAbsolute as isAbsolute5, join as join10, relative as relative3, resolve as resolve5, sep as sep6 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
 import { existsSync as existsSync4, readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, statSync } from "node:fs";
@@ -12139,7 +12216,7 @@ function assertWithinDir(child, baseDir) {
 init_process_birth();
 import { execFileSync as execFileSync2 } from "node:child_process";
 import { lstatSync as lstatSync5 } from "node:fs";
-import { isAbsolute as isAbsolute2, join as join6 } from "node:path";
+import { isAbsolute as isAbsolute3, join as join6 } from "node:path";
 function createUnfollowedFileSnapshot(directoryPath, directoryIdentity) {
   return { directoryPath, directoryIdentity, fileIdentities: /* @__PURE__ */ new Map() };
 }
@@ -12325,7 +12402,7 @@ function readUnfollowedFiles(directoryPath, identity, relativePaths, expectedIde
       throw new Error("Selected file identities did not match the requested paths.");
     }
     const entries = relativePaths.map((relativePath, index) => {
-      if (isAbsolute2(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
+      if (isAbsolute3(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
         throw new Error(`Invalid relative path: ${relativePath}.`);
       }
       if (expectedIdentities) {
@@ -12743,7 +12820,7 @@ function projectRootFromYaml(yamlFilePath) {
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
 import { spawnSync as spawnSync2 } from "node:child_process";
 import { closeSync as closeSync3, constants as constants4, existsSync as existsSync8, fstatSync as fstatSync3, lstatSync as lstatSync6, mkdirSync as mkdirSync7, openSync as openSync3, readFileSync as readFileSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync4, renameSync as renameSync3, statSync as statSync3, symlinkSync as symlinkSync2, unlinkSync as unlinkSync4 } from "node:fs";
-import { dirname as dirname8, isAbsolute as isAbsolute3, join as join9, relative as relative2, resolve as resolve4, sep as sep5 } from "node:path";
+import { dirname as dirname8, isAbsolute as isAbsolute4, join as join9, relative as relative2, resolve as resolve4, sep as sep5 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
 var WORKTREE_REPAIR_ENTRY = '"${CLAUDE_PLUGIN_ROOT:-${RN_DEV_AGENT_CODEX_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:?set it to the installed rn-dev-agent plugin root, then re-run}}}/rn-dev-agent-core/dist/worktree-inheritance.js"';
@@ -12802,7 +12879,7 @@ function contained(parent, child) {
   if (parent === child)
     return true;
   const rel = relative2(parent, child);
-  return rel !== "" && !rel.startsWith(`..${sep5}`) && rel !== ".." && !isAbsolute3(rel);
+  return rel !== "" && !rel.startsWith(`..${sep5}`) && rel !== ".." && !isAbsolute4(rel);
 }
 function toPosix(path) {
   return sep5 === "/" ? path : path.split(sep5).join("/");
@@ -12938,7 +13015,7 @@ function resolveWorktreeLayout(input) {
 }
 function classifySource(path, type, boundary) {
   const rel = relative2(boundary, path);
-  if (rel === ".." || rel.startsWith(`..${sep5}`) || isAbsolute3(rel)) {
+  if (rel === ".." || rel.startsWith(`..${sep5}`) || isAbsolute4(rel)) {
     return { state: "WRONG_TYPE" };
   }
   const paths = [boundary];
@@ -13519,11 +13596,11 @@ function actionFileExists(path) {
   return true;
 }
 function referencedActionPath(parentFile, reference) {
-  if (isAbsolute4(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
+  if (isAbsolute5(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
     return null;
   }
   const child = join10(dirname9(parentFile), reference);
-  if (child === ".." || child.startsWith(`..${sep6}`) || isAbsolute4(child))
+  if (child === ".." || child.startsWith(`..${sep6}`) || isAbsolute5(child))
     return null;
   return child;
 }
@@ -13700,7 +13777,7 @@ function captureActionFromContext(context, actionId) {
       flowRoot: snapshot.directory,
       readFileFn: (path) => {
         const child = relative3(snapshot.directory, path);
-        if (child === "" || child === ".." || child.startsWith(`..${sep6}`) || isAbsolute4(child)) {
+        if (child === "" || child === ".." || child.startsWith(`..${sep6}`) || isAbsolute5(child)) {
           throw new Error(`Refusing action flow outside ${snapshot.directory}.`);
         }
         const text2 = context.fileContents.get(child);
@@ -14857,7 +14934,7 @@ function maestroAuthorityRefusal(authority, underlyingError) {
 import { existsSync as existsSync16, readFileSync as readFileSync14, readdirSync as readdirSync7, realpathSync as realpathSync7, rmSync as rmSync3 } from "node:fs";
 import { createHash as createHash4 } from "node:crypto";
 import { tmpdir as tmpdir3 } from "node:os";
-import { isAbsolute as isAbsolute5, join as join22, sep as sep7 } from "node:path";
+import { isAbsolute as isAbsolute6, join as join22, sep as sep7 } from "node:path";
 var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
 var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
 var WEAK_DEVICE_ID_KEYS = ["id"];
@@ -15008,7 +15085,7 @@ function readStructuredFlowArtifact(reportDir, previous) {
     if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
       return unfinalized;
     const normalizedDataFile = flow.dataFile;
-    if (isAbsolute5(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+    if (isAbsolute6(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
       return unfinalized;
     }
     const realDataFile = realpathSync7(join22(reportDir, normalizedDataFile));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -8354,7 +8354,7 @@ var init_keyboard_guard = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/util/secure-state-file.js
-import { readFileSync as readFileSync10, writeFileSync as writeFileSync3, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync3, lstatSync as lstatSync9 } from "node:fs";
+import { readFileSync as readFileSync10, writeFileSync as writeFileSync3, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
 import { join as join12, dirname as dirname12 } from "node:path";
 import { homedir as homedir3 } from "node:os";
 function getStateDir() {
@@ -8384,7 +8384,7 @@ function writeJsonStateFileAtomic(path, value) {
   mkdirSync8(dirname12(path), { recursive: true });
   const tmpPath = `${path}.tmp.${process.pid}`;
   writeFileSync3(tmpPath, JSON.stringify(value), { encoding: "utf8", mode: 384 });
-  renameSync3(tmpPath, path);
+  renameSync4(tmpPath, path);
 }
 function deleteStateFile(path) {
   try {
@@ -8820,7 +8820,7 @@ var init_declared_source_contract = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/nav-graph/storage.js
-import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, existsSync as existsSync12, renameSync as renameSync4, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
+import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
 import { join as join15, dirname as dirname13 } from "node:path";
 function isRnProject(dir) {
   const pkgPath = join15(dir, "package.json");
@@ -10403,15 +10403,16 @@ var init_release_android_slot = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-runner-pin.js
-import { spawnSync as spawnSync2 } from "node:child_process";
+import { spawnSync as spawnSync3 } from "node:child_process";
 import { existsSync as existsSync18 } from "node:fs";
 import { dirname as dirname15, join as join24, resolve as resolve8 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
 init_process_birth();
+import { spawnSync } from "node:child_process";
 import { createHash as createHash2 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, rmSync, symlinkSync, unlinkSync as unlinkSync2 } from "node:fs";
+import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2 } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname as dirname2, join as join2, relative, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -10961,6 +10962,135 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error));
   }
 }
+var memoizedWdaToolchainFingerprint;
+function wdaToolchainFingerprint() {
+  if (memoizedWdaToolchainFingerprint !== void 0)
+    return memoizedWdaToolchainFingerprint;
+  try {
+    const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
+    const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
+    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+  } catch {
+    memoizedWdaToolchainFingerprint = null;
+  }
+  return memoizedWdaToolchainFingerprint;
+}
+function persistentWdaStoreBuildsRoot() {
+  const fingerprint = wdaToolchainFingerprint();
+  if (!fingerprint)
+    return null;
+  const versionsRoot = runnerCacheVersionsRoot();
+  const components = [
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+  ];
+  for (const component of components) {
+    try {
+      const stat = lstatSync2(component);
+      if (!stat.isDirectory() || stat.isSymbolicLink())
+        return null;
+    } catch {
+      break;
+    }
+  }
+  return components[2];
+}
+function isCompleteWdaBuild(keyDir) {
+  try {
+    const products = join2(keyDir, "DerivedData", "Build", "Products");
+    const entries = readdirSync(products, { withFileTypes: true });
+    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
+      if (!name.endsWith(".app"))
+        return false;
+      try {
+        const executable = lstatSync2(join2(products, entry.name, name, name.slice(0, -".app".length)));
+        return executable.isFile() && !executable.isSymbolicLink();
+      } catch {
+        return false;
+      }
+    }));
+  } catch {
+    return false;
+  }
+}
+function copyWdaBuildKey(sourceKey, stagedKey) {
+  cpSync(sourceKey, stagedKey, {
+    recursive: true,
+    mode: constants2.COPYFILE_FICLONE,
+    verbatimSymlinks: true
+  });
+  return isCompleteWdaBuild(stagedKey);
+}
+function seedRunnerSnapshotCacheFromStore(cacheRoot) {
+  let seeded = 0;
+  try {
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    const target = join2(cacheRoot, "wda-builds");
+    for (const entry of readdirSync(storeBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory())
+        continue;
+      const sourceKey = join2(storeBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      mkdirSync(target, { recursive: true });
+      const stagedKey = join2(target, `.seed-${entry.name}`);
+      try {
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          renameSync(stagedKey, join2(target, entry.name));
+          seeded += 1;
+        } else {
+          rmSync(stagedKey, { recursive: true, force: true });
+        }
+      } catch {
+        try {
+          rmSync(stagedKey, { recursive: true, force: true });
+        } catch {
+        }
+      }
+    }
+  } catch {
+  }
+  return seeded;
+}
+function publishRunnerSnapshotCacheToStore(cacheRoot) {
+  let published = 0;
+  try {
+    const spawnBuilds = join2(cacheRoot, "wda-builds");
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    for (const entry of readdirSync(spawnBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith("."))
+        continue;
+      const sourceKey = join2(spawnBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      const storeKey = join2(storeBuilds, entry.name);
+      if (isCompleteWdaBuild(storeKey))
+        continue;
+      mkdirSync(storeBuilds, { recursive: true, mode: 448 });
+      const stage = mkdtempSync(join2(storeBuilds, ".stage-"));
+      try {
+        const stagedKey = join2(stage, entry.name);
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          if (existsSync3(storeKey)) {
+            const evicted = join2(stage, "evicted");
+            renameSync(storeKey, evicted);
+          }
+          renameSync(stagedKey, storeKey);
+          published += 1;
+        }
+      } finally {
+        rmSync(stage, { recursive: true, force: true });
+      }
+    }
+  } catch {
+  }
+  return published;
+}
 function provisionRunnerSnapshotCache(snapshotRoot, testHooks = {}, setOwnedCacheRoot = () => {
 }) {
   const cacheRoot = expectedRunnerCacheRoot(snapshotRoot);
@@ -11081,8 +11211,12 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
       }
     }
     chmodSync2(snapshotRoot, 320);
-    if (cacheRoot)
+    if (cacheRoot) {
       assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+      recordRunnerDiagnostic("cache-seed", {
+        seededBuilds: seedRunnerSnapshotCacheFromStore(cacheRoot)
+      });
+    }
     const openedRunner = lstatSync2(snapshotRunner);
     recordRunnerDiagnostic("runner-exec-begin", { runnerPinVersion: MAESTRO_RUNNER_PIN.version });
     if (platform === "ios") {
@@ -11108,6 +11242,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
           chmodSync2(entryPath, 384);
       }
     } catch {
+    }
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
@@ -11394,7 +11533,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync2, renameSync, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
+import { writeFileSync as writeFileSync2, renameSync as renameSync2, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
 import { dirname as dirname5, basename as basename2 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -11698,7 +11837,7 @@ var atomicWriter = {
   },
   /** Underlying `fs.renameSync(from, to)`. */
   _rename(from, to) {
-    renameSync(from, to);
+    renameSync2(from, to);
   },
   /** Underlying `fs.statSync(path).mtimeMs`. */
   _statMtimeMs(path) {
@@ -12482,8 +12621,8 @@ function projectRootFromYaml(yamlFilePath) {
 }
 
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
-import { spawnSync } from "node:child_process";
-import { closeSync as closeSync3, constants as constants4, existsSync as existsSync8, fstatSync as fstatSync3, lstatSync as lstatSync6, mkdirSync as mkdirSync7, openSync as openSync3, readFileSync as readFileSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync4, renameSync as renameSync2, statSync as statSync3, symlinkSync as symlinkSync2, unlinkSync as unlinkSync4 } from "node:fs";
+import { spawnSync as spawnSync2 } from "node:child_process";
+import { closeSync as closeSync3, constants as constants4, existsSync as existsSync8, fstatSync as fstatSync3, lstatSync as lstatSync6, mkdirSync as mkdirSync7, openSync as openSync3, readFileSync as readFileSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync4, renameSync as renameSync3, statSync as statSync3, symlinkSync as symlinkSync2, unlinkSync as unlinkSync4 } from "node:fs";
 import { dirname as dirname8, isAbsolute as isAbsolute3, join as join9, relative as relative2, resolve as resolve4, sep as sep5 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
@@ -12522,7 +12661,7 @@ function gitEnvironment() {
   return env;
 }
 function git(cwd, args) {
-  const result = spawnSync("git", args, {
+  const result = spawnSync2("git", args, {
     cwd,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -13032,7 +13171,7 @@ function isTracked(worktreeRoot, relativePath) {
   return listed.ok && listed.stdout.trim().length > 0;
 }
 function isIgnoreSafe(worktreeRoot, relativePath) {
-  const result = spawnSync("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
+  const result = spawnSync2("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
     cwd: worktreeRoot,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -14065,7 +14204,7 @@ function chooseMaestroDispatch(inputs) {
 
 // packages/rn-dev-agent-core/dist/tools/resolve-ios-app-file.js
 import { execFileSync as execFileSync3 } from "node:child_process";
-import { existsSync as existsSync14, cpSync, rmSync as rmSync2, mkdirSync as mkdirSync10, readdirSync as readdirSync6, statSync as statSync6 } from "node:fs";
+import { existsSync as existsSync14, cpSync as cpSync2, rmSync as rmSync2, mkdirSync as mkdirSync10, readdirSync as readdirSync6, statSync as statSync6 } from "node:fs";
 import { tmpdir as tmpdir2 } from "node:os";
 import { join as join20, basename as basename7 } from "node:path";
 function flowUsesClearState(flowText) {
@@ -14080,7 +14219,7 @@ function defaultSnapshotApp(appPath) {
     try {
       execFileSync3("cp", ["-Rc", appPath, dest], { timeout: 3e4, stdio: "ignore" });
     } catch {
-      cpSync(appPath, dest, { recursive: true });
+      cpSync2(appPath, dest, { recursive: true });
     }
     return dest;
   } catch {
@@ -17048,7 +17187,7 @@ async function diagnose(json2) {
   _resetEngineStatusForTest();
   const status = await getEngineStatus();
   const report = doctorPinnedRunner(status, nodePlatformKey());
-  const runtimeProbe = spawnSync2("xcrun", ["simctl", "list", "devices", "--json"], {
+  const runtimeProbe = spawnSync3("xcrun", ["simctl", "list", "devices", "--json"], {
     encoding: "utf8",
     timeout: 5e3
   });
@@ -17078,7 +17217,7 @@ async function diagnose(json2) {
 }
 function install() {
   const script = ensureScriptPath();
-  const result = spawnSync2("bash", [script], { stdio: "inherit" });
+  const result = spawnSync3("bash", [script], { stdio: "inherit" });
   return result.status === 0 ? 0 : 1;
 }
 function migrate(root2, json2) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10962,18 +10962,17 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error));
   }
 }
-var memoizedWdaToolchainFingerprint;
+var testWdaToolchainFingerprint;
 function wdaToolchainFingerprint() {
-  if (memoizedWdaToolchainFingerprint !== void 0)
-    return memoizedWdaToolchainFingerprint;
+  if (testWdaToolchainFingerprint !== void 0)
+    return testWdaToolchainFingerprint;
   try {
     const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
     const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
-    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+    return probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
   } catch {
-    memoizedWdaToolchainFingerprint = null;
+    return null;
   }
-  return memoizedWdaToolchainFingerprint;
 }
 function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
@@ -11006,7 +11005,7 @@ function isCompleteWdaBuild(keyDir) {
         return false;
       try {
         const executable = lstatSync2(join2(products, entry.name, name, name.slice(0, -".app".length)));
-        return executable.isFile() && !executable.isSymbolicLink();
+        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10975,15 +10975,16 @@ function wdaToolchainFingerprint() {
   }
   return memoizedWdaToolchainFingerprint;
 }
-function persistentWdaStoreBuildsRoot() {
+function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
-  if (!fingerprint)
+  if (!fingerprint || !pinArchiveCoords(platformKey))
     return null;
   const versionsRoot = runnerCacheVersionsRoot();
   const components = [
     join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
-    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
-    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint, "wda-builds")
   ];
   for (const component of components) {
     try {
@@ -10994,7 +10995,7 @@ function persistentWdaStoreBuildsRoot() {
       break;
     }
   }
-  return components[2];
+  return components[3];
 }
 function isCompleteWdaBuild(keyDir) {
   try {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -11231,6 +11231,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
       "--"
     ]);
   } finally {
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
+    }
     try {
       chmodSync2(snapshotRoot, 448);
       for (const entry of readdirSync(snapshotRoot, { recursive: true, withFileTypes: true })) {
@@ -11243,11 +11248,6 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
           chmodSync2(entryPath, 384);
       }
     } catch {
-    }
-    if (cacheRoot) {
-      recordRunnerDiagnostic("cache-publish", {
-        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
-      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10996,167 +10996,92 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
-function parseAndNormalizeWdaXctestrun(source) {
-  let cursor = 0;
-  const skipWhitespace = () => {
-    while (/\s/.test(source[cursor] ?? ""))
-      cursor += 1;
-  };
-  const consume = (token2) => {
-    if (!source.startsWith(token2, cursor))
-      return false;
-    cursor += token2.length;
-    return true;
-  };
-  const consumePattern = (pattern) => {
-    const match = pattern.exec(source.slice(cursor));
-    if (!match || match.index !== 0)
-      return false;
-    cursor += match[0].length;
-    return true;
-  };
-  const parseTextElement = (tag) => {
-    if (consume(`<${tag}/>`))
-      return "";
-    if (!consume(`<${tag}>`))
-      return null;
-    const close = `</${tag}>`;
-    const end = source.indexOf(close, cursor);
-    if (end < 0)
-      return null;
-    const text = source.slice(cursor, end);
-    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
-      return null;
-    }
-    cursor = end + close.length;
-    return text;
-  };
-  const validScalar = (tag, value) => {
-    if (tag === "string")
-      return true;
-    if (tag === "integer")
-      return /^[+-]?\d+$/.test(value);
-    if (tag === "real") {
-      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
-    }
-    if (tag === "date")
-      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
-    const compact = value.replace(/\s/g, "");
-    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
-  };
-  const parseValue = () => {
-    skipWhitespace();
-    const start = cursor;
-    if (consume("<dict/>"))
-      return { kind: "dict", start, end: cursor, entries: [] };
-    if (consume("<dict>")) {
-      const entries = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</dict>"))
-          return { kind: "dict", start, end: cursor, entries };
-        const entryStart = cursor;
-        const key = parseTextElement("key");
-        if (key === null)
-          return null;
-        const value = parseValue();
-        if (!value)
-          return null;
-        entries.push({ key, start: entryStart, end: value.end, value });
-      }
-    }
-    if (consume("<array/>"))
-      return { kind: "array", start, end: cursor, values: [] };
-    if (consume("<array>")) {
-      const values = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</array>"))
-          return { kind: "array", start, end: cursor, values };
-        const value = parseValue();
-        if (!value)
-          return null;
-        values.push(value);
-      }
-    }
-    if (consume("<true/>") || consume("<false/>"))
-      return { kind: "scalar", start, end: cursor };
-    for (const tag of ["string", "integer", "real", "date", "data"]) {
-      const before = cursor;
-      const value = parseTextElement(tag);
-      if (value !== null) {
-        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
-      }
-      cursor = before;
-    }
+var testWdaPlutil;
+function runWdaPlutil(args) {
+  if (process.platform !== "darwin" && !testWdaPlutil)
     return null;
-  };
-  skipWhitespace();
-  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+  try {
+    const result = testWdaPlutil ? testWdaPlutil(args) : spawnSync("plutil", [...args], { encoding: "utf8", timeout: 15e3 });
+    return result.status === 0 ? result.stdout ?? "" : null;
+  } catch {
     return null;
-  skipWhitespace();
-  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
-    return null;
-  skipWhitespace();
-  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
-    return null;
-  const root2 = parseValue();
-  if (!root2 || root2.kind !== "dict")
-    return null;
-  skipWhitespace();
-  if (!consume("</plist>"))
-    return null;
-  skipWhitespace();
-  if (cursor !== source.length)
-    return null;
-  const portEntries = [];
-  const collectPortEntries = (value) => {
-    if (value.kind === "dict") {
-      for (const entry of value.entries) {
-        if (entry.key === "USE_PORT")
-          portEntries.push(entry);
-        else
-          collectPortEntries(entry.value);
-      }
-    } else if (value.kind === "array") {
-      for (const child of value.values)
-        collectPortEntries(child);
-    }
-  };
-  collectPortEntries(root2);
-  let normalized = source;
-  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
-    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
   }
-  return normalized;
+}
+function readWdaXctestrun(xctestrunPath) {
+  const json2 = runWdaPlutil(["-convert", "json", "-o", "-", xctestrunPath]);
+  if (json2 === null)
+    return null;
+  try {
+    const plist = JSON.parse(json2);
+    return plist !== null && typeof plist === "object" && !Array.isArray(plist) ? plist : null;
+  } catch {
+    return null;
+  }
+}
+function forEachWdaTestTarget(plist, visit) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      if (configuration === null || typeof configuration !== "object")
+        continue;
+      const targets = configuration.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
+          visit(target);
+        }
+      }
+    }
+    return;
+  }
+  for (const [key, target] of Object.entries(plist)) {
+    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
+      visit(target);
+    }
+  }
+}
+function hasInjectedWdaPort(plist) {
+  let found = false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment) && Object.hasOwn(environment, "USE_PORT")) {
+      found = true;
+    }
+  });
+  return found;
 }
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join2(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync(products, { withFileTypes: true });
     const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync2(join2(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
-      if (!name.endsWith(".app"))
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join2(products, entry.name)) !== null) && entries.some((entry) => {
+      if (!entry.isDirectory())
         return false;
       try {
-        const executable = lstatSync2(join2(products, entry.name, name, name.slice(0, -".app".length)));
+        const executable = lstatSync2(join2(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
         return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
-    }));
+    });
   } catch {
     return false;
   }
 }
 function removeInjectedWdaPort(xctestrunPath) {
-  const source = readFileSync2(xctestrunPath, "utf8");
-  const normalized = parseAndNormalizeWdaXctestrun(source);
-  if (normalized === null)
+  const plist = readWdaXctestrun(xctestrunPath);
+  if (!plist)
     return false;
-  if (normalized !== source)
-    writeFileSync(xctestrunPath, normalized);
-  return true;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment)) {
+      delete environment.USE_PORT;
+    }
+  });
+  writeFileSync(xctestrunPath, JSON.stringify(plist, null, 2));
+  return runWdaPlutil(["-convert", "xml1", xctestrunPath]) !== null;
 }
 function isRealDirectory(path) {
   try {
@@ -11210,8 +11135,8 @@ function isReusableStoredWdaBuild(keyDir) {
     return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
       if (!entry.isFile())
         return false;
-      const source = readFileSync2(join2(products, entry.name), "utf8");
-      return parseAndNormalizeWdaXctestrun(source) === source;
+      const plist = readWdaXctestrun(join2(products, entry.name));
+      return plist !== null && !hasInjectedWdaPort(plist);
     });
   } catch {
     return false;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10996,11 +10996,146 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
+function parseAndNormalizeWdaXctestrun(source) {
+  let cursor = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(source[cursor] ?? ""))
+      cursor += 1;
+  };
+  const consume = (token2) => {
+    if (!source.startsWith(token2, cursor))
+      return false;
+    cursor += token2.length;
+    return true;
+  };
+  const consumePattern = (pattern) => {
+    const match = pattern.exec(source.slice(cursor));
+    if (!match || match.index !== 0)
+      return false;
+    cursor += match[0].length;
+    return true;
+  };
+  const parseTextElement = (tag) => {
+    if (consume(`<${tag}/>`))
+      return "";
+    if (!consume(`<${tag}>`))
+      return null;
+    const close = `</${tag}>`;
+    const end = source.indexOf(close, cursor);
+    if (end < 0)
+      return null;
+    const text = source.slice(cursor, end);
+    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
+      return null;
+    }
+    cursor = end + close.length;
+    return text;
+  };
+  const validScalar = (tag, value) => {
+    if (tag === "string")
+      return true;
+    if (tag === "integer")
+      return /^[+-]?\d+$/.test(value);
+    if (tag === "real") {
+      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
+    }
+    if (tag === "date")
+      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
+    const compact = value.replace(/\s/g, "");
+    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
+  };
+  const parseValue = () => {
+    skipWhitespace();
+    const start = cursor;
+    if (consume("<dict/>"))
+      return { kind: "dict", start, end: cursor, entries: [] };
+    if (consume("<dict>")) {
+      const entries = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</dict>"))
+          return { kind: "dict", start, end: cursor, entries };
+        const entryStart = cursor;
+        const key = parseTextElement("key");
+        if (key === null)
+          return null;
+        const value = parseValue();
+        if (!value)
+          return null;
+        entries.push({ key, start: entryStart, end: value.end, value });
+      }
+    }
+    if (consume("<array/>"))
+      return { kind: "array", start, end: cursor, values: [] };
+    if (consume("<array>")) {
+      const values = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</array>"))
+          return { kind: "array", start, end: cursor, values };
+        const value = parseValue();
+        if (!value)
+          return null;
+        values.push(value);
+      }
+    }
+    if (consume("<true/>") || consume("<false/>"))
+      return { kind: "scalar", start, end: cursor };
+    for (const tag of ["string", "integer", "real", "date", "data"]) {
+      const before = cursor;
+      const value = parseTextElement(tag);
+      if (value !== null) {
+        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
+      }
+      cursor = before;
+    }
+    return null;
+  };
+  skipWhitespace();
+  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+    return null;
+  skipWhitespace();
+  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
+    return null;
+  skipWhitespace();
+  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
+    return null;
+  const root2 = parseValue();
+  if (!root2 || root2.kind !== "dict")
+    return null;
+  skipWhitespace();
+  if (!consume("</plist>"))
+    return null;
+  skipWhitespace();
+  if (cursor !== source.length)
+    return null;
+  const portEntries = [];
+  const collectPortEntries = (value) => {
+    if (value.kind === "dict") {
+      for (const entry of value.entries) {
+        if (entry.key === "USE_PORT")
+          portEntries.push(entry);
+        else
+          collectPortEntries(entry.value);
+      }
+    } else if (value.kind === "array") {
+      for (const child of value.values)
+        collectPortEntries(child);
+    }
+  };
+  collectPortEntries(root2);
+  let normalized = source;
+  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
+    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
+  }
+  return normalized;
+}
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join2(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync(products, { withFileTypes: true });
-    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
+    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync2(join2(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
       if (!name.endsWith(".app"))
         return false;
       try {
@@ -11016,8 +11151,8 @@ function isCompleteWdaBuild(keyDir) {
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const source = readFileSync2(xctestrunPath, "utf8");
-  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
-  if (normalized.includes("USE_PORT"))
+  const normalized = parseAndNormalizeWdaXctestrun(source);
+  if (normalized === null)
     return false;
   if (normalized !== source)
     writeFileSync(xctestrunPath, normalized);
@@ -11072,7 +11207,12 @@ function isReusableStoredWdaBuild(keyDir) {
       return false;
     }
     const products = join2(keyDir, "DerivedData", "Build", "Products");
-    return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync2(join2(products, entry.name), "utf8").includes("USE_PORT"));
+    return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
+      if (!entry.isFile())
+        return false;
+      const source = readFileSync2(join2(products, entry.name), "utf8");
+      return parseAndNormalizeWdaXctestrun(source) === source;
+    });
   } catch {
     return false;
   }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71985,6 +71985,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       "--"
     ]);
   } finally {
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
+    }
     try {
       chmodSync5(snapshotRoot, 448);
       for (const entry of readdirSync8(snapshotRoot, { recursive: true, withFileTypes: true })) {
@@ -71997,11 +72002,6 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync5(entryPath, 384);
       }
     } catch {
-    }
-    if (cacheRoot) {
-      recordRunnerDiagnostic("cache-publish", {
-        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
-      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71750,167 +71750,91 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
-function parseAndNormalizeWdaXctestrun(source) {
-  let cursor = 0;
-  const skipWhitespace = () => {
-    while (/\s/.test(source[cursor] ?? ""))
-      cursor += 1;
-  };
-  const consume = (token2) => {
-    if (!source.startsWith(token2, cursor))
-      return false;
-    cursor += token2.length;
-    return true;
-  };
-  const consumePattern = (pattern) => {
-    const match = pattern.exec(source.slice(cursor));
-    if (!match || match.index !== 0)
-      return false;
-    cursor += match[0].length;
-    return true;
-  };
-  const parseTextElement = (tag) => {
-    if (consume(`<${tag}/>`))
-      return "";
-    if (!consume(`<${tag}>`))
-      return null;
-    const close = `</${tag}>`;
-    const end = source.indexOf(close, cursor);
-    if (end < 0)
-      return null;
-    const text = source.slice(cursor, end);
-    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
-      return null;
-    }
-    cursor = end + close.length;
-    return text;
-  };
-  const validScalar = (tag, value) => {
-    if (tag === "string")
-      return true;
-    if (tag === "integer")
-      return /^[+-]?\d+$/.test(value);
-    if (tag === "real") {
-      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
-    }
-    if (tag === "date")
-      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
-    const compact = value.replace(/\s/g, "");
-    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
-  };
-  const parseValue = () => {
-    skipWhitespace();
-    const start = cursor;
-    if (consume("<dict/>"))
-      return { kind: "dict", start, end: cursor, entries: [] };
-    if (consume("<dict>")) {
-      const entries = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</dict>"))
-          return { kind: "dict", start, end: cursor, entries };
-        const entryStart = cursor;
-        const key = parseTextElement("key");
-        if (key === null)
-          return null;
-        const value = parseValue();
-        if (!value)
-          return null;
-        entries.push({ key, start: entryStart, end: value.end, value });
-      }
-    }
-    if (consume("<array/>"))
-      return { kind: "array", start, end: cursor, values: [] };
-    if (consume("<array>")) {
-      const values = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</array>"))
-          return { kind: "array", start, end: cursor, values };
-        const value = parseValue();
-        if (!value)
-          return null;
-        values.push(value);
-      }
-    }
-    if (consume("<true/>") || consume("<false/>"))
-      return { kind: "scalar", start, end: cursor };
-    for (const tag of ["string", "integer", "real", "date", "data"]) {
-      const before = cursor;
-      const value = parseTextElement(tag);
-      if (value !== null) {
-        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
-      }
-      cursor = before;
-    }
+function runWdaPlutil(args) {
+  if (process.platform !== "darwin" && !testWdaPlutil)
     return null;
-  };
-  skipWhitespace();
-  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+  try {
+    const result = testWdaPlutil ? testWdaPlutil(args) : spawnSync3("plutil", [...args], { encoding: "utf8", timeout: 15e3 });
+    return result.status === 0 ? result.stdout ?? "" : null;
+  } catch {
     return null;
-  skipWhitespace();
-  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
-    return null;
-  skipWhitespace();
-  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
-    return null;
-  const root = parseValue();
-  if (!root || root.kind !== "dict")
-    return null;
-  skipWhitespace();
-  if (!consume("</plist>"))
-    return null;
-  skipWhitespace();
-  if (cursor !== source.length)
-    return null;
-  const portEntries = [];
-  const collectPortEntries = (value) => {
-    if (value.kind === "dict") {
-      for (const entry of value.entries) {
-        if (entry.key === "USE_PORT")
-          portEntries.push(entry);
-        else
-          collectPortEntries(entry.value);
-      }
-    } else if (value.kind === "array") {
-      for (const child of value.values)
-        collectPortEntries(child);
-    }
-  };
-  collectPortEntries(root);
-  let normalized = source;
-  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
-    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
   }
-  return normalized;
+}
+function readWdaXctestrun(xctestrunPath) {
+  const json = runWdaPlutil(["-convert", "json", "-o", "-", xctestrunPath]);
+  if (json === null)
+    return null;
+  try {
+    const plist = JSON.parse(json);
+    return plist !== null && typeof plist === "object" && !Array.isArray(plist) ? plist : null;
+  } catch {
+    return null;
+  }
+}
+function forEachWdaTestTarget(plist, visit) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      if (configuration === null || typeof configuration !== "object")
+        continue;
+      const targets = configuration.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
+          visit(target);
+        }
+      }
+    }
+    return;
+  }
+  for (const [key, target] of Object.entries(plist)) {
+    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
+      visit(target);
+    }
+  }
+}
+function hasInjectedWdaPort(plist) {
+  let found = false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment) && Object.hasOwn(environment, "USE_PORT")) {
+      found = true;
+    }
+  });
+  return found;
 }
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join35(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync8(products, { withFileTypes: true });
     const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync25(join35(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
-      if (!name.endsWith(".app"))
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join35(products, entry.name)) !== null) && entries.some((entry) => {
+      if (!entry.isDirectory())
         return false;
       try {
-        const executable = lstatSync12(join35(products, entry.name, name, name.slice(0, -".app".length)));
+        const executable = lstatSync12(join35(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
         return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
-    }));
+    });
   } catch {
     return false;
   }
 }
 function removeInjectedWdaPort(xctestrunPath) {
-  const source = readFileSync25(xctestrunPath, "utf8");
-  const normalized = parseAndNormalizeWdaXctestrun(source);
-  if (normalized === null)
+  const plist = readWdaXctestrun(xctestrunPath);
+  if (!plist)
     return false;
-  if (normalized !== source)
-    writeFileSync12(xctestrunPath, normalized);
-  return true;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment)) {
+      delete environment.USE_PORT;
+    }
+  });
+  writeFileSync12(xctestrunPath, JSON.stringify(plist, null, 2));
+  return runWdaPlutil(["-convert", "xml1", xctestrunPath]) !== null;
 }
 function isRealDirectory(path) {
   try {
@@ -71964,8 +71888,8 @@ function isReusableStoredWdaBuild(keyDir) {
     return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
       if (!entry.isFile())
         return false;
-      const source = readFileSync25(join35(products, entry.name), "utf8");
-      return parseAndNormalizeWdaXctestrun(source) === source;
+      const plist = readWdaXctestrun(join35(products, entry.name));
+      return plist !== null && !hasInjectedWdaPort(plist);
     });
   } catch {
     return false;
@@ -72287,7 +72211,7 @@ function getEngineStatus(resolvers) {
     return Promise.resolve(testStatus);
   return detect(resolvers ?? {}).catch(() => buildReplayEngineStatus("unknown-version", null, false));
 }
-var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testWdaToolchainFingerprint, testStatus, testAttestation;
+var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testWdaToolchainFingerprint, testWdaPlutil, testStatus, testAttestation;
 var init_engine_pin = __esm({
   "packages/rn-dev-agent-core/dist/domain/engine-pin.js"() {
     "use strict";

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71308,7 +71308,7 @@ import { spawnSync as spawnSync3 } from "node:child_process";
 import { createHash as createHash13 } from "node:crypto";
 import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11, writeFileSync as writeFileSync12 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { basename as basename6, dirname as dirname17, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
+import { basename as basename6, dirname as dirname17, isAbsolute as isAbsolute9, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
 import { gunzipSync } from "node:zlib";
 function parseActionEnginePinVersion(enginePin) {
   const match = ACTION_ENGINE_PIN_RE.exec(enginePin.trim());
@@ -71771,28 +71771,50 @@ function readWdaXctestrun(xctestrunPath) {
     return null;
   }
 }
+function asWdaPlistRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
 function forEachWdaTestTarget(plist, visit) {
   const configurations = plist.TestConfigurations;
   if (Array.isArray(configurations)) {
     for (const configuration of configurations) {
-      if (configuration === null || typeof configuration !== "object")
+      const configurationRecord = asWdaPlistRecord(configuration);
+      if (!configurationRecord)
         continue;
-      const targets = configuration.TestTargets;
+      const targets = configurationRecord.TestTargets;
       if (!Array.isArray(targets))
         continue;
       for (const target of targets) {
-        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
-          visit(target);
-        }
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord)
+          visit(targetRecord);
       }
     }
     return;
   }
   for (const [key, target] of Object.entries(plist)) {
-    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
-      visit(target);
-    }
+    const targetRecord = asWdaPlistRecord(target);
+    if (key !== "__xctestrun_metadata__" && targetRecord)
+      visit(targetRecord);
   }
+}
+function findWdaTestTarget(plist) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      const targets = asWdaPlistRecord(configuration)?.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord && (targetRecord.TestTargetName === "WebDriverAgentRunner" || targetRecord.BlueprintName === "WebDriverAgentRunner")) {
+          return targetRecord;
+        }
+      }
+    }
+    return null;
+  }
+  return asWdaPlistRecord(plist.WebDriverAgentRunner);
 }
 function hasInjectedWdaPort(plist) {
   let found = false;
@@ -71804,24 +71826,79 @@ function hasInjectedWdaPort(plist) {
   });
   return found;
 }
-function isCompleteWdaBuild(keyDir) {
-  try {
-    const products = join35(keyDir, "DerivedData", "Build", "Products");
-    const entries = readdirSync8(products, { withFileTypes: true });
-    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join35(products, entry.name)) !== null) && entries.some((entry) => {
-      if (!entry.isDirectory())
-        return false;
-      try {
-        const executable = lstatSync12(join35(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
-        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
-      } catch {
+function isWithinWdaKey(keyDir, candidate) {
+  const path = relative7(keyDir, candidate);
+  return path === "" || path !== ".." && !path.startsWith(`..${sep6}`) && !isAbsolute9(path);
+}
+function isContainedWdaProductTree(keyDir, products) {
+  const lexicalKey = resolve12(keyDir);
+  const realKey = realpathSync13(keyDir);
+  const visit = (directory) => {
+    for (const entry of readdirSync8(directory, { withFileTypes: true })) {
+      const path = join35(directory, entry.name);
+      const stat2 = lstatSync12(path);
+      if (stat2.isSymbolicLink()) {
+        const target = readlinkSync5(path);
+        if (isAbsolute9(target) || !isWithinWdaKey(lexicalKey, resolve12(directory, target)) || !isWithinWdaKey(realKey, realpathSync13(path))) {
+          return false;
+        }
+      } else if (stat2.isDirectory() && !visit(path)) {
         return false;
       }
-    });
-  } catch {
-    return false;
+    }
+    return true;
+  };
+  return visit(products);
+}
+function resolveWdaProductReference(reference, products, testHost) {
+  if (typeof reference !== "string")
+    return null;
+  if (reference.startsWith("__TESTROOT__/")) {
+    return resolve12(products, reference.slice("__TESTROOT__/".length));
   }
+  if (testHost && reference.startsWith("__TESTHOST__/")) {
+    return resolve12(testHost, reference.slice("__TESTHOST__/".length));
+  }
+  return null;
+}
+function readCompleteWdaBuildManifest(keyDir) {
+  try {
+    const derivedData = join35(keyDir, "DerivedData");
+    const build = join35(derivedData, "Build");
+    const products = join35(build, "Products");
+    if (!isRealDirectory(keyDir) || !isRealDirectory(derivedData) || !isRealDirectory(build) || !isRealDirectory(products) || !isContainedWdaProductTree(keyDir, products)) {
+      return null;
+    }
+    const selected = readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)[0];
+    if (!selected?.isFile())
+      return null;
+    const selectedXctestrun = join35(products, selected.name);
+    const plist = readWdaXctestrun(selectedXctestrun);
+    const target = plist && findWdaTestTarget(plist);
+    if (!target)
+      return null;
+    const testHost = resolveWdaProductReference(target.TestHostPath, products);
+    if (!testHost)
+      return null;
+    const hostPath = relative7(products, testHost).split(sep6);
+    if (hostPath.length !== 2 || hostPath[1] !== "WebDriverAgentRunner-Runner.app" || !isRealDirectory(join35(products, hostPath[0])) || !isRealDirectory(testHost)) {
+      return null;
+    }
+    const executable = lstatSync12(join35(testHost, "WebDriverAgentRunner-Runner"));
+    if (!executable.isFile() || executable.isSymbolicLink() || (executable.mode & 73) === 0) {
+      return null;
+    }
+    const testBundle = resolveWdaProductReference(target.TestBundlePath, products, testHost);
+    if (!testBundle || !isWithinWdaKey(resolve12(keyDir), testBundle) || !existsSync24(testBundle)) {
+      return null;
+    }
+    return { products, selectedXctestrun };
+  } catch {
+    return null;
+  }
+}
+function isCompleteWdaBuild(keyDir) {
+  return readCompleteWdaBuildManifest(keyDir) !== null;
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const plist = readWdaXctestrun(xctestrunPath);
@@ -71845,10 +71922,10 @@ function isRealDirectory(path) {
   }
 }
 function copyReusableWdaBuild(sourceKey, stagedKey) {
-  const sourceProducts = join35(sourceKey, "DerivedData", "Build", "Products");
-  if (!isRealDirectory(sourceKey) || !isRealDirectory(join35(sourceKey, "DerivedData")) || !isRealDirectory(join35(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+  const manifest = readCompleteWdaBuildManifest(sourceKey);
+  if (!manifest)
     return false;
-  }
+  const sourceProducts = manifest.products;
   const stagedProducts = join35(stagedKey, "DerivedData", "Build", "Products");
   mkdirSync17(dirname17(stagedProducts), { recursive: true });
   cpSync2(sourceProducts, stagedProducts, {
@@ -72678,7 +72755,7 @@ var init_device_existence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname18, isAbsolute as isAbsolute9, join as join37, resolve as resolve13 } from "node:path";
+import { dirname as dirname18, isAbsolute as isAbsolute10, join as join37, resolve as resolve13 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { createHash as createHash15 } from "node:crypto";
 function sameAndroidMetroReverse(current, next) {
@@ -72764,7 +72841,7 @@ function sessionSourceResolver(status, dependencies) {
   return (root) => resolveSourceIdentity(root, stored?.kind === "declared-root" ? { declaredRoot: stored.contentRoot, declaredManifests: stored.declaredManifests } : {});
 }
 function anchorDeclaredProjectRoot(status, projectRoot) {
-  if (isAbsolute9(projectRoot))
+  if (isAbsolute10(projectRoot))
     return projectRoot;
   const boundAppRoot = status.source?.appRoot;
   return typeof boundAppRoot === "string" && boundAppRoot.length > 0 ? resolve13(boundAppRoot, projectRoot) : projectRoot;
@@ -75781,11 +75858,11 @@ var init_events = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/recorder.js
 import { closeSync as closeSync10, constants as constants8, fstatSync as fstatSync7, openSync as openSync10, readSync as readSync4 } from "node:fs";
-import { isAbsolute as isAbsolute10 } from "node:path";
+import { isAbsolute as isAbsolute11 } from "node:path";
 function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute10(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+  return typeof p === "string" && isAbsolute11(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
 }
 function readShotBounded(p) {
   let fd;
@@ -75878,7 +75955,7 @@ var init_recorder = __esm({
        * whatever path the pipeline actually captured to.
        */
       registerCapturedScreenshot(p) {
-        if (typeof p !== "string" || !isAbsolute10(p))
+        if (typeof p !== "string" || !isAbsolute11(p))
           return;
         this.trustedShotPaths.delete(p);
         this.trustedShotPaths.add(p);
@@ -77538,7 +77615,7 @@ var init_atomic_writer = __esm({
 // packages/rn-dev-agent-core/dist/domain/unfollowed-file.js
 import { execFileSync as execFileSync15 } from "node:child_process";
 import { lstatSync as lstatSync14 } from "node:fs";
-import { isAbsolute as isAbsolute11, join as join39 } from "node:path";
+import { isAbsolute as isAbsolute12, join as join39 } from "node:path";
 function createUnfollowedFileSnapshot(directoryPath, directoryIdentity2) {
   return { directoryPath, directoryIdentity: directoryIdentity2, fileIdentities: /* @__PURE__ */ new Map() };
 }
@@ -77636,7 +77713,7 @@ function readUnfollowedFiles(directoryPath, identity2, relativePaths, expectedId
       throw new Error("Selected file identities did not match the requested paths.");
     }
     const entries = relativePaths.map((relativePath, index) => {
-      if (isAbsolute11(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
+      if (isAbsolute12(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
         throw new Error(`Invalid relative path: ${relativePath}.`);
       }
       if (expectedIdentities) {
@@ -77824,7 +77901,7 @@ try {
 
 // packages/rn-dev-agent-core/dist/domain/action-store.js
 import { existsSync as existsSync27, lstatSync as lstatSync15, readFileSync as readFileSync28, statSync as statSync14, unlinkSync as unlinkSync13 } from "node:fs";
-import { basename as basename8, dirname as dirname21, isAbsolute as isAbsolute12, join as join40, relative as relative8, resolve as resolve16, sep as sep8 } from "node:path";
+import { basename as basename8, dirname as dirname21, isAbsolute as isAbsolute13, join as join40, relative as relative8, resolve as resolve16, sep as sep8 } from "node:path";
 function actionPathFor(projectRoot, actionId) {
   assertValidActionId(actionId, "actionPathFor");
   const actionsDir = join40(projectRoot, ".rn-agent", "actions");
@@ -77889,11 +77966,11 @@ function ownedActionPathIdentityMatches(entries) {
   }
 }
 function referencedActionPath(parentFile, reference) {
-  if (isAbsolute12(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
+  if (isAbsolute13(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
     return null;
   }
   const child = join40(dirname21(parentFile), reference);
-  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child))
+  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child))
     return null;
   return child;
 }
@@ -78128,7 +78205,7 @@ function captureActionFromContext(context, actionId) {
       flowRoot: snapshot.directory,
       readFileFn: (path) => {
         const child = relative8(snapshot.directory, path);
-        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child)) {
+        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child)) {
           throw new Error(`Refusing action flow outside ${snapshot.directory}.`);
         }
         const text2 = context.fileContents.get(child);
@@ -80463,7 +80540,7 @@ var init_maestro_device_authority = __esm({
 import { existsSync as existsSync29, readFileSync as readFileSync29, readdirSync as readdirSync11, realpathSync as realpathSync15, rmSync as rmSync11 } from "node:fs";
 import { createHash as createHash16 } from "node:crypto";
 import { tmpdir as tmpdir9 } from "node:os";
-import { isAbsolute as isAbsolute13, join as join43, sep as sep9 } from "node:path";
+import { isAbsolute as isAbsolute14, join as join43, sep as sep9 } from "node:path";
 function idsFrom(value, keys) {
   if (!value || typeof value !== "object")
     return [];
@@ -80602,7 +80679,7 @@ function readStructuredFlowArtifact(reportDir, previous) {
     if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
       return unfinalized;
     const normalizedDataFile = flow.dataFile;
-    if (isAbsolute13(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
       return unfinalized;
     }
     const realDataFile = realpathSync15(join43(reportDir, normalizedDataFile));
@@ -88608,7 +88685,7 @@ var init_startup_integrity = __esm({
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
 import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
-import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute14, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
+import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute15, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
   if (!unparsedArgs || typeof unparsedArgs !== "object" || Array.isArray(unparsedArgs)) {
@@ -88648,7 +88725,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let loadedCoreBundlePath = null;
   let coreBundleSha256 = null;
   try {
-    if (typeof argv[1] === "string" && isAbsolute14(argv[1])) {
+    if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
       executedEntrypointPath = realpathSync16(argv[1]);
     }
   } catch {
@@ -88685,7 +88762,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   const authorityArg = argv[1];
-  if (typeof authorityArg !== "string" || !isAbsolute14(authorityArg))
+  if (typeof authorityArg !== "string" || !isAbsolute15(authorityArg))
     return null;
   let arg;
   try {
@@ -88734,7 +88811,7 @@ function proofCandidateStartupMatches(entrypoint, startup, headCoreBundleSha256)
 }
 function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   const normalizedOverride = (value) => {
-    if (!value || !isAbsolute14(value))
+    if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
       return realpathSync16(value);
@@ -88873,11 +88950,11 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
   }
 }
 function isNormalizedDescendant(root, path) {
-  if (!isAbsolute14(root) || !isAbsolute14(path) || resolve18(root) !== root || resolve18(path) !== path) {
+  if (!isAbsolute15(root) || !isAbsolute15(path) || resolve18(root) !== root || resolve18(path) !== path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute14(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
   const parts = relative9(root, path).split(sep10);
@@ -88926,7 +89003,7 @@ function proofRootExists(args) {
   }
 }
 function resolveProofWorktreeRoot(detectedProjectRoot) {
-  if (!detectedProjectRoot || !isAbsolute14(detectedProjectRoot) || resolve18(detectedProjectRoot) !== detectedProjectRoot) {
+  if (!detectedProjectRoot || !isAbsolute15(detectedProjectRoot) || resolve18(detectedProjectRoot) !== detectedProjectRoot) {
     return null;
   }
   try {
@@ -88934,7 +89011,7 @@ function resolveProofWorktreeRoot(detectedProjectRoot) {
       cwd: detectedProjectRoot,
       encoding: "utf8"
     }).trim();
-    return root && isAbsolute14(root) && resolve18(root) === root ? root : null;
+    return root && isAbsolute15(root) && resolve18(root) === root ? root : null;
   } catch {
     return null;
   }
@@ -89261,7 +89338,7 @@ function createProofCaptureHandler(deps) {
     ].map((path) => repositoryPath(active, path));
     const requiredOutputs = new Set(phase === "finalized" ? [...proofOutputs, repositoryPath(active, active.context.receiptPath)] : proofOutputs);
     const allowedOutputs = phase === "setup" ? observedSetupScreenshots(active) : phase === "clean" ? /* @__PURE__ */ new Set() : requiredOutputs;
-    const invalidChange = git2.changes.some((change) => isAbsolute14(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
+    const invalidChange = git2.changes.some((change) => isAbsolute15(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
     const changedPaths = new Set(git2.changes.map((change) => change.path.replaceAll("\\", "/")));
     const unrelated = [...changedPaths].some((path) => !allowedOutputs.has(path));
     const missing = (phase === "validation" || phase === "finalized") && [...requiredOutputs].some((path) => !changedPaths.has(path));
@@ -89876,7 +89953,7 @@ var init_proof_capture2 = __esm({
     init_proof_receipt();
     init_utils();
     init_startup_integrity();
-    absolutePathSchema = external_exports.string().min(1).refine(isAbsolute14, "path must be absolute");
+    absolutePathSchema = external_exports.string().min(1).refine(isAbsolute15, "path must be absolute");
     beginRehearsalSchema = external_exports.object({
       action: external_exports.literal("begin_rehearsal"),
       projectRoot: absolutePathSchema,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71304,8 +71304,9 @@ var init_maestro_runner_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
+import { spawnSync as spawnSync3 } from "node:child_process";
 import { createHash as createHash13 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
+import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename6, dirname as dirname17, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -71716,6 +71717,134 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error2));
   }
 }
+function wdaToolchainFingerprint() {
+  if (memoizedWdaToolchainFingerprint !== void 0)
+    return memoizedWdaToolchainFingerprint;
+  try {
+    const probe = spawnSync3("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
+    const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
+    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+  } catch {
+    memoizedWdaToolchainFingerprint = null;
+  }
+  return memoizedWdaToolchainFingerprint;
+}
+function persistentWdaStoreBuildsRoot() {
+  const fingerprint = wdaToolchainFingerprint();
+  if (!fingerprint)
+    return null;
+  const versionsRoot = runnerCacheVersionsRoot();
+  const components = [
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+  ];
+  for (const component of components) {
+    try {
+      const stat2 = lstatSync12(component);
+      if (!stat2.isDirectory() || stat2.isSymbolicLink())
+        return null;
+    } catch {
+      break;
+    }
+  }
+  return components[2];
+}
+function isCompleteWdaBuild(keyDir) {
+  try {
+    const products = join35(keyDir, "DerivedData", "Build", "Products");
+    const entries = readdirSync8(products, { withFileTypes: true });
+    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
+      if (!name.endsWith(".app"))
+        return false;
+      try {
+        const executable = lstatSync12(join35(products, entry.name, name, name.slice(0, -".app".length)));
+        return executable.isFile() && !executable.isSymbolicLink();
+      } catch {
+        return false;
+      }
+    }));
+  } catch {
+    return false;
+  }
+}
+function copyWdaBuildKey(sourceKey, stagedKey) {
+  cpSync2(sourceKey, stagedKey, {
+    recursive: true,
+    mode: constants7.COPYFILE_FICLONE,
+    verbatimSymlinks: true
+  });
+  return isCompleteWdaBuild(stagedKey);
+}
+function seedRunnerSnapshotCacheFromStore(cacheRoot) {
+  let seeded = 0;
+  try {
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    const target = join35(cacheRoot, "wda-builds");
+    for (const entry of readdirSync8(storeBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory())
+        continue;
+      const sourceKey = join35(storeBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      mkdirSync17(target, { recursive: true });
+      const stagedKey = join35(target, `.seed-${entry.name}`);
+      try {
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          renameSync7(stagedKey, join35(target, entry.name));
+          seeded += 1;
+        } else {
+          rmSync10(stagedKey, { recursive: true, force: true });
+        }
+      } catch {
+        try {
+          rmSync10(stagedKey, { recursive: true, force: true });
+        } catch {
+        }
+      }
+    }
+  } catch {
+  }
+  return seeded;
+}
+function publishRunnerSnapshotCacheToStore(cacheRoot) {
+  let published = 0;
+  try {
+    const spawnBuilds = join35(cacheRoot, "wda-builds");
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    for (const entry of readdirSync8(spawnBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith("."))
+        continue;
+      const sourceKey = join35(spawnBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      const storeKey = join35(storeBuilds, entry.name);
+      if (isCompleteWdaBuild(storeKey))
+        continue;
+      mkdirSync17(storeBuilds, { recursive: true, mode: 448 });
+      const stage = mkdtempSync2(join35(storeBuilds, ".stage-"));
+      try {
+        const stagedKey = join35(stage, entry.name);
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          if (existsSync24(storeKey)) {
+            const evicted = join35(stage, "evicted");
+            renameSync7(storeKey, evicted);
+          }
+          renameSync7(stagedKey, storeKey);
+          published += 1;
+        }
+      } finally {
+        rmSync10(stage, { recursive: true, force: true });
+      }
+    }
+  } catch {
+  }
+  return published;
+}
 function provisionRunnerSnapshotCache(snapshotRoot, testHooks = {}, setOwnedCacheRoot = () => {
 }) {
   const cacheRoot = expectedRunnerCacheRoot(snapshotRoot);
@@ -71836,8 +71965,12 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       }
     }
     chmodSync5(snapshotRoot, 320);
-    if (cacheRoot)
+    if (cacheRoot) {
       assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+      recordRunnerDiagnostic("cache-seed", {
+        seededBuilds: seedRunnerSnapshotCacheFromStore(cacheRoot)
+      });
+    }
     const openedRunner = lstatSync12(snapshotRunner);
     recordRunnerDiagnostic("runner-exec-begin", { runnerPinVersion: MAESTRO_RUNNER_PIN.version });
     if (platform === "ios") {
@@ -71863,6 +71996,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync5(entryPath, 384);
       }
     } catch {
+    }
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
@@ -71954,7 +72092,7 @@ function getEngineStatus(resolvers) {
     return Promise.resolve(testStatus);
   return detect(resolvers ?? {}).catch(() => buildReplayEngineStatus("unknown-version", null, false));
 }
-var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testStatus, testAttestation;
+var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, memoizedWdaToolchainFingerprint, testStatus, testAttestation;
 var init_engine_pin = __esm({
   "packages/rn-dev-agent-core/dist/domain/engine-pin.js"() {
     "use strict";
@@ -76825,7 +76963,7 @@ var init_macro_asserts = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
-import { writeFileSync as writeFileSync12, renameSync as renameSync7, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
+import { writeFileSync as writeFileSync12, renameSync as renameSync8, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
 import { dirname as dirname20, basename as basename7 } from "node:path";
 function generateTmpStamp() {
   const rand = Math.random().toString(36).slice(2, 10);
@@ -77134,7 +77272,7 @@ var init_atomic_writer = __esm({
       },
       /** Underlying `fs.renameSync(from, to)`. */
       _rename(from, to) {
-        renameSync7(from, to);
+        renameSync8(from, to);
       },
       /** Underlying `fs.statSync(path).mtimeMs`. */
       _statMtimeMs(path) {
@@ -84369,7 +84507,7 @@ var init_interact = __esm({
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash18, randomBytes as randomBytes8, randomUUID as randomUUID11 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync8, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname24, join as join45 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -84710,7 +84848,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   }
   const temporary = join45(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
   writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
-  renameSync8(temporary, outputPath);
+  renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
@@ -85052,7 +85190,7 @@ var init_evidence = __esm({
             flag: "wx",
             mode: 384
           });
-          renameSync8(temp, this.path);
+          renameSync9(temp, this.path);
           chmodSync7(this.path, 384);
         } catch (error2) {
           try {
@@ -88350,7 +88488,7 @@ var init_startup_integrity = __esm({
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16 } from "node:fs";
 import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute14, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
@@ -88819,7 +88957,7 @@ function writeProofReceiptAtomic(path, receipt2) {
     fsyncSync(descriptor);
     closeSync12(descriptor);
     descriptor = null;
-    renameSync9(temporary, path);
+    renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -94380,7 +94518,7 @@ var init_target = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname32, join as join57 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash23 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join57(projectRoot, ".rn-agent", "e2e");
@@ -94431,7 +94569,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
   };
   const tmp = `${filePath}.tmp`;
   writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
+  renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
@@ -94663,7 +94801,7 @@ var init_lock_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -94723,7 +94861,7 @@ function writeJsonAtomic(file, value) {
   mkdirSync23(join59(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync11(tmp, file);
+  renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
   const file = join59(e2eRunsDirFor(projectRoot), "index.json");
@@ -94776,7 +94914,7 @@ var init_e2e_run = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join60 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 function requestsDir(projectRoot) {
   return join60(e2eRunsDirFor(projectRoot), "requests");
 }
@@ -94789,7 +94927,7 @@ function writeRequest(projectRoot, req) {
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync12(tmp, file);
+  renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71729,15 +71729,16 @@ function wdaToolchainFingerprint() {
   }
   return memoizedWdaToolchainFingerprint;
 }
-function persistentWdaStoreBuildsRoot() {
+function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
-  if (!fingerprint)
+  if (!fingerprint || !pinArchiveCoords(platformKey))
     return null;
   const versionsRoot = runnerCacheVersionsRoot();
   const components = [
     join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
-    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
-    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint, "wda-builds")
   ];
   for (const component of components) {
     try {
@@ -71748,7 +71749,7 @@ function persistentWdaStoreBuildsRoot() {
       break;
     }
   }
-  return components[2];
+  return components[3];
 }
 function isCompleteWdaBuild(keyDir) {
   try {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71750,11 +71750,146 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
+function parseAndNormalizeWdaXctestrun(source) {
+  let cursor = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(source[cursor] ?? ""))
+      cursor += 1;
+  };
+  const consume = (token2) => {
+    if (!source.startsWith(token2, cursor))
+      return false;
+    cursor += token2.length;
+    return true;
+  };
+  const consumePattern = (pattern) => {
+    const match = pattern.exec(source.slice(cursor));
+    if (!match || match.index !== 0)
+      return false;
+    cursor += match[0].length;
+    return true;
+  };
+  const parseTextElement = (tag) => {
+    if (consume(`<${tag}/>`))
+      return "";
+    if (!consume(`<${tag}>`))
+      return null;
+    const close = `</${tag}>`;
+    const end = source.indexOf(close, cursor);
+    if (end < 0)
+      return null;
+    const text = source.slice(cursor, end);
+    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
+      return null;
+    }
+    cursor = end + close.length;
+    return text;
+  };
+  const validScalar = (tag, value) => {
+    if (tag === "string")
+      return true;
+    if (tag === "integer")
+      return /^[+-]?\d+$/.test(value);
+    if (tag === "real") {
+      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
+    }
+    if (tag === "date")
+      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
+    const compact = value.replace(/\s/g, "");
+    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
+  };
+  const parseValue = () => {
+    skipWhitespace();
+    const start = cursor;
+    if (consume("<dict/>"))
+      return { kind: "dict", start, end: cursor, entries: [] };
+    if (consume("<dict>")) {
+      const entries = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</dict>"))
+          return { kind: "dict", start, end: cursor, entries };
+        const entryStart = cursor;
+        const key = parseTextElement("key");
+        if (key === null)
+          return null;
+        const value = parseValue();
+        if (!value)
+          return null;
+        entries.push({ key, start: entryStart, end: value.end, value });
+      }
+    }
+    if (consume("<array/>"))
+      return { kind: "array", start, end: cursor, values: [] };
+    if (consume("<array>")) {
+      const values = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</array>"))
+          return { kind: "array", start, end: cursor, values };
+        const value = parseValue();
+        if (!value)
+          return null;
+        values.push(value);
+      }
+    }
+    if (consume("<true/>") || consume("<false/>"))
+      return { kind: "scalar", start, end: cursor };
+    for (const tag of ["string", "integer", "real", "date", "data"]) {
+      const before = cursor;
+      const value = parseTextElement(tag);
+      if (value !== null) {
+        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
+      }
+      cursor = before;
+    }
+    return null;
+  };
+  skipWhitespace();
+  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+    return null;
+  skipWhitespace();
+  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
+    return null;
+  skipWhitespace();
+  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
+    return null;
+  const root = parseValue();
+  if (!root || root.kind !== "dict")
+    return null;
+  skipWhitespace();
+  if (!consume("</plist>"))
+    return null;
+  skipWhitespace();
+  if (cursor !== source.length)
+    return null;
+  const portEntries = [];
+  const collectPortEntries = (value) => {
+    if (value.kind === "dict") {
+      for (const entry of value.entries) {
+        if (entry.key === "USE_PORT")
+          portEntries.push(entry);
+        else
+          collectPortEntries(entry.value);
+      }
+    } else if (value.kind === "array") {
+      for (const child of value.values)
+        collectPortEntries(child);
+    }
+  };
+  collectPortEntries(root);
+  let normalized = source;
+  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
+    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
+  }
+  return normalized;
+}
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join35(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync8(products, { withFileTypes: true });
-    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
+    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync25(join35(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
       if (!name.endsWith(".app"))
         return false;
       try {
@@ -71770,8 +71905,8 @@ function isCompleteWdaBuild(keyDir) {
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const source = readFileSync25(xctestrunPath, "utf8");
-  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
-  if (normalized.includes("USE_PORT"))
+  const normalized = parseAndNormalizeWdaXctestrun(source);
+  if (normalized === null)
     return false;
   if (normalized !== source)
     writeFileSync12(xctestrunPath, normalized);
@@ -71826,7 +71961,12 @@ function isReusableStoredWdaBuild(keyDir) {
       return false;
     }
     const products = join35(keyDir, "DerivedData", "Build", "Products");
-    return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync25(join35(products, entry.name), "utf8").includes("USE_PORT"));
+    return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
+      if (!entry.isFile())
+        return false;
+      const source = readFileSync25(join35(products, entry.name), "utf8");
+      return parseAndNormalizeWdaXctestrun(source) === source;
+    });
   } catch {
     return false;
   }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71306,7 +71306,7 @@ var init_maestro_runner_pin = __esm({
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
 import { spawnSync as spawnSync3 } from "node:child_process";
 import { createHash as createHash13 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
+import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11, writeFileSync as writeFileSync12 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename6, dirname as dirname17, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -71768,13 +71768,68 @@ function isCompleteWdaBuild(keyDir) {
     return false;
   }
 }
-function copyWdaBuildKey(sourceKey, stagedKey) {
-  cpSync2(sourceKey, stagedKey, {
+function removeInjectedWdaPort(xctestrunPath) {
+  const source = readFileSync25(xctestrunPath, "utf8");
+  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
+  if (normalized.includes("USE_PORT"))
+    return false;
+  if (normalized !== source)
+    writeFileSync12(xctestrunPath, normalized);
+  return true;
+}
+function isRealDirectory(path) {
+  try {
+    const stat2 = lstatSync12(path);
+    return stat2.isDirectory() && !stat2.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function copyReusableWdaBuild(sourceKey, stagedKey) {
+  const sourceProducts = join35(sourceKey, "DerivedData", "Build", "Products");
+  if (!isRealDirectory(sourceKey) || !isRealDirectory(join35(sourceKey, "DerivedData")) || !isRealDirectory(join35(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+    return false;
+  }
+  const stagedProducts = join35(stagedKey, "DerivedData", "Build", "Products");
+  mkdirSync17(dirname17(stagedProducts), { recursive: true });
+  cpSync2(sourceProducts, stagedProducts, {
     recursive: true,
     mode: constants7.COPYFILE_FICLONE,
     verbatimSymlinks: true
   });
+  for (const entry of readdirSync8(stagedProducts, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".xctestrun") && !removeInjectedWdaPort(join35(stagedProducts, entry.name))) {
+      return false;
+    }
+  }
   return isCompleteWdaBuild(stagedKey);
+}
+function isReusableStoredWdaBuild(keyDir) {
+  try {
+    if (!isCompleteWdaBuild(keyDir))
+      return false;
+    const keyEntries = readdirSync8(keyDir, { withFileTypes: true });
+    const derivedData = keyEntries[0];
+    if (keyEntries.length !== 1 || derivedData?.name !== "DerivedData" || !derivedData.isDirectory()) {
+      return false;
+    }
+    const derivedDataEntries = readdirSync8(join35(keyDir, "DerivedData"), { withFileTypes: true });
+    const build = derivedDataEntries[0];
+    if (derivedDataEntries.length !== 1 || build?.name !== "Build" || !build.isDirectory()) {
+      return false;
+    }
+    const buildEntries = readdirSync8(join35(keyDir, "DerivedData", "Build"), {
+      withFileTypes: true
+    });
+    const productsEntry = buildEntries[0];
+    if (buildEntries.length !== 1 || productsEntry?.name !== "Products" || !productsEntry.isDirectory()) {
+      return false;
+    }
+    const products = join35(keyDir, "DerivedData", "Build", "Products");
+    return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync25(join35(products, entry.name), "utf8").includes("USE_PORT"));
+  } catch {
+    return false;
+  }
 }
 function seedRunnerSnapshotCacheFromStore(cacheRoot) {
   let seeded = 0;
@@ -71792,7 +71847,7 @@ function seedRunnerSnapshotCacheFromStore(cacheRoot) {
       mkdirSync17(target, { recursive: true });
       const stagedKey = join35(target, `.seed-${entry.name}`);
       try {
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           renameSync7(stagedKey, join35(target, entry.name));
           seeded += 1;
         } else {
@@ -71823,13 +71878,13 @@ function publishRunnerSnapshotCacheToStore(cacheRoot) {
       if (!isCompleteWdaBuild(sourceKey))
         continue;
       const storeKey = join35(storeBuilds, entry.name);
-      if (isCompleteWdaBuild(storeKey))
+      if (isReusableStoredWdaBuild(storeKey))
         continue;
       mkdirSync17(storeBuilds, { recursive: true, mode: 448 });
       const stage = mkdtempSync2(join35(storeBuilds, ".stage-"));
       try {
         const stagedKey = join35(stage, entry.name);
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           if (existsSync24(storeKey)) {
             const evicted = join35(stage, "evicted");
             renameSync7(storeKey, evicted);
@@ -76963,7 +77018,7 @@ var init_macro_asserts = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
-import { writeFileSync as writeFileSync12, renameSync as renameSync8, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
+import { writeFileSync as writeFileSync13, renameSync as renameSync8, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
 import { dirname as dirname20, basename as basename7 } from "node:path";
 function generateTmpStamp() {
   const rand = Math.random().toString(36).slice(2, 10);
@@ -77006,7 +77061,7 @@ function withPairWriteLock(yamlPath, operation, acquisitionPrecondition) {
   const ownerPath = `${dirname20(yamlPath)}/.rn-action-write-owner.${generateTmpStamp()}`;
   const owner = currentLockOwner();
   const lockFd = openSync11(ownerPath, "wx", 384);
-  writeFileSync12(lockFd, `${JSON.stringify(owner)}
+  writeFileSync13(lockFd, `${JSON.stringify(owner)}
 `, "utf8");
   const deadline = Date.now() + ACTION_WRITE_LOCK_TIMEOUT_MS;
   let acquired = false;
@@ -77260,12 +77315,12 @@ var init_atomic_writer = __esm({
     atomicWriter = {
       /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
       _writeFile(path, content) {
-        writeFileSync12(path, content, "utf8");
+        writeFileSync13(path, content, "utf8");
       },
       _writeFileWithMode(path, content, mode) {
         const fd = openSync11(path, "wx", mode);
         try {
-          writeFileSync12(fd, content, "utf8");
+          writeFileSync13(fd, content, "utf8");
         } finally {
           closeSync11(fd);
         }
@@ -81634,7 +81689,7 @@ var init_cdp_replay_dispatch = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { existsSync as existsSync30, readFileSync as readFileSync30, writeFileSync as writeFileSync13 } from "node:fs";
+import { existsSync as existsSync30, readFileSync as readFileSync30, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
 import { basename as basename10, join as join44, dirname as dirname23 } from "node:path";
 import { randomUUID as randomUUID9 } from "node:crypto";
@@ -82000,7 +82055,7 @@ function createMaestroRunHandler(deps = {}) {
           proofDomain: reactOnlyProof ? "react-tree" : "partitioned"
         });
       }
-      writeFileSync13(flowFile, validatedContent, "utf-8");
+      writeFileSync14(flowFile, validatedContent, "utf-8");
       if (isLoginMetadata(semanticActionMeta) && !loginPostconditionId(validatedCommands)) {
         return failResult("Refusing login replay without a final positive post-submit testID assertion. End the flow with assertVisible.id or extendedWaitUntil.visible.id.", "ASSERTION_FAILED", { proofDomain: "react-tree", postcondition: "missing" });
       }
@@ -82234,7 +82289,7 @@ function createMaestroRunHandler(deps = {}) {
         clearTimeout(deadlineTimer);
       }
     }
-    writeFileSync13(flowFile, validatedContent, "utf-8");
+    writeFileSync14(flowFile, validatedContent, "utf-8");
     const dispatch = selectDispatch({ platform, flowHasHideKeyboard });
     if ("error" in dispatch) {
       return failResult(dispatch.error);
@@ -82422,7 +82477,7 @@ function createMaestroRunHandler(deps = {}) {
         };
         try {
           const stageResult = await (async () => {
-            writeFileSync13(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+            writeFileSync14(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
             const executeOnce = async (beforeDispatch) => {
               if (flowDeadline - now() <= 0) {
                 const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -82831,7 +82886,7 @@ function createMaestroRunHandler(deps = {}) {
     } finally {
       clearTimeout(flowAbortTimer);
       try {
-        writeFileSync13(flowFile, validatedContent, "utf-8");
+        writeFileSync14(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -84507,7 +84562,7 @@ var init_interact = __esm({
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash18, randomBytes as randomBytes8, randomUUID as randomUUID11 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync15 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname24, join as join45 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -84813,7 +84868,7 @@ function readOrCreateRunnerDiagnosticsSalt(directory) {
   }
   const salt = randomBytes8(32);
   try {
-    writeFileSync14(path, salt, { flag: "wx", mode: 384 });
+    writeFileSync15(path, salt, { flag: "wx", mode: 384 });
     return salt;
   } catch {
     const raced = readFileSync31(path);
@@ -84847,7 +84902,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
   const temporary = join45(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
-  writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
+  writeFileSync15(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
@@ -84948,7 +85003,7 @@ function exportLatestRunnerDiagnosticsBundle(outputPath, sessionId, directory = 
   const source = latestRunnerDiagnosticsPath(sessionId, directory);
   if (!source)
     throw new Error("No runner diagnostics bundle is available for the exact session.");
-  writeFileSync14(outputPath, readFileSync31(source), { flag: "wx", mode: 384 });
+  writeFileSync15(outputPath, readFileSync31(source), { flag: "wx", mode: 384 });
   chmodSync7(outputPath, 384);
   return outputPath;
 }
@@ -85184,7 +85239,7 @@ var init_evidence = __esm({
             redactionVersion: REDACTION_RULES_VERSION
           });
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-          writeFileSync14(temp, contents.length > 0 ? `${contents}
+          writeFileSync15(temp, contents.length > 0 ? `${contents}
 ` : "", {
             encoding: "utf8",
             flag: "wx",
@@ -86904,7 +86959,7 @@ var init_managed_automation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
-import { writeFileSync as writeFileSync15 } from "node:fs";
+import { writeFileSync as writeFileSync16 } from "node:fs";
 import { join as join46 } from "node:path";
 import { tmpdir as tmpdir11 } from "node:os";
 function yamlEscape(s) {
@@ -86975,7 +87030,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync15(flowFile, content, "utf-8");
+    writeFileSync16(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -88488,7 +88543,7 @@ var init_startup_integrity = __esm({
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
 import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute14, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
@@ -88952,7 +89007,7 @@ function writeProofReceiptAtomic(path, receipt2) {
   let descriptor = null;
   try {
     descriptor = openSync12(temporary, "wx", 384);
-    writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync17(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync12(descriptor);
@@ -92251,7 +92306,7 @@ var init_maestro_generate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-test-all.js
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
 import { basename as basename13, dirname as dirname30, join as join52, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function readNestedFlowEnvelope(result) {
@@ -92501,7 +92556,7 @@ function createMaestroTestAllHandler(deps = {}) {
         continue;
       }
       const safeFlowFile = join52(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
+      writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -92524,7 +92579,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync18(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -94518,7 +94573,7 @@ var init_target = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname32, join as join57 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash23 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join57(projectRoot, ".rn-agent", "e2e");
@@ -94568,7 +94623,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
+  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
   renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
@@ -94801,7 +94856,7 @@ var init_lock_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -94860,7 +94915,7 @@ function e2eRunsDirFor(projectRoot) {
 function writeJsonAtomic(file, value) {
   mkdirSync23(join59(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
+  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
@@ -94914,7 +94969,7 @@ var init_e2e_run = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join60 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 function requestsDir(projectRoot) {
   return join60(e2eRunsDirFor(projectRoot), "requests");
 }
@@ -94926,7 +94981,7 @@ function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
+  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
   renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71718,16 +71718,15 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
   }
 }
 function wdaToolchainFingerprint() {
-  if (memoizedWdaToolchainFingerprint !== void 0)
-    return memoizedWdaToolchainFingerprint;
+  if (testWdaToolchainFingerprint !== void 0)
+    return testWdaToolchainFingerprint;
   try {
     const probe = spawnSync3("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
     const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
-    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+    return probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
   } catch {
-    memoizedWdaToolchainFingerprint = null;
+    return null;
   }
-  return memoizedWdaToolchainFingerprint;
 }
 function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
@@ -71760,7 +71759,7 @@ function isCompleteWdaBuild(keyDir) {
         return false;
       try {
         const executable = lstatSync12(join35(products, entry.name, name, name.slice(0, -".app".length)));
-        return executable.isFile() && !executable.isSymbolicLink();
+        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
@@ -72093,7 +72092,7 @@ function getEngineStatus(resolvers) {
     return Promise.resolve(testStatus);
   return detect(resolvers ?? {}).catch(() => buildReplayEngineStatus("unknown-version", null, false));
 }
-var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, memoizedWdaToolchainFingerprint, testStatus, testAttestation;
+var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testWdaToolchainFingerprint, testStatus, testAttestation;
 var init_engine_pin = __esm({
   "packages/rn-dev-agent-core/dist/domain/engine-pin.js"() {
     "use strict";

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -59311,15 +59311,16 @@ function wdaToolchainFingerprint() {
   }
   return memoizedWdaToolchainFingerprint;
 }
-function persistentWdaStoreBuildsRoot() {
+function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
-  if (!fingerprint)
+  if (!fingerprint || !pinArchiveCoords(platformKey))
     return null;
   const versionsRoot = runnerCacheVersionsRoot();
   const components = [
     join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
-    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
-    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint, "wda-builds")
   ];
   for (const component of components) {
     try {
@@ -59330,7 +59331,7 @@ function persistentWdaStoreBuildsRoot() {
       break;
     }
   }
-  return components[2];
+  return components[3];
 }
 function isCompleteWdaBuild(keyDir) {
   try {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -58727,7 +58727,7 @@ import { spawnSync } from "node:child_process";
 import { createHash as createHash7 } from "node:crypto";
 import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { basename as basename5, dirname as dirname11, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
+import { basename as basename5, dirname as dirname11, isAbsolute as isAbsolute5, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 // packages/rn-dev-agent-core/dist/experience/runner-diagnostics.js
@@ -59354,28 +59354,50 @@ function readWdaXctestrun(xctestrunPath) {
     return null;
   }
 }
+function asWdaPlistRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
 function forEachWdaTestTarget(plist, visit) {
   const configurations = plist.TestConfigurations;
   if (Array.isArray(configurations)) {
     for (const configuration of configurations) {
-      if (configuration === null || typeof configuration !== "object")
+      const configurationRecord = asWdaPlistRecord(configuration);
+      if (!configurationRecord)
         continue;
-      const targets = configuration.TestTargets;
+      const targets = configurationRecord.TestTargets;
       if (!Array.isArray(targets))
         continue;
       for (const target of targets) {
-        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
-          visit(target);
-        }
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord)
+          visit(targetRecord);
       }
     }
     return;
   }
   for (const [key, target] of Object.entries(plist)) {
-    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
-      visit(target);
-    }
+    const targetRecord = asWdaPlistRecord(target);
+    if (key !== "__xctestrun_metadata__" && targetRecord)
+      visit(targetRecord);
   }
+}
+function findWdaTestTarget(plist) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      const targets = asWdaPlistRecord(configuration)?.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord && (targetRecord.TestTargetName === "WebDriverAgentRunner" || targetRecord.BlueprintName === "WebDriverAgentRunner")) {
+          return targetRecord;
+        }
+      }
+    }
+    return null;
+  }
+  return asWdaPlistRecord(plist.WebDriverAgentRunner);
 }
 function hasInjectedWdaPort(plist) {
   let found = false;
@@ -59387,24 +59409,79 @@ function hasInjectedWdaPort(plist) {
   });
   return found;
 }
-function isCompleteWdaBuild(keyDir) {
-  try {
-    const products = join25(keyDir, "DerivedData", "Build", "Products");
-    const entries = readdirSync7(products, { withFileTypes: true });
-    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join25(products, entry.name)) !== null) && entries.some((entry) => {
-      if (!entry.isDirectory())
-        return false;
-      try {
-        const executable = lstatSync7(join25(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
-        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
-      } catch {
+function isWithinWdaKey(keyDir, candidate) {
+  const path = relative3(keyDir, candidate);
+  return path === "" || path !== ".." && !path.startsWith(`..${sep4}`) && !isAbsolute5(path);
+}
+function isContainedWdaProductTree(keyDir, products) {
+  const lexicalKey = resolve4(keyDir);
+  const realKey = realpathSync7(keyDir);
+  const visit = (directory) => {
+    for (const entry of readdirSync7(directory, { withFileTypes: true })) {
+      const path = join25(directory, entry.name);
+      const stat2 = lstatSync7(path);
+      if (stat2.isSymbolicLink()) {
+        const target = readlinkSync3(path);
+        if (isAbsolute5(target) || !isWithinWdaKey(lexicalKey, resolve4(directory, target)) || !isWithinWdaKey(realKey, realpathSync7(path))) {
+          return false;
+        }
+      } else if (stat2.isDirectory() && !visit(path)) {
         return false;
       }
-    });
-  } catch {
-    return false;
+    }
+    return true;
+  };
+  return visit(products);
+}
+function resolveWdaProductReference(reference, products, testHost) {
+  if (typeof reference !== "string")
+    return null;
+  if (reference.startsWith("__TESTROOT__/")) {
+    return resolve4(products, reference.slice("__TESTROOT__/".length));
   }
+  if (testHost && reference.startsWith("__TESTHOST__/")) {
+    return resolve4(testHost, reference.slice("__TESTHOST__/".length));
+  }
+  return null;
+}
+function readCompleteWdaBuildManifest(keyDir) {
+  try {
+    const derivedData = join25(keyDir, "DerivedData");
+    const build = join25(derivedData, "Build");
+    const products = join25(build, "Products");
+    if (!isRealDirectory(keyDir) || !isRealDirectory(derivedData) || !isRealDirectory(build) || !isRealDirectory(products) || !isContainedWdaProductTree(keyDir, products)) {
+      return null;
+    }
+    const selected = readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)[0];
+    if (!selected?.isFile())
+      return null;
+    const selectedXctestrun = join25(products, selected.name);
+    const plist = readWdaXctestrun(selectedXctestrun);
+    const target = plist && findWdaTestTarget(plist);
+    if (!target)
+      return null;
+    const testHost = resolveWdaProductReference(target.TestHostPath, products);
+    if (!testHost)
+      return null;
+    const hostPath = relative3(products, testHost).split(sep4);
+    if (hostPath.length !== 2 || hostPath[1] !== "WebDriverAgentRunner-Runner.app" || !isRealDirectory(join25(products, hostPath[0])) || !isRealDirectory(testHost)) {
+      return null;
+    }
+    const executable = lstatSync7(join25(testHost, "WebDriverAgentRunner-Runner"));
+    if (!executable.isFile() || executable.isSymbolicLink() || (executable.mode & 73) === 0) {
+      return null;
+    }
+    const testBundle = resolveWdaProductReference(target.TestBundlePath, products, testHost);
+    if (!testBundle || !isWithinWdaKey(resolve4(keyDir), testBundle) || !existsSync18(testBundle)) {
+      return null;
+    }
+    return { products, selectedXctestrun };
+  } catch {
+    return null;
+  }
+}
+function isCompleteWdaBuild(keyDir) {
+  return readCompleteWdaBuildManifest(keyDir) !== null;
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const plist = readWdaXctestrun(xctestrunPath);
@@ -59428,10 +59505,10 @@ function isRealDirectory(path) {
   }
 }
 function copyReusableWdaBuild(sourceKey, stagedKey) {
-  const sourceProducts = join25(sourceKey, "DerivedData", "Build", "Products");
-  if (!isRealDirectory(sourceKey) || !isRealDirectory(join25(sourceKey, "DerivedData")) || !isRealDirectory(join25(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+  const manifest = readCompleteWdaBuildManifest(sourceKey);
+  if (!manifest)
     return false;
-  }
+  const sourceProducts = manifest.products;
   const stagedProducts = join25(stagedKey, "DerivedData", "Build", "Products");
   mkdirSync12(dirname11(stagedProducts), { recursive: true });
   cpSync2(sourceProducts, stagedProducts, {
@@ -62246,7 +62323,7 @@ init_process_birth();
 import { execFileSync as execFileSync10, spawn as spawn6 } from "node:child_process";
 import { createHash as createHash10, createHmac as createHmac2, timingSafeEqual as timingSafeEqual4 } from "node:crypto";
 import { closeSync as closeSync5, existsSync as existsSync22, fstatSync as fstatSync3, mkdirSync as mkdirSync15, openSync as openSync5, readFileSync as readFileSync22, readSync as readSync2, realpathSync as realpathSync10, rmSync as rmSync10 } from "node:fs";
-import { dirname as dirname13, isAbsolute as isAbsolute5, join as join29, relative as relative4, resolve as resolve7 } from "node:path";
+import { dirname as dirname13, isAbsolute as isAbsolute6, join as join29, relative as relative4, resolve as resolve7 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/authority-json.js
 var intrinsicJsonStringify = JSON.stringify;
@@ -64348,7 +64425,7 @@ async function stopManagedMetroWithEvidence(binding, input, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/package-integration.js
 import { closeSync as closeSync6, constants as constants5, fstatSync as fstatSync4, lstatSync as lstatSync10, openSync as openSync6, readFileSync as readFileSync23 } from "node:fs";
-import { basename as basename6, isAbsolute as isAbsolute6, join as join30, relative as relative5, resolve as resolve8, sep as sep5 } from "node:path";
+import { basename as basename6, isAbsolute as isAbsolute7, join as join30, relative as relative5, resolve as resolve8, sep as sep5 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/metro-authority.js
 import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
@@ -68265,7 +68342,7 @@ function assertBoundCleanup(result) {
 }
 function assertNoSymlinkPath(root, candidate) {
   const child = relative5(root, candidate);
-  if (child === ".." || child.startsWith(`..${sep5}`) || isAbsolute6(child)) {
+  if (child === ".." || child.startsWith(`..${sep5}`) || isAbsolute7(child)) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration path escapes the app root");
   }
   let current = root;
@@ -68717,7 +68794,7 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname15, isAbsolute as isAbsolute8, join as join34, resolve as resolve11 } from "node:path";
+import { dirname as dirname15, isAbsolute as isAbsolute9, join as join34, resolve as resolve11 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { createHash as createHash13 } from "node:crypto";
 
@@ -68726,7 +68803,7 @@ init_metro_cwd();
 import { createHash as createHash11, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
 import { execFileSync as execFileSync11 } from "node:child_process";
 import { closeSync as closeSync7, constants as constants6, existsSync as existsSync23, fstatSync as fstatSync5, lstatSync as lstatSync11, openSync as openSync7, readdirSync as readdirSync8, readFileSync as readFileSync24, readlinkSync as readlinkSync4, readSync as readSync3, realpathSync as realpathSync11 } from "node:fs";
-import { dirname as dirname14, isAbsolute as isAbsolute7, join as join31, relative as relative6, resolve as resolve9 } from "node:path";
+import { dirname as dirname14, isAbsolute as isAbsolute8, join as join31, relative as relative6, resolve as resolve9 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
   const hash = createHash11("sha256");
@@ -68903,7 +68980,7 @@ function updateDependencyPath(hash, path, label, state) {
 }
 function isContained(root, candidate) {
   const child = relative6(root, candidate);
-  return child !== ".." && !child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) && !isAbsolute7(child);
+  return child !== ".." && !child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) && !isAbsolute8(child);
 }
 function isExcludedRuntimePath(root, candidate) {
   const entry = relative6(root, candidate).split("\\").join("/");
@@ -69288,7 +69365,7 @@ ${stderr}`.toLowerCase().includes("not a git repository");
 }
 function assertContained(root, candidate, code) {
   const child = relative6(root, candidate);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute7(child)) {
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute8(child)) {
     throw new Error(`${code}: path is outside the declared content root`);
   }
 }
@@ -69331,7 +69408,7 @@ function resolveSourceIdentity(inputRoot, dependencies = {}) {
     const contentRoot = canonicalize(git2(appRoot, ["rev-parse", "--show-toplevel"]));
     assertContained(contentRoot, appRoot, "APP_ROOT_OUTSIDE_WORKTREE");
     const commonRaw = git2(appRoot, ["rev-parse", "--git-common-dir"]);
-    const commonDirectory = canonicalize(isAbsolute7(commonRaw) ? commonRaw : join31(appRoot, commonRaw));
+    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join31(appRoot, commonRaw));
     const head = git2(appRoot, ["rev-parse", "HEAD"]);
     const appRelative = relative6(contentRoot, appRoot) || ".";
     return {
@@ -70270,7 +70347,7 @@ function sessionSourceResolver(status, dependencies) {
   return (root) => resolveSourceIdentity(root, stored?.kind === "declared-root" ? { declaredRoot: stored.contentRoot, declaredManifests: stored.declaredManifests } : {});
 }
 function anchorDeclaredProjectRoot(status, projectRoot) {
-  if (isAbsolute8(projectRoot))
+  if (isAbsolute9(projectRoot))
     return projectRoot;
   const boundAppRoot = status.source?.appRoot;
   return typeof boundAppRoot === "string" && boundAppRoot.length > 0 ? resolve11(boundAppRoot, projectRoot) : projectRoot;
@@ -72857,7 +72934,7 @@ init_rn_android_runner_client();
 
 // packages/rn-dev-agent-core/dist/observability/recorder.js
 import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSync6, openSync as openSync8, readSync as readSync4 } from "node:fs";
-import { isAbsolute as isAbsolute9 } from "node:path";
+import { isAbsolute as isAbsolute10 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/util/redact.js
 import { homedir as homedir7 } from "node:os";
@@ -73146,7 +73223,7 @@ var SHOT_REGISTRY_CAP = 64;
 function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute9(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+  return typeof p === "string" && isAbsolute10(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
 }
 function readShotBounded(p) {
   let fd;
@@ -73230,7 +73307,7 @@ var Recorder = class {
    * whatever path the pipeline actually captured to.
    */
   registerCapturedScreenshot(p) {
-    if (typeof p !== "string" || !isAbsolute9(p))
+    if (typeof p !== "string" || !isAbsolute10(p))
       return;
     this.trustedShotPaths.delete(p);
     this.trustedShotPaths.add(p);
@@ -74397,7 +74474,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/action-store.js
 import { existsSync as existsSync26, lstatSync as lstatSync15, readFileSync as readFileSync27, statSync as statSync13, unlinkSync as unlinkSync12 } from "node:fs";
-import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute12, join as join38, relative as relative8, resolve as resolve15, sep as sep8 } from "node:path";
+import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute13, join as join38, relative as relative8, resolve as resolve15, sep as sep8 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
@@ -74851,7 +74928,7 @@ var atomicWriter = {
 init_process_birth();
 import { execFileSync as execFileSync14 } from "node:child_process";
 import { lstatSync as lstatSync13 } from "node:fs";
-import { isAbsolute as isAbsolute10, join as join36 } from "node:path";
+import { isAbsolute as isAbsolute11, join as join36 } from "node:path";
 function createUnfollowedFileSnapshot(directoryPath, directoryIdentity) {
   return { directoryPath, directoryIdentity, fileIdentities: /* @__PURE__ */ new Map() };
 }
@@ -75037,7 +75114,7 @@ function readUnfollowedFiles(directoryPath, identity2, relativePaths, expectedId
       throw new Error("Selected file identities did not match the requested paths.");
     }
     const entries = relativePaths.map((relativePath, index) => {
-      if (isAbsolute10(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
+      if (isAbsolute11(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
         throw new Error(`Invalid relative path: ${relativePath}.`);
       }
       if (expectedIdentities) {
@@ -75134,7 +75211,7 @@ init_maestro_validator();
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
 import { spawnSync as spawnSync3 } from "node:child_process";
 import { closeSync as closeSync10, constants as constants9, existsSync as existsSync25, fstatSync as fstatSync8, lstatSync as lstatSync14, mkdirSync as mkdirSync18, openSync as openSync10, readFileSync as readFileSync26, readlinkSync as readlinkSync5, realpathSync as realpathSync12, renameSync as renameSync8, statSync as statSync12, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
-import { dirname as dirname18, isAbsolute as isAbsolute11, join as join37, relative as relative7, resolve as resolve14, sep as sep7 } from "node:path";
+import { dirname as dirname18, isAbsolute as isAbsolute12, join as join37, relative as relative7, resolve as resolve14, sep as sep7 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
 var WORKTREE_REPAIR_ENTRY = '"${CLAUDE_PLUGIN_ROOT:-${RN_DEV_AGENT_CODEX_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:?set it to the installed rn-dev-agent plugin root, then re-run}}}/rn-dev-agent-core/dist/worktree-inheritance.js"';
@@ -75193,7 +75270,7 @@ function contained(parent, child) {
   if (parent === child)
     return true;
   const rel = relative7(parent, child);
-  return rel !== "" && !rel.startsWith(`..${sep7}`) && rel !== ".." && !isAbsolute11(rel);
+  return rel !== "" && !rel.startsWith(`..${sep7}`) && rel !== ".." && !isAbsolute12(rel);
 }
 function toPosix(path) {
   return sep7 === "/" ? path : path.split(sep7).join("/");
@@ -75329,7 +75406,7 @@ function resolveWorktreeLayout(input) {
 }
 function classifySource(path, type, boundary) {
   const rel = relative7(boundary, path);
-  if (rel === ".." || rel.startsWith(`..${sep7}`) || isAbsolute11(rel)) {
+  if (rel === ".." || rel.startsWith(`..${sep7}`) || isAbsolute12(rel)) {
     return { state: "WRONG_TYPE" };
   }
   const paths = [boundary];
@@ -75943,11 +76020,11 @@ function ownedActionPathIdentityMatches(entries) {
   }
 }
 function referencedActionPath(parentFile, reference) {
-  if (isAbsolute12(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
+  if (isAbsolute13(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
     return null;
   }
   const child = join38(dirname19(parentFile), reference);
-  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child))
+  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child))
     return null;
   return child;
 }
@@ -76182,7 +76259,7 @@ function captureActionFromContext(context, actionId) {
       flowRoot: snapshot.directory,
       readFileFn: (path) => {
         const child = relative8(snapshot.directory, path);
-        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child)) {
+        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child)) {
           throw new Error(`Refusing action flow outside ${snapshot.directory}.`);
         }
         const text2 = context.fileContents.get(child);
@@ -78427,7 +78504,7 @@ function maestroAuthorityRefusal(authority, underlyingError) {
 import { existsSync as existsSync28, readFileSync as readFileSync28, readdirSync as readdirSync11, realpathSync as realpathSync14, rmSync as rmSync11 } from "node:fs";
 import { createHash as createHash14 } from "node:crypto";
 import { tmpdir as tmpdir8 } from "node:os";
-import { isAbsolute as isAbsolute13, join as join41, sep as sep9 } from "node:path";
+import { isAbsolute as isAbsolute14, join as join41, sep as sep9 } from "node:path";
 var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
 var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
 var WEAK_DEVICE_ID_KEYS = ["id"];
@@ -78578,7 +78655,7 @@ function readStructuredFlowArtifact(reportDir, previous) {
     if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
       return unfinalized;
     const normalizedDataFile = flow.dataFile;
-    if (isAbsolute13(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
       return unfinalized;
     }
     const realDataFile = realpathSync14(join41(reportDir, normalizedDataFile));
@@ -85815,7 +85892,7 @@ function createDeviceRecordHandler(deps = {}) {
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
 import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute14, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
+import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute15, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
@@ -86344,7 +86421,7 @@ function readStartupIntegrityAttestation() {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-var absolutePathSchema = external_exports.string().min(1).refine(isAbsolute14, "path must be absolute");
+var absolutePathSchema = external_exports.string().min(1).refine(isAbsolute15, "path must be absolute");
 var beginRehearsalSchema = external_exports.object({
   action: external_exports.literal("begin_rehearsal"),
   projectRoot: absolutePathSchema,
@@ -86469,7 +86546,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let loadedCoreBundlePath = null;
   let coreBundleSha256 = null;
   try {
-    if (typeof argv[1] === "string" && isAbsolute14(argv[1])) {
+    if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
       executedEntrypointPath = realpathSync15(argv[1]);
     }
   } catch {
@@ -86507,7 +86584,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   const authorityArg = argv[1];
-  if (typeof authorityArg !== "string" || !isAbsolute14(authorityArg))
+  if (typeof authorityArg !== "string" || !isAbsolute15(authorityArg))
     return null;
   let arg;
   try {
@@ -86556,7 +86633,7 @@ function proofCandidateStartupMatches(entrypoint, startup, headCoreBundleSha256)
 }
 function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   const normalizedOverride = (value) => {
-    if (!value || !isAbsolute14(value))
+    if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
       return realpathSync15(value);
@@ -86695,11 +86772,11 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
   }
 }
 function isNormalizedDescendant(root, path) {
-  if (!isAbsolute14(root) || !isAbsolute14(path) || resolve17(root) !== root || resolve17(path) !== path) {
+  if (!isAbsolute15(root) || !isAbsolute15(path) || resolve17(root) !== root || resolve17(path) !== path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute14(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
   const parts = relative9(root, path).split(sep10);
@@ -86748,7 +86825,7 @@ function proofRootExists(args) {
   }
 }
 function resolveProofWorktreeRoot(detectedProjectRoot) {
-  if (!detectedProjectRoot || !isAbsolute14(detectedProjectRoot) || resolve17(detectedProjectRoot) !== detectedProjectRoot) {
+  if (!detectedProjectRoot || !isAbsolute15(detectedProjectRoot) || resolve17(detectedProjectRoot) !== detectedProjectRoot) {
     return null;
   }
   try {
@@ -86756,7 +86833,7 @@ function resolveProofWorktreeRoot(detectedProjectRoot) {
       cwd: detectedProjectRoot,
       encoding: "utf8"
     }).trim();
-    return root && isAbsolute14(root) && resolve17(root) === root ? root : null;
+    return root && isAbsolute15(root) && resolve17(root) === root ? root : null;
   } catch {
     return null;
   }
@@ -87083,7 +87160,7 @@ function createProofCaptureHandler(deps) {
     ].map((path) => repositoryPath(active, path));
     const requiredOutputs = new Set(phase === "finalized" ? [...proofOutputs, repositoryPath(active, active.context.receiptPath)] : proofOutputs);
     const allowedOutputs = phase === "setup" ? observedSetupScreenshots(active) : phase === "clean" ? /* @__PURE__ */ new Set() : requiredOutputs;
-    const invalidChange = git2.changes.some((change) => isAbsolute14(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
+    const invalidChange = git2.changes.some((change) => isAbsolute15(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
     const changedPaths = new Set(git2.changes.map((change) => change.path.replaceAll("\\", "/")));
     const unrelated = [...changedPaths].some((path) => !allowedOutputs.has(path));
     const missing = (phase === "validation" || phase === "finalized") && [...requiredOutputs].some((path) => !changedPaths.has(path));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -58723,8 +58723,9 @@ function projectRootFromYaml(yamlFilePath) {
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
 init_process_birth();
+import { spawnSync } from "node:child_process";
 import { createHash as createHash7 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9 } from "node:fs";
+import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename5, dirname as dirname11, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -59297,6 +59298,135 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error2));
   }
 }
+var memoizedWdaToolchainFingerprint;
+function wdaToolchainFingerprint() {
+  if (memoizedWdaToolchainFingerprint !== void 0)
+    return memoizedWdaToolchainFingerprint;
+  try {
+    const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
+    const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
+    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+  } catch {
+    memoizedWdaToolchainFingerprint = null;
+  }
+  return memoizedWdaToolchainFingerprint;
+}
+function persistentWdaStoreBuildsRoot() {
+  const fingerprint = wdaToolchainFingerprint();
+  if (!fingerprint)
+    return null;
+  const versionsRoot = runnerCacheVersionsRoot();
+  const components = [
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
+    join25(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+  ];
+  for (const component of components) {
+    try {
+      const stat2 = lstatSync7(component);
+      if (!stat2.isDirectory() || stat2.isSymbolicLink())
+        return null;
+    } catch {
+      break;
+    }
+  }
+  return components[2];
+}
+function isCompleteWdaBuild(keyDir) {
+  try {
+    const products = join25(keyDir, "DerivedData", "Build", "Products");
+    const entries = readdirSync7(products, { withFileTypes: true });
+    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
+      if (!name.endsWith(".app"))
+        return false;
+      try {
+        const executable = lstatSync7(join25(products, entry.name, name, name.slice(0, -".app".length)));
+        return executable.isFile() && !executable.isSymbolicLink();
+      } catch {
+        return false;
+      }
+    }));
+  } catch {
+    return false;
+  }
+}
+function copyWdaBuildKey(sourceKey, stagedKey) {
+  cpSync2(sourceKey, stagedKey, {
+    recursive: true,
+    mode: constants2.COPYFILE_FICLONE,
+    verbatimSymlinks: true
+  });
+  return isCompleteWdaBuild(stagedKey);
+}
+function seedRunnerSnapshotCacheFromStore(cacheRoot) {
+  let seeded = 0;
+  try {
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    const target = join25(cacheRoot, "wda-builds");
+    for (const entry of readdirSync7(storeBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory())
+        continue;
+      const sourceKey = join25(storeBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      mkdirSync12(target, { recursive: true });
+      const stagedKey = join25(target, `.seed-${entry.name}`);
+      try {
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          renameSync4(stagedKey, join25(target, entry.name));
+          seeded += 1;
+        } else {
+          rmSync6(stagedKey, { recursive: true, force: true });
+        }
+      } catch {
+        try {
+          rmSync6(stagedKey, { recursive: true, force: true });
+        } catch {
+        }
+      }
+    }
+  } catch {
+  }
+  return seeded;
+}
+function publishRunnerSnapshotCacheToStore(cacheRoot) {
+  let published = 0;
+  try {
+    const spawnBuilds = join25(cacheRoot, "wda-builds");
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    for (const entry of readdirSync7(spawnBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith("."))
+        continue;
+      const sourceKey = join25(spawnBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      const storeKey = join25(storeBuilds, entry.name);
+      if (isCompleteWdaBuild(storeKey))
+        continue;
+      mkdirSync12(storeBuilds, { recursive: true, mode: 448 });
+      const stage = mkdtempSync(join25(storeBuilds, ".stage-"));
+      try {
+        const stagedKey = join25(stage, entry.name);
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          if (existsSync18(storeKey)) {
+            const evicted = join25(stage, "evicted");
+            renameSync4(storeKey, evicted);
+          }
+          renameSync4(stagedKey, storeKey);
+          published += 1;
+        }
+      } finally {
+        rmSync6(stage, { recursive: true, force: true });
+      }
+    }
+  } catch {
+  }
+  return published;
+}
 function provisionRunnerSnapshotCache(snapshotRoot, testHooks = {}, setOwnedCacheRoot = () => {
 }) {
   const cacheRoot = expectedRunnerCacheRoot(snapshotRoot);
@@ -59417,8 +59547,12 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       }
     }
     chmodSync4(snapshotRoot, 320);
-    if (cacheRoot)
+    if (cacheRoot) {
       assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+      recordRunnerDiagnostic("cache-seed", {
+        seededBuilds: seedRunnerSnapshotCacheFromStore(cacheRoot)
+      });
+    }
     const openedRunner = lstatSync7(snapshotRunner);
     recordRunnerDiagnostic("runner-exec-begin", { runnerPinVersion: MAESTRO_RUNNER_PIN.version });
     if (platform === "ios") {
@@ -59444,6 +59578,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync4(entryPath, 384);
       }
     } catch {
+    }
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
@@ -59607,14 +59746,14 @@ import { join as join28 } from "node:path";
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn5 } from "node:child_process";
 import { randomUUID as randomUUID7 } from "node:crypto";
-import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync5, rmSync as rmSync8, writeFileSync as writeFileSync10 } from "node:fs";
+import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync6, rmSync as rmSync8, writeFileSync as writeFileSync10 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
 import { join as join27 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync4, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync9 } from "node:fs";
+import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync5, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync9 } from "node:fs";
 import { join as join26, resolve as resolve5 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
@@ -61003,7 +61142,7 @@ function sendOperation(directory, request2, timeoutMs) {
   const requestPath2 = join27(directory.worker.controlPath, `${prefix}.request`);
   const responsePath = join27(directory.worker.controlPath, `${prefix}.response`);
   writeFileSync10(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
-  renameSync5(pendingPath, requestPath2);
+  renameSync6(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
     throw new Error("SESSION_INTEGRATION_WORKER_TIMEOUT");
   }
@@ -62080,7 +62219,7 @@ function canonicalAuthorityJson(value) {
 }
 
 // packages/rn-dev-agent-core/dist/session/managed-metro-enforcement.js
-import { spawnSync } from "node:child_process";
+import { spawnSync as spawnSync2 } from "node:child_process";
 import { createHash as createHash9 } from "node:crypto";
 import { closeSync as closeSync4, constants as constants4, existsSync as existsSync21, mkdirSync as mkdirSync14, openSync as openSync4, readFileSync as readFileSync21, realpathSync as realpathSync9, rmSync as rmSync9, statSync as statSync9, symlinkSync as symlinkSync2, writeSync as writeSync2 } from "node:fs";
 import { dirname as dirname12, resolve as resolve6 } from "node:path";
@@ -62090,7 +62229,7 @@ function sha256(value) {
   return createHash9("sha256").update(value).digest("hex");
 }
 function defaultRun2(command, args) {
-  const result = spawnSync(command, [...args], {
+  const result = spawnSync2(command, [...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     timeout: 25e3
@@ -74142,7 +74281,7 @@ import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute12
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync11, renameSync as renameSync6, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
+import { writeFileSync as writeFileSync11, renameSync as renameSync7, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
 import { dirname as dirname17, basename as basename7 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -74446,7 +74585,7 @@ var atomicWriter = {
   },
   /** Underlying `fs.renameSync(from, to)`. */
   _rename(from, to) {
-    renameSync6(from, to);
+    renameSync7(from, to);
   },
   /** Underlying `fs.statSync(path).mtimeMs`. */
   _statMtimeMs(path) {
@@ -74873,8 +75012,8 @@ function listUnfollowedDirectory(directoryPath, identity2) {
 init_maestro_validator();
 
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
-import { spawnSync as spawnSync2 } from "node:child_process";
-import { closeSync as closeSync10, constants as constants9, existsSync as existsSync25, fstatSync as fstatSync8, lstatSync as lstatSync14, mkdirSync as mkdirSync18, openSync as openSync10, readFileSync as readFileSync26, readlinkSync as readlinkSync5, realpathSync as realpathSync12, renameSync as renameSync7, statSync as statSync12, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
+import { spawnSync as spawnSync3 } from "node:child_process";
+import { closeSync as closeSync10, constants as constants9, existsSync as existsSync25, fstatSync as fstatSync8, lstatSync as lstatSync14, mkdirSync as mkdirSync18, openSync as openSync10, readFileSync as readFileSync26, readlinkSync as readlinkSync5, realpathSync as realpathSync12, renameSync as renameSync8, statSync as statSync12, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
 import { dirname as dirname18, isAbsolute as isAbsolute11, join as join37, relative as relative7, resolve as resolve14, sep as sep7 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
@@ -74913,7 +75052,7 @@ function gitEnvironment() {
   return env;
 }
 function git(cwd, args) {
-  const result = spawnSync2("git", args, {
+  const result = spawnSync3("git", args, {
     cwd,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -75423,7 +75562,7 @@ function isTracked(worktreeRoot, relativePath) {
   return listed.ok && listed.stdout.trim().length > 0;
 }
 function isIgnoreSafe(worktreeRoot, relativePath) {
-  const result = spawnSync2("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
+  const result = spawnSync3("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
     cwd: worktreeRoot,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -82201,7 +82340,7 @@ import { promisify as promisify19 } from "node:util";
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash16, randomBytes as randomBytes7, randomUUID as randomUUID10 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync8, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync13 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync13 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname22, join as join43 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -82502,7 +82641,7 @@ var ExperienceRecorder = class {
         flag: "wx",
         mode: 384
       });
-      renameSync8(temp, this.path);
+      renameSync9(temp, this.path);
       chmodSync7(this.path, 384);
     } catch (error2) {
       try {
@@ -82831,7 +82970,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   }
   const temporary = join43(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
   writeFileSync13(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
-  renameSync8(temporary, outputPath);
+  renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
@@ -85555,7 +85694,7 @@ function createDeviceRecordHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync9, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
 import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute14, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
@@ -86639,7 +86778,7 @@ function writeProofReceiptAtomic(path, receipt2) {
     fsyncSync(descriptor);
     closeSync11(descriptor);
     descriptor = null;
-    renameSync9(temporary, path);
+    renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -92258,7 +92397,7 @@ init_sources();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname30, join as join56 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash22 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
@@ -92310,7 +92449,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
   };
   const tmp = `${filePath}.tmp`;
   writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
+  renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
@@ -92513,7 +92652,7 @@ function createLockE2eTestHandler(deps = {}) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join58 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -92574,7 +92713,7 @@ function writeJsonAtomic(file, value) {
   mkdirSync23(join58(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync11(tmp, file);
+  renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
   const file = join58(e2eRunsDirFor(projectRoot), "index.json");
@@ -92622,7 +92761,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -92641,7 +92780,7 @@ function writeRequest(projectRoot, req) {
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync12(tmp, file);
+  renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -58725,7 +58725,7 @@ function projectRootFromYaml(yamlFilePath) {
 init_process_birth();
 import { spawnSync } from "node:child_process";
 import { createHash as createHash7 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9 } from "node:fs";
+import { accessSync, chmodSync as chmodSync4, constants as constants2, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync18, lstatSync as lstatSync7, mkdirSync as mkdirSync12, mkdtempSync, readFileSync as readFileSync17, readdirSync as readdirSync7, readlinkSync as readlinkSync3, realpathSync as realpathSync7, renameSync as renameSync4, rmSync as rmSync6, symlinkSync, unlinkSync as unlinkSync9, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename5, dirname as dirname11, join as join25, relative as relative3, resolve as resolve4, sep as sep4 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -59350,13 +59350,68 @@ function isCompleteWdaBuild(keyDir) {
     return false;
   }
 }
-function copyWdaBuildKey(sourceKey, stagedKey) {
-  cpSync2(sourceKey, stagedKey, {
+function removeInjectedWdaPort(xctestrunPath) {
+  const source = readFileSync17(xctestrunPath, "utf8");
+  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
+  if (normalized.includes("USE_PORT"))
+    return false;
+  if (normalized !== source)
+    writeFileSync9(xctestrunPath, normalized);
+  return true;
+}
+function isRealDirectory(path) {
+  try {
+    const stat2 = lstatSync7(path);
+    return stat2.isDirectory() && !stat2.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function copyReusableWdaBuild(sourceKey, stagedKey) {
+  const sourceProducts = join25(sourceKey, "DerivedData", "Build", "Products");
+  if (!isRealDirectory(sourceKey) || !isRealDirectory(join25(sourceKey, "DerivedData")) || !isRealDirectory(join25(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+    return false;
+  }
+  const stagedProducts = join25(stagedKey, "DerivedData", "Build", "Products");
+  mkdirSync12(dirname11(stagedProducts), { recursive: true });
+  cpSync2(sourceProducts, stagedProducts, {
     recursive: true,
     mode: constants2.COPYFILE_FICLONE,
     verbatimSymlinks: true
   });
+  for (const entry of readdirSync7(stagedProducts, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".xctestrun") && !removeInjectedWdaPort(join25(stagedProducts, entry.name))) {
+      return false;
+    }
+  }
   return isCompleteWdaBuild(stagedKey);
+}
+function isReusableStoredWdaBuild(keyDir) {
+  try {
+    if (!isCompleteWdaBuild(keyDir))
+      return false;
+    const keyEntries = readdirSync7(keyDir, { withFileTypes: true });
+    const derivedData = keyEntries[0];
+    if (keyEntries.length !== 1 || derivedData?.name !== "DerivedData" || !derivedData.isDirectory()) {
+      return false;
+    }
+    const derivedDataEntries = readdirSync7(join25(keyDir, "DerivedData"), { withFileTypes: true });
+    const build = derivedDataEntries[0];
+    if (derivedDataEntries.length !== 1 || build?.name !== "Build" || !build.isDirectory()) {
+      return false;
+    }
+    const buildEntries = readdirSync7(join25(keyDir, "DerivedData", "Build"), {
+      withFileTypes: true
+    });
+    const productsEntry = buildEntries[0];
+    if (buildEntries.length !== 1 || productsEntry?.name !== "Products" || !productsEntry.isDirectory()) {
+      return false;
+    }
+    const products = join25(keyDir, "DerivedData", "Build", "Products");
+    return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync17(join25(products, entry.name), "utf8").includes("USE_PORT"));
+  } catch {
+    return false;
+  }
 }
 function seedRunnerSnapshotCacheFromStore(cacheRoot) {
   let seeded = 0;
@@ -59374,7 +59429,7 @@ function seedRunnerSnapshotCacheFromStore(cacheRoot) {
       mkdirSync12(target, { recursive: true });
       const stagedKey = join25(target, `.seed-${entry.name}`);
       try {
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           renameSync4(stagedKey, join25(target, entry.name));
           seeded += 1;
         } else {
@@ -59405,13 +59460,13 @@ function publishRunnerSnapshotCacheToStore(cacheRoot) {
       if (!isCompleteWdaBuild(sourceKey))
         continue;
       const storeKey = join25(storeBuilds, entry.name);
-      if (isCompleteWdaBuild(storeKey))
+      if (isReusableStoredWdaBuild(storeKey))
         continue;
       mkdirSync12(storeBuilds, { recursive: true, mode: 448 });
       const stage = mkdtempSync(join25(storeBuilds, ".stage-"));
       try {
         const stagedKey = join25(stage, entry.name);
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           if (existsSync18(storeKey)) {
             const evicted = join25(stage, "evicted");
             renameSync4(storeKey, evicted);
@@ -59746,14 +59801,14 @@ import { join as join28 } from "node:path";
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn5 } from "node:child_process";
 import { randomUUID as randomUUID7 } from "node:crypto";
-import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync6, rmSync as rmSync8, writeFileSync as writeFileSync10 } from "node:fs";
+import { closeSync as closeSync3, constants as constants3, existsSync as existsSync19, fstatSync as fstatSync2, lstatSync as lstatSync9, mkdtempSync as mkdtempSync2, openSync as openSync3, readFileSync as readFileSync19, realpathSync as realpathSync8, renameSync as renameSync6, rmSync as rmSync8, writeFileSync as writeFileSync11 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
 import { join as join27 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync5, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync9 } from "node:fs";
+import { chmodSync as chmodSync5, linkSync, lstatSync as lstatSync8, mkdirSync as mkdirSync13, readFileSync as readFileSync18, renameSync as renameSync5, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync10 } from "node:fs";
 import { join as join26, resolve as resolve5 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
@@ -59827,7 +59882,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
   const temporary = join26(layout.root, `.bound-directory.${randomUUID6()}.key`);
   try {
     try {
-      writeFileSync9(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
+      writeFileSync10(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
       try {
         linkSync(temporary, path);
       } catch (error2) {
@@ -60965,7 +61020,7 @@ function stopWorker(worker, signal = "SIGTERM") {
   const stoppedPath = join27(worker.controlPath, "stopped");
   if (signal === "SIGTERM") {
     try {
-      writeFileSync10(join27(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
+      writeFileSync11(join27(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
     } catch {
     }
     if (waitForFile(stoppedPath, 1e3)) {
@@ -60976,7 +61031,7 @@ function stopWorker(worker, signal = "SIGTERM") {
     }
   }
   try {
-    writeFileSync10(join27(worker.controlPath, "terminate"), JSON.stringify({
+    writeFileSync11(join27(worker.controlPath, "terminate"), JSON.stringify({
       lifecycleCapability: worker.lifecycleCapability,
       signal: "SIGKILL"
     }), { flag: "wx", mode: 384 });
@@ -61141,7 +61196,7 @@ function sendOperation(directory, request2, timeoutMs) {
   const pendingPath = join27(directory.worker.controlPath, `${prefix}.pending`);
   const requestPath2 = join27(directory.worker.controlPath, `${prefix}.request`);
   const responsePath = join27(directory.worker.controlPath, `${prefix}.response`);
-  writeFileSync10(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
+  writeFileSync11(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
   renameSync6(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
     throw new Error("SESSION_INTEGRATION_WORKER_TIMEOUT");
@@ -74281,7 +74336,7 @@ import { basename as basename8, dirname as dirname19, isAbsolute as isAbsolute12
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync11, renameSync as renameSync7, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
+import { writeFileSync as writeFileSync12, renameSync as renameSync7, statSync as statSync11, mkdirSync as mkdirSync17, existsSync as existsSync24, unlinkSync as unlinkSync10, readdirSync as readdirSync9, openSync as openSync9, closeSync as closeSync9, chmodSync as chmodSync6, fstatSync as fstatSync7, lstatSync as lstatSync12, readFileSync as readFileSync25, linkSync as linkSync2, constants as constants8 } from "node:fs";
 import { dirname as dirname17, basename as basename7 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -74331,7 +74386,7 @@ function withPairWriteLock(yamlPath, operation, acquisitionPrecondition) {
   const ownerPath = `${dirname17(yamlPath)}/.rn-action-write-owner.${generateTmpStamp()}`;
   const owner = currentLockOwner();
   const lockFd = openSync9(ownerPath, "wx", 384);
-  writeFileSync11(lockFd, `${JSON.stringify(owner)}
+  writeFileSync12(lockFd, `${JSON.stringify(owner)}
 `, "utf8");
   const deadline = Date.now() + ACTION_WRITE_LOCK_TIMEOUT_MS;
   let acquired = false;
@@ -74573,12 +74628,12 @@ function cleanupOrphans(yamlPath, sidecarPath) {
 var atomicWriter = {
   /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
   _writeFile(path, content) {
-    writeFileSync11(path, content, "utf8");
+    writeFileSync12(path, content, "utf8");
   },
   _writeFileWithMode(path, content, mode) {
     const fd = openSync9(path, "wx", mode);
     try {
-      writeFileSync11(fd, content, "utf8");
+      writeFileSync12(fd, content, "utf8");
     } finally {
       closeSync9(fd);
     }
@@ -77973,7 +78028,7 @@ function outputIndicatesFlowFailure(output) {
 init_utils();
 import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { existsSync as existsSync29, readFileSync as readFileSync29, writeFileSync as writeFileSync12 } from "node:fs";
+import { existsSync as existsSync29, readFileSync as readFileSync29, writeFileSync as writeFileSync13 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
 import { basename as basename10, join as join42, dirname as dirname21 } from "node:path";
 init_agent_device_wrapper();
@@ -79957,7 +80012,7 @@ function createMaestroRunHandler(deps = {}) {
           proofDomain: reactOnlyProof ? "react-tree" : "partitioned"
         });
       }
-      writeFileSync12(flowFile, validatedContent, "utf-8");
+      writeFileSync13(flowFile, validatedContent, "utf-8");
       if (isLoginMetadata(semanticActionMeta) && !loginPostconditionId(validatedCommands)) {
         return failResult("Refusing login replay without a final positive post-submit testID assertion. End the flow with assertVisible.id or extendedWaitUntil.visible.id.", "ASSERTION_FAILED", { proofDomain: "react-tree", postcondition: "missing" });
       }
@@ -80191,7 +80246,7 @@ function createMaestroRunHandler(deps = {}) {
         clearTimeout(deadlineTimer);
       }
     }
-    writeFileSync12(flowFile, validatedContent, "utf-8");
+    writeFileSync13(flowFile, validatedContent, "utf-8");
     const dispatch = selectDispatch({ platform, flowHasHideKeyboard });
     if ("error" in dispatch) {
       return failResult(dispatch.error);
@@ -80379,7 +80434,7 @@ function createMaestroRunHandler(deps = {}) {
         };
         try {
           const stageResult = await (async () => {
-            writeFileSync12(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+            writeFileSync13(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
             const executeOnce = async (beforeDispatch) => {
               if (flowDeadline - now() <= 0) {
                 const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -80788,7 +80843,7 @@ function createMaestroRunHandler(deps = {}) {
     } finally {
       clearTimeout(flowAbortTimer);
       try {
-        writeFileSync12(flowFile, validatedContent, "utf-8");
+        writeFileSync13(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -82340,7 +82395,7 @@ import { promisify as promisify19 } from "node:util";
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash16, randomBytes as randomBytes7, randomUUID as randomUUID10 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync13 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname22, join as join43 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -82635,7 +82690,7 @@ var ExperienceRecorder = class {
         redactionVersion: REDACTION_RULES_VERSION
       });
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-      writeFileSync13(temp, contents.length > 0 ? `${contents}
+      writeFileSync14(temp, contents.length > 0 ? `${contents}
 ` : "", {
         encoding: "utf8",
         flag: "wx",
@@ -82935,7 +82990,7 @@ function readOrCreateRunnerDiagnosticsSalt(directory) {
   }
   const salt = randomBytes7(32);
   try {
-    writeFileSync13(path, salt, { flag: "wx", mode: 384 });
+    writeFileSync14(path, salt, { flag: "wx", mode: 384 });
     return salt;
   } catch {
     const raced = readFileSync30(path);
@@ -82969,7 +83024,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
   const temporary = join43(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
-  writeFileSync13(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
+  writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
@@ -83070,7 +83125,7 @@ function exportLatestRunnerDiagnosticsBundle(outputPath, sessionId, directory = 
   const source = latestRunnerDiagnosticsPath(sessionId, directory);
   if (!source)
     throw new Error("No runner diagnostics bundle is available for the exact session.");
-  writeFileSync13(outputPath, readFileSync30(source), { flag: "wx", mode: 384 });
+  writeFileSync14(outputPath, readFileSync30(source), { flag: "wx", mode: 384 });
   chmodSync7(outputPath, 384);
   return outputPath;
 }
@@ -84473,7 +84528,7 @@ init_utils();
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 init_project_config();
 init_maestro_validator();
-import { writeFileSync as writeFileSync14 } from "node:fs";
+import { writeFileSync as writeFileSync15 } from "node:fs";
 import { join as join44 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
 init_agent_device_wrapper();
@@ -84773,7 +84828,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync14(flowFile, content, "utf-8");
+    writeFileSync15(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -85694,7 +85749,7 @@ function createDeviceRecordHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
 import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute14, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
@@ -86773,7 +86828,7 @@ function writeProofReceiptAtomic(path, receipt2) {
   let descriptor = null;
   try {
     descriptor = openSync11(temporary, "wx", 384);
-    writeFileSync15(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync11(descriptor);
@@ -89764,7 +89819,7 @@ function buildGracefulShutdown(deps) {
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
 import { createHash as createHash21 } from "node:crypto";
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { closeSync as closeSync12, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16, writeSync as writeSync3 } from "node:fs";
+import { closeSync as closeSync12, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
 import { join as join49, resolve as resolve19 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
@@ -89927,7 +89982,7 @@ var Lockfile = class {
       return false;
     body.lastHeartbeat = this.opts.clock();
     try {
-      writeFileSync16(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
+      writeFileSync17(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
     } catch {
     }
     return true;
@@ -90212,7 +90267,7 @@ init_agent_device_wrapper();
 init_storage();
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
 import { basename as basename13, dirname as dirname28, join as join51, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 init_maestro_validator();
@@ -90465,7 +90520,7 @@ function createMaestroTestAllHandler(deps = {}) {
         continue;
       }
       const safeFlowFile = join51(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
+      writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -90488,7 +90543,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync18(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -92397,7 +92452,7 @@ init_sources();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname30, join as join56 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash22 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
@@ -92448,7 +92503,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
+  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
   renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
@@ -92652,7 +92707,7 @@ function createLockE2eTestHandler(deps = {}) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join58 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -92712,7 +92767,7 @@ function e2eRunsDirFor(projectRoot) {
 function writeJsonAtomic(file, value) {
   mkdirSync23(join58(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
+  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
@@ -92761,7 +92816,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -92779,7 +92834,7 @@ function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
+  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
   renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -59567,6 +59567,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       "--"
     ]);
   } finally {
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
+    }
     try {
       chmodSync4(snapshotRoot, 448);
       for (const entry of readdirSync7(snapshotRoot, { recursive: true, withFileTypes: true })) {
@@ -59579,11 +59584,6 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync4(entryPath, 384);
       }
     } catch {
-    }
-    if (cacheRoot) {
-      recordRunnerDiagnostic("cache-publish", {
-        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
-      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -59298,18 +59298,17 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error2));
   }
 }
-var memoizedWdaToolchainFingerprint;
+var testWdaToolchainFingerprint;
 function wdaToolchainFingerprint() {
-  if (memoizedWdaToolchainFingerprint !== void 0)
-    return memoizedWdaToolchainFingerprint;
+  if (testWdaToolchainFingerprint !== void 0)
+    return testWdaToolchainFingerprint;
   try {
     const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
     const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
-    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+    return probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
   } catch {
-    memoizedWdaToolchainFingerprint = null;
+    return null;
   }
-  return memoizedWdaToolchainFingerprint;
 }
 function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
@@ -59342,7 +59341,7 @@ function isCompleteWdaBuild(keyDir) {
         return false;
       try {
         const executable = lstatSync7(join25(products, entry.name, name, name.slice(0, -".app".length)));
-        return executable.isFile() && !executable.isSymbolicLink();
+        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -59332,11 +59332,146 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
+function parseAndNormalizeWdaXctestrun(source) {
+  let cursor = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(source[cursor] ?? ""))
+      cursor += 1;
+  };
+  const consume = (token2) => {
+    if (!source.startsWith(token2, cursor))
+      return false;
+    cursor += token2.length;
+    return true;
+  };
+  const consumePattern = (pattern) => {
+    const match = pattern.exec(source.slice(cursor));
+    if (!match || match.index !== 0)
+      return false;
+    cursor += match[0].length;
+    return true;
+  };
+  const parseTextElement = (tag) => {
+    if (consume(`<${tag}/>`))
+      return "";
+    if (!consume(`<${tag}>`))
+      return null;
+    const close = `</${tag}>`;
+    const end = source.indexOf(close, cursor);
+    if (end < 0)
+      return null;
+    const text = source.slice(cursor, end);
+    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
+      return null;
+    }
+    cursor = end + close.length;
+    return text;
+  };
+  const validScalar = (tag, value) => {
+    if (tag === "string")
+      return true;
+    if (tag === "integer")
+      return /^[+-]?\d+$/.test(value);
+    if (tag === "real") {
+      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
+    }
+    if (tag === "date")
+      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
+    const compact = value.replace(/\s/g, "");
+    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
+  };
+  const parseValue = () => {
+    skipWhitespace();
+    const start = cursor;
+    if (consume("<dict/>"))
+      return { kind: "dict", start, end: cursor, entries: [] };
+    if (consume("<dict>")) {
+      const entries = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</dict>"))
+          return { kind: "dict", start, end: cursor, entries };
+        const entryStart = cursor;
+        const key = parseTextElement("key");
+        if (key === null)
+          return null;
+        const value = parseValue();
+        if (!value)
+          return null;
+        entries.push({ key, start: entryStart, end: value.end, value });
+      }
+    }
+    if (consume("<array/>"))
+      return { kind: "array", start, end: cursor, values: [] };
+    if (consume("<array>")) {
+      const values = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</array>"))
+          return { kind: "array", start, end: cursor, values };
+        const value = parseValue();
+        if (!value)
+          return null;
+        values.push(value);
+      }
+    }
+    if (consume("<true/>") || consume("<false/>"))
+      return { kind: "scalar", start, end: cursor };
+    for (const tag of ["string", "integer", "real", "date", "data"]) {
+      const before = cursor;
+      const value = parseTextElement(tag);
+      if (value !== null) {
+        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
+      }
+      cursor = before;
+    }
+    return null;
+  };
+  skipWhitespace();
+  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+    return null;
+  skipWhitespace();
+  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
+    return null;
+  skipWhitespace();
+  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
+    return null;
+  const root = parseValue();
+  if (!root || root.kind !== "dict")
+    return null;
+  skipWhitespace();
+  if (!consume("</plist>"))
+    return null;
+  skipWhitespace();
+  if (cursor !== source.length)
+    return null;
+  const portEntries = [];
+  const collectPortEntries = (value) => {
+    if (value.kind === "dict") {
+      for (const entry of value.entries) {
+        if (entry.key === "USE_PORT")
+          portEntries.push(entry);
+        else
+          collectPortEntries(entry.value);
+      }
+    } else if (value.kind === "array") {
+      for (const child of value.values)
+        collectPortEntries(child);
+    }
+  };
+  collectPortEntries(root);
+  let normalized = source;
+  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
+    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
+  }
+  return normalized;
+}
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join25(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync7(products, { withFileTypes: true });
-    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
+    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync17(join25(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
       if (!name.endsWith(".app"))
         return false;
       try {
@@ -59352,8 +59487,8 @@ function isCompleteWdaBuild(keyDir) {
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const source = readFileSync17(xctestrunPath, "utf8");
-  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
-  if (normalized.includes("USE_PORT"))
+  const normalized = parseAndNormalizeWdaXctestrun(source);
+  if (normalized === null)
     return false;
   if (normalized !== source)
     writeFileSync9(xctestrunPath, normalized);
@@ -59408,7 +59543,12 @@ function isReusableStoredWdaBuild(keyDir) {
       return false;
     }
     const products = join25(keyDir, "DerivedData", "Build", "Products");
-    return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync17(join25(products, entry.name), "utf8").includes("USE_PORT"));
+    return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
+      if (!entry.isFile())
+        return false;
+      const source = readFileSync17(join25(products, entry.name), "utf8");
+      return parseAndNormalizeWdaXctestrun(source) === source;
+    });
   } catch {
     return false;
   }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -59332,167 +59332,92 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
-function parseAndNormalizeWdaXctestrun(source) {
-  let cursor = 0;
-  const skipWhitespace = () => {
-    while (/\s/.test(source[cursor] ?? ""))
-      cursor += 1;
-  };
-  const consume = (token2) => {
-    if (!source.startsWith(token2, cursor))
-      return false;
-    cursor += token2.length;
-    return true;
-  };
-  const consumePattern = (pattern) => {
-    const match = pattern.exec(source.slice(cursor));
-    if (!match || match.index !== 0)
-      return false;
-    cursor += match[0].length;
-    return true;
-  };
-  const parseTextElement = (tag) => {
-    if (consume(`<${tag}/>`))
-      return "";
-    if (!consume(`<${tag}>`))
-      return null;
-    const close = `</${tag}>`;
-    const end = source.indexOf(close, cursor);
-    if (end < 0)
-      return null;
-    const text = source.slice(cursor, end);
-    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
-      return null;
-    }
-    cursor = end + close.length;
-    return text;
-  };
-  const validScalar = (tag, value) => {
-    if (tag === "string")
-      return true;
-    if (tag === "integer")
-      return /^[+-]?\d+$/.test(value);
-    if (tag === "real") {
-      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
-    }
-    if (tag === "date")
-      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
-    const compact = value.replace(/\s/g, "");
-    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
-  };
-  const parseValue = () => {
-    skipWhitespace();
-    const start = cursor;
-    if (consume("<dict/>"))
-      return { kind: "dict", start, end: cursor, entries: [] };
-    if (consume("<dict>")) {
-      const entries = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</dict>"))
-          return { kind: "dict", start, end: cursor, entries };
-        const entryStart = cursor;
-        const key = parseTextElement("key");
-        if (key === null)
-          return null;
-        const value = parseValue();
-        if (!value)
-          return null;
-        entries.push({ key, start: entryStart, end: value.end, value });
-      }
-    }
-    if (consume("<array/>"))
-      return { kind: "array", start, end: cursor, values: [] };
-    if (consume("<array>")) {
-      const values = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</array>"))
-          return { kind: "array", start, end: cursor, values };
-        const value = parseValue();
-        if (!value)
-          return null;
-        values.push(value);
-      }
-    }
-    if (consume("<true/>") || consume("<false/>"))
-      return { kind: "scalar", start, end: cursor };
-    for (const tag of ["string", "integer", "real", "date", "data"]) {
-      const before = cursor;
-      const value = parseTextElement(tag);
-      if (value !== null) {
-        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
-      }
-      cursor = before;
-    }
+var testWdaPlutil;
+function runWdaPlutil(args) {
+  if (process.platform !== "darwin" && !testWdaPlutil)
     return null;
-  };
-  skipWhitespace();
-  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+  try {
+    const result = testWdaPlutil ? testWdaPlutil(args) : spawnSync("plutil", [...args], { encoding: "utf8", timeout: 15e3 });
+    return result.status === 0 ? result.stdout ?? "" : null;
+  } catch {
     return null;
-  skipWhitespace();
-  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
-    return null;
-  skipWhitespace();
-  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
-    return null;
-  const root = parseValue();
-  if (!root || root.kind !== "dict")
-    return null;
-  skipWhitespace();
-  if (!consume("</plist>"))
-    return null;
-  skipWhitespace();
-  if (cursor !== source.length)
-    return null;
-  const portEntries = [];
-  const collectPortEntries = (value) => {
-    if (value.kind === "dict") {
-      for (const entry of value.entries) {
-        if (entry.key === "USE_PORT")
-          portEntries.push(entry);
-        else
-          collectPortEntries(entry.value);
-      }
-    } else if (value.kind === "array") {
-      for (const child of value.values)
-        collectPortEntries(child);
-    }
-  };
-  collectPortEntries(root);
-  let normalized = source;
-  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
-    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
   }
-  return normalized;
+}
+function readWdaXctestrun(xctestrunPath) {
+  const json = runWdaPlutil(["-convert", "json", "-o", "-", xctestrunPath]);
+  if (json === null)
+    return null;
+  try {
+    const plist = JSON.parse(json);
+    return plist !== null && typeof plist === "object" && !Array.isArray(plist) ? plist : null;
+  } catch {
+    return null;
+  }
+}
+function forEachWdaTestTarget(plist, visit) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      if (configuration === null || typeof configuration !== "object")
+        continue;
+      const targets = configuration.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
+          visit(target);
+        }
+      }
+    }
+    return;
+  }
+  for (const [key, target] of Object.entries(plist)) {
+    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
+      visit(target);
+    }
+  }
+}
+function hasInjectedWdaPort(plist) {
+  let found = false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment) && Object.hasOwn(environment, "USE_PORT")) {
+      found = true;
+    }
+  });
+  return found;
 }
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join25(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync7(products, { withFileTypes: true });
     const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync17(join25(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync7(join25(products, entry.name)).some((name) => {
-      if (!name.endsWith(".app"))
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join25(products, entry.name)) !== null) && entries.some((entry) => {
+      if (!entry.isDirectory())
         return false;
       try {
-        const executable = lstatSync7(join25(products, entry.name, name, name.slice(0, -".app".length)));
+        const executable = lstatSync7(join25(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
         return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
-    }));
+    });
   } catch {
     return false;
   }
 }
 function removeInjectedWdaPort(xctestrunPath) {
-  const source = readFileSync17(xctestrunPath, "utf8");
-  const normalized = parseAndNormalizeWdaXctestrun(source);
-  if (normalized === null)
+  const plist = readWdaXctestrun(xctestrunPath);
+  if (!plist)
     return false;
-  if (normalized !== source)
-    writeFileSync9(xctestrunPath, normalized);
-  return true;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment)) {
+      delete environment.USE_PORT;
+    }
+  });
+  writeFileSync9(xctestrunPath, JSON.stringify(plist, null, 2));
+  return runWdaPlutil(["-convert", "xml1", xctestrunPath]) !== null;
 }
 function isRealDirectory(path) {
   try {
@@ -59546,8 +59471,8 @@ function isReusableStoredWdaBuild(keyDir) {
     return readdirSync7(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
       if (!entry.isFile())
         return false;
-      const source = readFileSync17(join25(products, entry.name), "utf8");
-      return parseAndNormalizeWdaXctestrun(source) === source;
+      const plist = readWdaXctestrun(join25(products, entry.name));
+      return plist !== null && !hasInjectedWdaPort(plist);
     });
   } catch {
     return false;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -8354,7 +8354,7 @@ var init_keyboard_guard = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/util/secure-state-file.js
-import { readFileSync as readFileSync10, writeFileSync as writeFileSync3, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
+import { readFileSync as readFileSync10, writeFileSync as writeFileSync4, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
 import { join as join12, dirname as dirname12 } from "node:path";
 import { homedir as homedir3 } from "node:os";
 function getStateDir() {
@@ -8383,7 +8383,7 @@ function readJsonStateFile(path) {
 function writeJsonStateFileAtomic(path, value) {
   mkdirSync8(dirname12(path), { recursive: true });
   const tmpPath = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmpPath, JSON.stringify(value), { encoding: "utf8", mode: 384 });
+  writeFileSync4(tmpPath, JSON.stringify(value), { encoding: "utf8", mode: 384 });
   renameSync4(tmpPath, path);
 }
 function deleteStateFile(path) {
@@ -8820,7 +8820,7 @@ var init_declared_source_contract = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/nav-graph/storage.js
-import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
+import { readFileSync as readFileSync11, writeFileSync as writeFileSync5, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
 import { join as join15, dirname as dirname13 } from "node:path";
 function isRnProject(dir) {
   const pkgPath = join15(dir, "package.json");
@@ -10412,7 +10412,7 @@ import { fileURLToPath as fileURLToPath2 } from "node:url";
 init_process_birth();
 import { spawnSync } from "node:child_process";
 import { createHash as createHash2 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2 } from "node:fs";
+import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname as dirname2, join as join2, relative, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -11014,13 +11014,68 @@ function isCompleteWdaBuild(keyDir) {
     return false;
   }
 }
-function copyWdaBuildKey(sourceKey, stagedKey) {
-  cpSync(sourceKey, stagedKey, {
+function removeInjectedWdaPort(xctestrunPath) {
+  const source = readFileSync2(xctestrunPath, "utf8");
+  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
+  if (normalized.includes("USE_PORT"))
+    return false;
+  if (normalized !== source)
+    writeFileSync(xctestrunPath, normalized);
+  return true;
+}
+function isRealDirectory(path) {
+  try {
+    const stat = lstatSync2(path);
+    return stat.isDirectory() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function copyReusableWdaBuild(sourceKey, stagedKey) {
+  const sourceProducts = join2(sourceKey, "DerivedData", "Build", "Products");
+  if (!isRealDirectory(sourceKey) || !isRealDirectory(join2(sourceKey, "DerivedData")) || !isRealDirectory(join2(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+    return false;
+  }
+  const stagedProducts = join2(stagedKey, "DerivedData", "Build", "Products");
+  mkdirSync(dirname2(stagedProducts), { recursive: true });
+  cpSync(sourceProducts, stagedProducts, {
     recursive: true,
     mode: constants2.COPYFILE_FICLONE,
     verbatimSymlinks: true
   });
+  for (const entry of readdirSync(stagedProducts, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".xctestrun") && !removeInjectedWdaPort(join2(stagedProducts, entry.name))) {
+      return false;
+    }
+  }
   return isCompleteWdaBuild(stagedKey);
+}
+function isReusableStoredWdaBuild(keyDir) {
+  try {
+    if (!isCompleteWdaBuild(keyDir))
+      return false;
+    const keyEntries = readdirSync(keyDir, { withFileTypes: true });
+    const derivedData = keyEntries[0];
+    if (keyEntries.length !== 1 || derivedData?.name !== "DerivedData" || !derivedData.isDirectory()) {
+      return false;
+    }
+    const derivedDataEntries = readdirSync(join2(keyDir, "DerivedData"), { withFileTypes: true });
+    const build = derivedDataEntries[0];
+    if (derivedDataEntries.length !== 1 || build?.name !== "Build" || !build.isDirectory()) {
+      return false;
+    }
+    const buildEntries = readdirSync(join2(keyDir, "DerivedData", "Build"), {
+      withFileTypes: true
+    });
+    const productsEntry = buildEntries[0];
+    if (buildEntries.length !== 1 || productsEntry?.name !== "Products" || !productsEntry.isDirectory()) {
+      return false;
+    }
+    const products = join2(keyDir, "DerivedData", "Build", "Products");
+    return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync2(join2(products, entry.name), "utf8").includes("USE_PORT"));
+  } catch {
+    return false;
+  }
 }
 function seedRunnerSnapshotCacheFromStore(cacheRoot) {
   let seeded = 0;
@@ -11038,7 +11093,7 @@ function seedRunnerSnapshotCacheFromStore(cacheRoot) {
       mkdirSync(target, { recursive: true });
       const stagedKey = join2(target, `.seed-${entry.name}`);
       try {
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           renameSync(stagedKey, join2(target, entry.name));
           seeded += 1;
         } else {
@@ -11069,13 +11124,13 @@ function publishRunnerSnapshotCacheToStore(cacheRoot) {
       if (!isCompleteWdaBuild(sourceKey))
         continue;
       const storeKey = join2(storeBuilds, entry.name);
-      if (isCompleteWdaBuild(storeKey))
+      if (isReusableStoredWdaBuild(storeKey))
         continue;
       mkdirSync(storeBuilds, { recursive: true, mode: 448 });
       const stage = mkdtempSync(join2(storeBuilds, ".stage-"));
       try {
         const stagedKey = join2(stage, entry.name);
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           if (existsSync3(storeKey)) {
             const evicted = join2(stage, "evicted");
             renameSync(storeKey, evicted);
@@ -11471,7 +11526,7 @@ import { existsSync as existsSync9, lstatSync as lstatSync7, readFileSync as rea
 import { basename as basename4, dirname as dirname9, isAbsolute as isAbsolute4, join as join10, relative as relative3, resolve as resolve5, sep as sep6 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
-import { existsSync as existsSync4, readFileSync as readFileSync4, writeFileSync, mkdirSync as mkdirSync3, statSync } from "node:fs";
+import { existsSync as existsSync4, readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, statSync } from "node:fs";
 import { join as join5, dirname as dirname4 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/runtime-paths.js
@@ -11533,7 +11588,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync2, renameSync as renameSync2, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
+import { writeFileSync as writeFileSync3, renameSync as renameSync2, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
 import { dirname as dirname5, basename as basename2 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -11583,7 +11638,7 @@ function withPairWriteLock(yamlPath, operation, acquisitionPrecondition) {
   const ownerPath = `${dirname5(yamlPath)}/.rn-action-write-owner.${generateTmpStamp()}`;
   const owner = currentLockOwner();
   const lockFd = openSync2(ownerPath, "wx", 384);
-  writeFileSync2(lockFd, `${JSON.stringify(owner)}
+  writeFileSync3(lockFd, `${JSON.stringify(owner)}
 `, "utf8");
   const deadline = Date.now() + ACTION_WRITE_LOCK_TIMEOUT_MS;
   let acquired = false;
@@ -11825,12 +11880,12 @@ function cleanupOrphans(yamlPath, sidecarPath) {
 var atomicWriter = {
   /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
   _writeFile(path, content) {
-    writeFileSync2(path, content, "utf8");
+    writeFileSync3(path, content, "utf8");
   },
   _writeFileWithMode(path, content, mode) {
     const fd = openSync2(path, "wx", mode);
     try {
-      writeFileSync2(fd, content, "utf8");
+      writeFileSync3(fd, content, "utf8");
     } finally {
       closeSync2(fd);
     }
@@ -14163,7 +14218,7 @@ function filterWithBoundedRegex(candidates, pattern, timeoutMs = 500) {
 init_utils();
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
-import { existsSync as existsSync17, readFileSync as readFileSync15, writeFileSync as writeFileSync5 } from "node:fs";
+import { existsSync as existsSync17, readFileSync as readFileSync15, writeFileSync as writeFileSync6 } from "node:fs";
 import { tmpdir as tmpdir4 } from "node:os";
 import { basename as basename8, join as join23, dirname as dirname14 } from "node:path";
 init_agent_device_wrapper();
@@ -16333,7 +16388,7 @@ function createMaestroRunHandler(deps = {}) {
           proofDomain: reactOnlyProof ? "react-tree" : "partitioned"
         });
       }
-      writeFileSync5(flowFile, validatedContent, "utf-8");
+      writeFileSync6(flowFile, validatedContent, "utf-8");
       if (isLoginMetadata(semanticActionMeta) && !loginPostconditionId(validatedCommands)) {
         return failResult("Refusing login replay without a final positive post-submit testID assertion. End the flow with assertVisible.id or extendedWaitUntil.visible.id.", "ASSERTION_FAILED", { proofDomain: "react-tree", postcondition: "missing" });
       }
@@ -16567,7 +16622,7 @@ function createMaestroRunHandler(deps = {}) {
         clearTimeout(deadlineTimer);
       }
     }
-    writeFileSync5(flowFile, validatedContent, "utf-8");
+    writeFileSync6(flowFile, validatedContent, "utf-8");
     const dispatch = selectDispatch({ platform, flowHasHideKeyboard });
     if ("error" in dispatch) {
       return failResult(dispatch.error);
@@ -16755,7 +16810,7 @@ function createMaestroRunHandler(deps = {}) {
         };
         try {
           const stageResult = await (async () => {
-            writeFileSync5(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+            writeFileSync6(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
             const executeOnce = async (beforeDispatch) => {
               if (flowDeadline - now() <= 0) {
                 const error = new Error("Maestro flow timeout exhausted before the next stage");
@@ -17164,7 +17219,7 @@ function createMaestroRunHandler(deps = {}) {
     } finally {
       clearTimeout(flowAbortTimer);
       try {
-        writeFileSync5(flowFile, validatedContent, "utf-8");
+        writeFileSync6(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -7884,7 +7884,7 @@ var require_dist = __commonJS({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-validator.js
-import { join as join3, dirname as dirname3, isAbsolute, sep as sep2 } from "node:path";
+import { join as join3, dirname as dirname3, isAbsolute as isAbsolute2, sep as sep2 } from "node:path";
 import { readFileSync as readFileSync3, realpathSync as realpathSync3 } from "node:fs";
 function isValidBundleId(s) {
   if (typeof s !== "string")
@@ -8062,7 +8062,7 @@ function resolveRunFlowTarget(file, opts) {
   if (!opts.flowDir || !opts.flowRoot) {
     throw new MaestroValidationError(`runFlow file ref "${file}" requires a flow root context (flowDir + flowRoot)`);
   }
-  if (isAbsolute(file)) {
+  if (isAbsolute2(file)) {
     throw new MaestroValidationError(`runFlow file ref must be relative, got absolute: ${file}`);
   }
   if (file.split(/[\\/]/).includes("..")) {
@@ -10414,7 +10414,7 @@ import { spawnSync } from "node:child_process";
 import { createHash as createHash2 } from "node:crypto";
 import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname as dirname2, join as join2, relative, resolve, sep } from "node:path";
+import { basename, dirname as dirname2, isAbsolute, join as join2, relative, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 // packages/rn-dev-agent-core/dist/experience/runner-diagnostics.js
@@ -11018,28 +11018,50 @@ function readWdaXctestrun(xctestrunPath) {
     return null;
   }
 }
+function asWdaPlistRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
 function forEachWdaTestTarget(plist, visit) {
   const configurations = plist.TestConfigurations;
   if (Array.isArray(configurations)) {
     for (const configuration of configurations) {
-      if (configuration === null || typeof configuration !== "object")
+      const configurationRecord = asWdaPlistRecord(configuration);
+      if (!configurationRecord)
         continue;
-      const targets = configuration.TestTargets;
+      const targets = configurationRecord.TestTargets;
       if (!Array.isArray(targets))
         continue;
       for (const target of targets) {
-        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
-          visit(target);
-        }
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord)
+          visit(targetRecord);
       }
     }
     return;
   }
   for (const [key, target] of Object.entries(plist)) {
-    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
-      visit(target);
-    }
+    const targetRecord = asWdaPlistRecord(target);
+    if (key !== "__xctestrun_metadata__" && targetRecord)
+      visit(targetRecord);
   }
+}
+function findWdaTestTarget(plist) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      const targets = asWdaPlistRecord(configuration)?.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord && (targetRecord.TestTargetName === "WebDriverAgentRunner" || targetRecord.BlueprintName === "WebDriverAgentRunner")) {
+          return targetRecord;
+        }
+      }
+    }
+    return null;
+  }
+  return asWdaPlistRecord(plist.WebDriverAgentRunner);
 }
 function hasInjectedWdaPort(plist) {
   let found = false;
@@ -11051,24 +11073,79 @@ function hasInjectedWdaPort(plist) {
   });
   return found;
 }
-function isCompleteWdaBuild(keyDir) {
-  try {
-    const products = join2(keyDir, "DerivedData", "Build", "Products");
-    const entries = readdirSync(products, { withFileTypes: true });
-    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join2(products, entry.name)) !== null) && entries.some((entry) => {
-      if (!entry.isDirectory())
-        return false;
-      try {
-        const executable = lstatSync2(join2(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
-        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
-      } catch {
+function isWithinWdaKey(keyDir, candidate) {
+  const path = relative(keyDir, candidate);
+  return path === "" || path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path);
+}
+function isContainedWdaProductTree(keyDir, products) {
+  const lexicalKey = resolve(keyDir);
+  const realKey = realpathSync2(keyDir);
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join2(directory, entry.name);
+      const stat = lstatSync2(path);
+      if (stat.isSymbolicLink()) {
+        const target = readlinkSync(path);
+        if (isAbsolute(target) || !isWithinWdaKey(lexicalKey, resolve(directory, target)) || !isWithinWdaKey(realKey, realpathSync2(path))) {
+          return false;
+        }
+      } else if (stat.isDirectory() && !visit(path)) {
         return false;
       }
-    });
-  } catch {
-    return false;
+    }
+    return true;
+  };
+  return visit(products);
+}
+function resolveWdaProductReference(reference, products, testHost) {
+  if (typeof reference !== "string")
+    return null;
+  if (reference.startsWith("__TESTROOT__/")) {
+    return resolve(products, reference.slice("__TESTROOT__/".length));
   }
+  if (testHost && reference.startsWith("__TESTHOST__/")) {
+    return resolve(testHost, reference.slice("__TESTHOST__/".length));
+  }
+  return null;
+}
+function readCompleteWdaBuildManifest(keyDir) {
+  try {
+    const derivedData = join2(keyDir, "DerivedData");
+    const build = join2(derivedData, "Build");
+    const products = join2(build, "Products");
+    if (!isRealDirectory(keyDir) || !isRealDirectory(derivedData) || !isRealDirectory(build) || !isRealDirectory(products) || !isContainedWdaProductTree(keyDir, products)) {
+      return null;
+    }
+    const selected = readdirSync(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)[0];
+    if (!selected?.isFile())
+      return null;
+    const selectedXctestrun = join2(products, selected.name);
+    const plist = readWdaXctestrun(selectedXctestrun);
+    const target = plist && findWdaTestTarget(plist);
+    if (!target)
+      return null;
+    const testHost = resolveWdaProductReference(target.TestHostPath, products);
+    if (!testHost)
+      return null;
+    const hostPath = relative(products, testHost).split(sep);
+    if (hostPath.length !== 2 || hostPath[1] !== "WebDriverAgentRunner-Runner.app" || !isRealDirectory(join2(products, hostPath[0])) || !isRealDirectory(testHost)) {
+      return null;
+    }
+    const executable = lstatSync2(join2(testHost, "WebDriverAgentRunner-Runner"));
+    if (!executable.isFile() || executable.isSymbolicLink() || (executable.mode & 73) === 0) {
+      return null;
+    }
+    const testBundle = resolveWdaProductReference(target.TestBundlePath, products, testHost);
+    if (!testBundle || !isWithinWdaKey(resolve(keyDir), testBundle) || !existsSync3(testBundle)) {
+      return null;
+    }
+    return { products, selectedXctestrun };
+  } catch {
+    return null;
+  }
+}
+function isCompleteWdaBuild(keyDir) {
+  return readCompleteWdaBuildManifest(keyDir) !== null;
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const plist = readWdaXctestrun(xctestrunPath);
@@ -11092,10 +11169,10 @@ function isRealDirectory(path) {
   }
 }
 function copyReusableWdaBuild(sourceKey, stagedKey) {
-  const sourceProducts = join2(sourceKey, "DerivedData", "Build", "Products");
-  if (!isRealDirectory(sourceKey) || !isRealDirectory(join2(sourceKey, "DerivedData")) || !isRealDirectory(join2(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+  const manifest = readCompleteWdaBuildManifest(sourceKey);
+  if (!manifest)
     return false;
-  }
+  const sourceProducts = manifest.products;
   const stagedProducts = join2(stagedKey, "DerivedData", "Build", "Products");
   mkdirSync(dirname2(stagedProducts), { recursive: true });
   cpSync(sourceProducts, stagedProducts, {
@@ -11588,7 +11665,7 @@ function parseProducesMap(raw) {
 
 // packages/rn-dev-agent-core/dist/domain/action-store.js
 import { existsSync as existsSync9, lstatSync as lstatSync7, readFileSync as readFileSync8, statSync as statSync4, unlinkSync as unlinkSync5 } from "node:fs";
-import { basename as basename4, dirname as dirname9, isAbsolute as isAbsolute4, join as join10, relative as relative3, resolve as resolve5, sep as sep6 } from "node:path";
+import { basename as basename4, dirname as dirname9, isAbsolute as isAbsolute5, join as join10, relative as relative3, resolve as resolve5, sep as sep6 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
 import { existsSync as existsSync4, readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync3, statSync } from "node:fs";
@@ -12139,7 +12216,7 @@ function assertWithinDir(child, baseDir) {
 init_process_birth();
 import { execFileSync as execFileSync2 } from "node:child_process";
 import { lstatSync as lstatSync5 } from "node:fs";
-import { isAbsolute as isAbsolute2, join as join6 } from "node:path";
+import { isAbsolute as isAbsolute3, join as join6 } from "node:path";
 function createUnfollowedFileSnapshot(directoryPath, directoryIdentity) {
   return { directoryPath, directoryIdentity, fileIdentities: /* @__PURE__ */ new Map() };
 }
@@ -12325,7 +12402,7 @@ function readUnfollowedFiles(directoryPath, identity, relativePaths, expectedIde
       throw new Error("Selected file identities did not match the requested paths.");
     }
     const entries = relativePaths.map((relativePath, index) => {
-      if (isAbsolute2(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
+      if (isAbsolute3(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
         throw new Error(`Invalid relative path: ${relativePath}.`);
       }
       if (expectedIdentities) {
@@ -12743,7 +12820,7 @@ function projectRootFromYaml(yamlFilePath) {
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
 import { spawnSync as spawnSync2 } from "node:child_process";
 import { closeSync as closeSync3, constants as constants4, existsSync as existsSync8, fstatSync as fstatSync3, lstatSync as lstatSync6, mkdirSync as mkdirSync7, openSync as openSync3, readFileSync as readFileSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync4, renameSync as renameSync3, statSync as statSync3, symlinkSync as symlinkSync2, unlinkSync as unlinkSync4 } from "node:fs";
-import { dirname as dirname8, isAbsolute as isAbsolute3, join as join9, relative as relative2, resolve as resolve4, sep as sep5 } from "node:path";
+import { dirname as dirname8, isAbsolute as isAbsolute4, join as join9, relative as relative2, resolve as resolve4, sep as sep5 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
 var WORKTREE_REPAIR_ENTRY = '"${CLAUDE_PLUGIN_ROOT:-${RN_DEV_AGENT_CODEX_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:?set it to the installed rn-dev-agent plugin root, then re-run}}}/rn-dev-agent-core/dist/worktree-inheritance.js"';
@@ -12802,7 +12879,7 @@ function contained(parent, child) {
   if (parent === child)
     return true;
   const rel = relative2(parent, child);
-  return rel !== "" && !rel.startsWith(`..${sep5}`) && rel !== ".." && !isAbsolute3(rel);
+  return rel !== "" && !rel.startsWith(`..${sep5}`) && rel !== ".." && !isAbsolute4(rel);
 }
 function toPosix(path) {
   return sep5 === "/" ? path : path.split(sep5).join("/");
@@ -12938,7 +13015,7 @@ function resolveWorktreeLayout(input) {
 }
 function classifySource(path, type, boundary) {
   const rel = relative2(boundary, path);
-  if (rel === ".." || rel.startsWith(`..${sep5}`) || isAbsolute3(rel)) {
+  if (rel === ".." || rel.startsWith(`..${sep5}`) || isAbsolute4(rel)) {
     return { state: "WRONG_TYPE" };
   }
   const paths = [boundary];
@@ -13519,11 +13596,11 @@ function actionFileExists(path) {
   return true;
 }
 function referencedActionPath(parentFile, reference) {
-  if (isAbsolute4(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
+  if (isAbsolute5(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
     return null;
   }
   const child = join10(dirname9(parentFile), reference);
-  if (child === ".." || child.startsWith(`..${sep6}`) || isAbsolute4(child))
+  if (child === ".." || child.startsWith(`..${sep6}`) || isAbsolute5(child))
     return null;
   return child;
 }
@@ -13700,7 +13777,7 @@ function captureActionFromContext(context, actionId) {
       flowRoot: snapshot.directory,
       readFileFn: (path) => {
         const child = relative3(snapshot.directory, path);
-        if (child === "" || child === ".." || child.startsWith(`..${sep6}`) || isAbsolute4(child)) {
+        if (child === "" || child === ".." || child.startsWith(`..${sep6}`) || isAbsolute5(child)) {
           throw new Error(`Refusing action flow outside ${snapshot.directory}.`);
         }
         const text2 = context.fileContents.get(child);
@@ -14857,7 +14934,7 @@ function maestroAuthorityRefusal(authority, underlyingError) {
 import { existsSync as existsSync16, readFileSync as readFileSync14, readdirSync as readdirSync7, realpathSync as realpathSync7, rmSync as rmSync3 } from "node:fs";
 import { createHash as createHash4 } from "node:crypto";
 import { tmpdir as tmpdir3 } from "node:os";
-import { isAbsolute as isAbsolute5, join as join22, sep as sep7 } from "node:path";
+import { isAbsolute as isAbsolute6, join as join22, sep as sep7 } from "node:path";
 var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
 var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
 var WEAK_DEVICE_ID_KEYS = ["id"];
@@ -15008,7 +15085,7 @@ function readStructuredFlowArtifact(reportDir, previous) {
     if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
       return unfinalized;
     const normalizedDataFile = flow.dataFile;
-    if (isAbsolute5(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+    if (isAbsolute6(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
       return unfinalized;
     }
     const realDataFile = realpathSync7(join22(reportDir, normalizedDataFile));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -8354,7 +8354,7 @@ var init_keyboard_guard = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/util/secure-state-file.js
-import { readFileSync as readFileSync10, writeFileSync as writeFileSync3, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync3, lstatSync as lstatSync9 } from "node:fs";
+import { readFileSync as readFileSync10, writeFileSync as writeFileSync3, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
 import { join as join12, dirname as dirname12 } from "node:path";
 import { homedir as homedir3 } from "node:os";
 function getStateDir() {
@@ -8384,7 +8384,7 @@ function writeJsonStateFileAtomic(path, value) {
   mkdirSync8(dirname12(path), { recursive: true });
   const tmpPath = `${path}.tmp.${process.pid}`;
   writeFileSync3(tmpPath, JSON.stringify(value), { encoding: "utf8", mode: 384 });
-  renameSync3(tmpPath, path);
+  renameSync4(tmpPath, path);
 }
 function deleteStateFile(path) {
   try {
@@ -8820,7 +8820,7 @@ var init_declared_source_contract = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/nav-graph/storage.js
-import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, existsSync as existsSync12, renameSync as renameSync4, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
+import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
 import { join as join15, dirname as dirname13 } from "node:path";
 function isRnProject(dir) {
   const pkgPath = join15(dir, "package.json");
@@ -10403,15 +10403,16 @@ var init_release_android_slot = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-runner-pin.js
-import { spawnSync as spawnSync2 } from "node:child_process";
+import { spawnSync as spawnSync3 } from "node:child_process";
 import { existsSync as existsSync18 } from "node:fs";
 import { dirname as dirname15, join as join24, resolve as resolve8 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
 init_process_birth();
+import { spawnSync } from "node:child_process";
 import { createHash as createHash2 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, rmSync, symlinkSync, unlinkSync as unlinkSync2 } from "node:fs";
+import { accessSync, chmodSync as chmodSync2, constants as constants2, copyFileSync as copyFileSync2, cpSync, existsSync as existsSync3, lstatSync as lstatSync2, mkdirSync, mkdtempSync, readFileSync as readFileSync2, readdirSync, readlinkSync, realpathSync as realpathSync2, renameSync, rmSync, symlinkSync, unlinkSync as unlinkSync2 } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname as dirname2, join as join2, relative, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -10961,6 +10962,135 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error));
   }
 }
+var memoizedWdaToolchainFingerprint;
+function wdaToolchainFingerprint() {
+  if (memoizedWdaToolchainFingerprint !== void 0)
+    return memoizedWdaToolchainFingerprint;
+  try {
+    const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
+    const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
+    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+  } catch {
+    memoizedWdaToolchainFingerprint = null;
+  }
+  return memoizedWdaToolchainFingerprint;
+}
+function persistentWdaStoreBuildsRoot() {
+  const fingerprint = wdaToolchainFingerprint();
+  if (!fingerprint)
+    return null;
+  const versionsRoot = runnerCacheVersionsRoot();
+  const components = [
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+  ];
+  for (const component of components) {
+    try {
+      const stat = lstatSync2(component);
+      if (!stat.isDirectory() || stat.isSymbolicLink())
+        return null;
+    } catch {
+      break;
+    }
+  }
+  return components[2];
+}
+function isCompleteWdaBuild(keyDir) {
+  try {
+    const products = join2(keyDir, "DerivedData", "Build", "Products");
+    const entries = readdirSync(products, { withFileTypes: true });
+    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
+      if (!name.endsWith(".app"))
+        return false;
+      try {
+        const executable = lstatSync2(join2(products, entry.name, name, name.slice(0, -".app".length)));
+        return executable.isFile() && !executable.isSymbolicLink();
+      } catch {
+        return false;
+      }
+    }));
+  } catch {
+    return false;
+  }
+}
+function copyWdaBuildKey(sourceKey, stagedKey) {
+  cpSync(sourceKey, stagedKey, {
+    recursive: true,
+    mode: constants2.COPYFILE_FICLONE,
+    verbatimSymlinks: true
+  });
+  return isCompleteWdaBuild(stagedKey);
+}
+function seedRunnerSnapshotCacheFromStore(cacheRoot) {
+  let seeded = 0;
+  try {
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    const target = join2(cacheRoot, "wda-builds");
+    for (const entry of readdirSync(storeBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory())
+        continue;
+      const sourceKey = join2(storeBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      mkdirSync(target, { recursive: true });
+      const stagedKey = join2(target, `.seed-${entry.name}`);
+      try {
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          renameSync(stagedKey, join2(target, entry.name));
+          seeded += 1;
+        } else {
+          rmSync(stagedKey, { recursive: true, force: true });
+        }
+      } catch {
+        try {
+          rmSync(stagedKey, { recursive: true, force: true });
+        } catch {
+        }
+      }
+    }
+  } catch {
+  }
+  return seeded;
+}
+function publishRunnerSnapshotCacheToStore(cacheRoot) {
+  let published = 0;
+  try {
+    const spawnBuilds = join2(cacheRoot, "wda-builds");
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    for (const entry of readdirSync(spawnBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith("."))
+        continue;
+      const sourceKey = join2(spawnBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      const storeKey = join2(storeBuilds, entry.name);
+      if (isCompleteWdaBuild(storeKey))
+        continue;
+      mkdirSync(storeBuilds, { recursive: true, mode: 448 });
+      const stage = mkdtempSync(join2(storeBuilds, ".stage-"));
+      try {
+        const stagedKey = join2(stage, entry.name);
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          if (existsSync3(storeKey)) {
+            const evicted = join2(stage, "evicted");
+            renameSync(storeKey, evicted);
+          }
+          renameSync(stagedKey, storeKey);
+          published += 1;
+        }
+      } finally {
+        rmSync(stage, { recursive: true, force: true });
+      }
+    }
+  } catch {
+  }
+  return published;
+}
 function provisionRunnerSnapshotCache(snapshotRoot, testHooks = {}, setOwnedCacheRoot = () => {
 }) {
   const cacheRoot = expectedRunnerCacheRoot(snapshotRoot);
@@ -11081,8 +11211,12 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
       }
     }
     chmodSync2(snapshotRoot, 320);
-    if (cacheRoot)
+    if (cacheRoot) {
       assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+      recordRunnerDiagnostic("cache-seed", {
+        seededBuilds: seedRunnerSnapshotCacheFromStore(cacheRoot)
+      });
+    }
     const openedRunner = lstatSync2(snapshotRunner);
     recordRunnerDiagnostic("runner-exec-begin", { runnerPinVersion: MAESTRO_RUNNER_PIN.version });
     if (platform === "ios") {
@@ -11108,6 +11242,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
           chmodSync2(entryPath, 384);
       }
     } catch {
+    }
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
@@ -11394,7 +11533,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
 init_process_birth();
-import { writeFileSync as writeFileSync2, renameSync, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
+import { writeFileSync as writeFileSync2, renameSync as renameSync2, statSync as statSync2, mkdirSync as mkdirSync4, existsSync as existsSync5, unlinkSync as unlinkSync3, readdirSync as readdirSync2, openSync as openSync2, closeSync as closeSync2, chmodSync as chmodSync4, fstatSync as fstatSync2, lstatSync as lstatSync4, readFileSync as readFileSync5, linkSync, constants as constants3 } from "node:fs";
 import { dirname as dirname5, basename as basename2 } from "node:path";
 var FUTURE_MTIME_BUFFER_MS = 1e3;
 var ORPHAN_MAX_AGE_MS = 5 * 60 * 1e3;
@@ -11698,7 +11837,7 @@ var atomicWriter = {
   },
   /** Underlying `fs.renameSync(from, to)`. */
   _rename(from, to) {
-    renameSync(from, to);
+    renameSync2(from, to);
   },
   /** Underlying `fs.statSync(path).mtimeMs`. */
   _statMtimeMs(path) {
@@ -12482,8 +12621,8 @@ function projectRootFromYaml(yamlFilePath) {
 }
 
 // packages/rn-dev-agent-core/dist/session/worktree-inheritance.js
-import { spawnSync } from "node:child_process";
-import { closeSync as closeSync3, constants as constants4, existsSync as existsSync8, fstatSync as fstatSync3, lstatSync as lstatSync6, mkdirSync as mkdirSync7, openSync as openSync3, readFileSync as readFileSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync4, renameSync as renameSync2, statSync as statSync3, symlinkSync as symlinkSync2, unlinkSync as unlinkSync4 } from "node:fs";
+import { spawnSync as spawnSync2 } from "node:child_process";
+import { closeSync as closeSync3, constants as constants4, existsSync as existsSync8, fstatSync as fstatSync3, lstatSync as lstatSync6, mkdirSync as mkdirSync7, openSync as openSync3, readFileSync as readFileSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync4, renameSync as renameSync3, statSync as statSync3, symlinkSync as symlinkSync2, unlinkSync as unlinkSync4 } from "node:fs";
 import { dirname as dirname8, isAbsolute as isAbsolute3, join as join9, relative as relative2, resolve as resolve4, sep as sep5 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/worktree-repair-remedy.js
@@ -12522,7 +12661,7 @@ function gitEnvironment() {
   return env;
 }
 function git(cwd, args) {
-  const result = spawnSync("git", args, {
+  const result = spawnSync2("git", args, {
     cwd,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -13032,7 +13171,7 @@ function isTracked(worktreeRoot, relativePath) {
   return listed.ok && listed.stdout.trim().length > 0;
 }
 function isIgnoreSafe(worktreeRoot, relativePath) {
-  const result = spawnSync("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
+  const result = spawnSync2("git", ["check-ignore", "--no-index", "-q", "--", relativePath], {
     cwd: worktreeRoot,
     encoding: "utf8",
     env: gitEnvironment(),
@@ -14065,7 +14204,7 @@ function chooseMaestroDispatch(inputs) {
 
 // packages/rn-dev-agent-core/dist/tools/resolve-ios-app-file.js
 import { execFileSync as execFileSync3 } from "node:child_process";
-import { existsSync as existsSync14, cpSync, rmSync as rmSync2, mkdirSync as mkdirSync10, readdirSync as readdirSync6, statSync as statSync6 } from "node:fs";
+import { existsSync as existsSync14, cpSync as cpSync2, rmSync as rmSync2, mkdirSync as mkdirSync10, readdirSync as readdirSync6, statSync as statSync6 } from "node:fs";
 import { tmpdir as tmpdir2 } from "node:os";
 import { join as join20, basename as basename7 } from "node:path";
 function flowUsesClearState(flowText) {
@@ -14080,7 +14219,7 @@ function defaultSnapshotApp(appPath) {
     try {
       execFileSync3("cp", ["-Rc", appPath, dest], { timeout: 3e4, stdio: "ignore" });
     } catch {
-      cpSync(appPath, dest, { recursive: true });
+      cpSync2(appPath, dest, { recursive: true });
     }
     return dest;
   } catch {
@@ -17048,7 +17187,7 @@ async function diagnose(json2) {
   _resetEngineStatusForTest();
   const status = await getEngineStatus();
   const report = doctorPinnedRunner(status, nodePlatformKey());
-  const runtimeProbe = spawnSync2("xcrun", ["simctl", "list", "devices", "--json"], {
+  const runtimeProbe = spawnSync3("xcrun", ["simctl", "list", "devices", "--json"], {
     encoding: "utf8",
     timeout: 5e3
   });
@@ -17078,7 +17217,7 @@ async function diagnose(json2) {
 }
 function install() {
   const script = ensureScriptPath();
-  const result = spawnSync2("bash", [script], { stdio: "inherit" });
+  const result = spawnSync3("bash", [script], { stdio: "inherit" });
   return result.status === 0 ? 0 : 1;
 }
 function migrate(root2, json2) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10962,18 +10962,17 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error));
   }
 }
-var memoizedWdaToolchainFingerprint;
+var testWdaToolchainFingerprint;
 function wdaToolchainFingerprint() {
-  if (memoizedWdaToolchainFingerprint !== void 0)
-    return memoizedWdaToolchainFingerprint;
+  if (testWdaToolchainFingerprint !== void 0)
+    return testWdaToolchainFingerprint;
   try {
     const probe = spawnSync("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
     const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
-    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+    return probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
   } catch {
-    memoizedWdaToolchainFingerprint = null;
+    return null;
   }
-  return memoizedWdaToolchainFingerprint;
 }
 function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
@@ -11006,7 +11005,7 @@ function isCompleteWdaBuild(keyDir) {
         return false;
       try {
         const executable = lstatSync2(join2(products, entry.name, name, name.slice(0, -".app".length)));
-        return executable.isFile() && !executable.isSymbolicLink();
+        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10975,15 +10975,16 @@ function wdaToolchainFingerprint() {
   }
   return memoizedWdaToolchainFingerprint;
 }
-function persistentWdaStoreBuildsRoot() {
+function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
-  if (!fingerprint)
+  if (!fingerprint || !pinArchiveCoords(platformKey))
     return null;
   const versionsRoot = runnerCacheVersionsRoot();
   const components = [
     join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
-    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
-    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint),
+    join2(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint, "wda-builds")
   ];
   for (const component of components) {
     try {
@@ -10994,7 +10995,7 @@ function persistentWdaStoreBuildsRoot() {
       break;
     }
   }
-  return components[2];
+  return components[3];
 }
 function isCompleteWdaBuild(keyDir) {
   try {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -11231,6 +11231,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
       "--"
     ]);
   } finally {
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
+    }
     try {
       chmodSync2(snapshotRoot, 448);
       for (const entry of readdirSync(snapshotRoot, { recursive: true, withFileTypes: true })) {
@@ -11243,11 +11248,6 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute, pla
           chmodSync2(entryPath, 384);
       }
     } catch {
-    }
-    if (cacheRoot) {
-      recordRunnerDiagnostic("cache-publish", {
-        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
-      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10996,167 +10996,92 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
-function parseAndNormalizeWdaXctestrun(source) {
-  let cursor = 0;
-  const skipWhitespace = () => {
-    while (/\s/.test(source[cursor] ?? ""))
-      cursor += 1;
-  };
-  const consume = (token2) => {
-    if (!source.startsWith(token2, cursor))
-      return false;
-    cursor += token2.length;
-    return true;
-  };
-  const consumePattern = (pattern) => {
-    const match = pattern.exec(source.slice(cursor));
-    if (!match || match.index !== 0)
-      return false;
-    cursor += match[0].length;
-    return true;
-  };
-  const parseTextElement = (tag) => {
-    if (consume(`<${tag}/>`))
-      return "";
-    if (!consume(`<${tag}>`))
-      return null;
-    const close = `</${tag}>`;
-    const end = source.indexOf(close, cursor);
-    if (end < 0)
-      return null;
-    const text = source.slice(cursor, end);
-    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
-      return null;
-    }
-    cursor = end + close.length;
-    return text;
-  };
-  const validScalar = (tag, value) => {
-    if (tag === "string")
-      return true;
-    if (tag === "integer")
-      return /^[+-]?\d+$/.test(value);
-    if (tag === "real") {
-      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
-    }
-    if (tag === "date")
-      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
-    const compact = value.replace(/\s/g, "");
-    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
-  };
-  const parseValue = () => {
-    skipWhitespace();
-    const start = cursor;
-    if (consume("<dict/>"))
-      return { kind: "dict", start, end: cursor, entries: [] };
-    if (consume("<dict>")) {
-      const entries = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</dict>"))
-          return { kind: "dict", start, end: cursor, entries };
-        const entryStart = cursor;
-        const key = parseTextElement("key");
-        if (key === null)
-          return null;
-        const value = parseValue();
-        if (!value)
-          return null;
-        entries.push({ key, start: entryStart, end: value.end, value });
-      }
-    }
-    if (consume("<array/>"))
-      return { kind: "array", start, end: cursor, values: [] };
-    if (consume("<array>")) {
-      const values = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</array>"))
-          return { kind: "array", start, end: cursor, values };
-        const value = parseValue();
-        if (!value)
-          return null;
-        values.push(value);
-      }
-    }
-    if (consume("<true/>") || consume("<false/>"))
-      return { kind: "scalar", start, end: cursor };
-    for (const tag of ["string", "integer", "real", "date", "data"]) {
-      const before = cursor;
-      const value = parseTextElement(tag);
-      if (value !== null) {
-        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
-      }
-      cursor = before;
-    }
+var testWdaPlutil;
+function runWdaPlutil(args) {
+  if (process.platform !== "darwin" && !testWdaPlutil)
     return null;
-  };
-  skipWhitespace();
-  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+  try {
+    const result = testWdaPlutil ? testWdaPlutil(args) : spawnSync("plutil", [...args], { encoding: "utf8", timeout: 15e3 });
+    return result.status === 0 ? result.stdout ?? "" : null;
+  } catch {
     return null;
-  skipWhitespace();
-  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
-    return null;
-  skipWhitespace();
-  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
-    return null;
-  const root2 = parseValue();
-  if (!root2 || root2.kind !== "dict")
-    return null;
-  skipWhitespace();
-  if (!consume("</plist>"))
-    return null;
-  skipWhitespace();
-  if (cursor !== source.length)
-    return null;
-  const portEntries = [];
-  const collectPortEntries = (value) => {
-    if (value.kind === "dict") {
-      for (const entry of value.entries) {
-        if (entry.key === "USE_PORT")
-          portEntries.push(entry);
-        else
-          collectPortEntries(entry.value);
-      }
-    } else if (value.kind === "array") {
-      for (const child of value.values)
-        collectPortEntries(child);
-    }
-  };
-  collectPortEntries(root2);
-  let normalized = source;
-  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
-    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
   }
-  return normalized;
+}
+function readWdaXctestrun(xctestrunPath) {
+  const json2 = runWdaPlutil(["-convert", "json", "-o", "-", xctestrunPath]);
+  if (json2 === null)
+    return null;
+  try {
+    const plist = JSON.parse(json2);
+    return plist !== null && typeof plist === "object" && !Array.isArray(plist) ? plist : null;
+  } catch {
+    return null;
+  }
+}
+function forEachWdaTestTarget(plist, visit) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      if (configuration === null || typeof configuration !== "object")
+        continue;
+      const targets = configuration.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
+          visit(target);
+        }
+      }
+    }
+    return;
+  }
+  for (const [key, target] of Object.entries(plist)) {
+    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
+      visit(target);
+    }
+  }
+}
+function hasInjectedWdaPort(plist) {
+  let found = false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment) && Object.hasOwn(environment, "USE_PORT")) {
+      found = true;
+    }
+  });
+  return found;
 }
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join2(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync(products, { withFileTypes: true });
     const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync2(join2(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
-      if (!name.endsWith(".app"))
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join2(products, entry.name)) !== null) && entries.some((entry) => {
+      if (!entry.isDirectory())
         return false;
       try {
-        const executable = lstatSync2(join2(products, entry.name, name, name.slice(0, -".app".length)));
+        const executable = lstatSync2(join2(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
         return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
-    }));
+    });
   } catch {
     return false;
   }
 }
 function removeInjectedWdaPort(xctestrunPath) {
-  const source = readFileSync2(xctestrunPath, "utf8");
-  const normalized = parseAndNormalizeWdaXctestrun(source);
-  if (normalized === null)
+  const plist = readWdaXctestrun(xctestrunPath);
+  if (!plist)
     return false;
-  if (normalized !== source)
-    writeFileSync(xctestrunPath, normalized);
-  return true;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment)) {
+      delete environment.USE_PORT;
+    }
+  });
+  writeFileSync(xctestrunPath, JSON.stringify(plist, null, 2));
+  return runWdaPlutil(["-convert", "xml1", xctestrunPath]) !== null;
 }
 function isRealDirectory(path) {
   try {
@@ -11210,8 +11135,8 @@ function isReusableStoredWdaBuild(keyDir) {
     return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
       if (!entry.isFile())
         return false;
-      const source = readFileSync2(join2(products, entry.name), "utf8");
-      return parseAndNormalizeWdaXctestrun(source) === source;
+      const plist = readWdaXctestrun(join2(products, entry.name));
+      return plist !== null && !hasInjectedWdaPort(plist);
     });
   } catch {
     return false;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10996,11 +10996,146 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
+function parseAndNormalizeWdaXctestrun(source) {
+  let cursor = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(source[cursor] ?? ""))
+      cursor += 1;
+  };
+  const consume = (token2) => {
+    if (!source.startsWith(token2, cursor))
+      return false;
+    cursor += token2.length;
+    return true;
+  };
+  const consumePattern = (pattern) => {
+    const match = pattern.exec(source.slice(cursor));
+    if (!match || match.index !== 0)
+      return false;
+    cursor += match[0].length;
+    return true;
+  };
+  const parseTextElement = (tag) => {
+    if (consume(`<${tag}/>`))
+      return "";
+    if (!consume(`<${tag}>`))
+      return null;
+    const close = `</${tag}>`;
+    const end = source.indexOf(close, cursor);
+    if (end < 0)
+      return null;
+    const text = source.slice(cursor, end);
+    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
+      return null;
+    }
+    cursor = end + close.length;
+    return text;
+  };
+  const validScalar = (tag, value) => {
+    if (tag === "string")
+      return true;
+    if (tag === "integer")
+      return /^[+-]?\d+$/.test(value);
+    if (tag === "real") {
+      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
+    }
+    if (tag === "date")
+      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
+    const compact = value.replace(/\s/g, "");
+    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
+  };
+  const parseValue = () => {
+    skipWhitespace();
+    const start = cursor;
+    if (consume("<dict/>"))
+      return { kind: "dict", start, end: cursor, entries: [] };
+    if (consume("<dict>")) {
+      const entries = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</dict>"))
+          return { kind: "dict", start, end: cursor, entries };
+        const entryStart = cursor;
+        const key = parseTextElement("key");
+        if (key === null)
+          return null;
+        const value = parseValue();
+        if (!value)
+          return null;
+        entries.push({ key, start: entryStart, end: value.end, value });
+      }
+    }
+    if (consume("<array/>"))
+      return { kind: "array", start, end: cursor, values: [] };
+    if (consume("<array>")) {
+      const values = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</array>"))
+          return { kind: "array", start, end: cursor, values };
+        const value = parseValue();
+        if (!value)
+          return null;
+        values.push(value);
+      }
+    }
+    if (consume("<true/>") || consume("<false/>"))
+      return { kind: "scalar", start, end: cursor };
+    for (const tag of ["string", "integer", "real", "date", "data"]) {
+      const before = cursor;
+      const value = parseTextElement(tag);
+      if (value !== null) {
+        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
+      }
+      cursor = before;
+    }
+    return null;
+  };
+  skipWhitespace();
+  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+    return null;
+  skipWhitespace();
+  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
+    return null;
+  skipWhitespace();
+  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
+    return null;
+  const root2 = parseValue();
+  if (!root2 || root2.kind !== "dict")
+    return null;
+  skipWhitespace();
+  if (!consume("</plist>"))
+    return null;
+  skipWhitespace();
+  if (cursor !== source.length)
+    return null;
+  const portEntries = [];
+  const collectPortEntries = (value) => {
+    if (value.kind === "dict") {
+      for (const entry of value.entries) {
+        if (entry.key === "USE_PORT")
+          portEntries.push(entry);
+        else
+          collectPortEntries(entry.value);
+      }
+    } else if (value.kind === "array") {
+      for (const child of value.values)
+        collectPortEntries(child);
+    }
+  };
+  collectPortEntries(root2);
+  let normalized = source;
+  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
+    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
+  }
+  return normalized;
+}
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join2(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync(products, { withFileTypes: true });
-    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
+    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync2(join2(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync(join2(products, entry.name)).some((name) => {
       if (!name.endsWith(".app"))
         return false;
       try {
@@ -11016,8 +11151,8 @@ function isCompleteWdaBuild(keyDir) {
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const source = readFileSync2(xctestrunPath, "utf8");
-  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
-  if (normalized.includes("USE_PORT"))
+  const normalized = parseAndNormalizeWdaXctestrun(source);
+  if (normalized === null)
     return false;
   if (normalized !== source)
     writeFileSync(xctestrunPath, normalized);
@@ -11072,7 +11207,12 @@ function isReusableStoredWdaBuild(keyDir) {
       return false;
     }
     const products = join2(keyDir, "DerivedData", "Build", "Products");
-    return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync2(join2(products, entry.name), "utf8").includes("USE_PORT"));
+    return readdirSync(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
+      if (!entry.isFile())
+        return false;
+      const source = readFileSync2(join2(products, entry.name), "utf8");
+      return parseAndNormalizeWdaXctestrun(source) === source;
+    });
   } catch {
     return false;
   }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71985,6 +71985,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       "--"
     ]);
   } finally {
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
+    }
     try {
       chmodSync5(snapshotRoot, 448);
       for (const entry of readdirSync8(snapshotRoot, { recursive: true, withFileTypes: true })) {
@@ -71997,11 +72002,6 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync5(entryPath, 384);
       }
     } catch {
-    }
-    if (cacheRoot) {
-      recordRunnerDiagnostic("cache-publish", {
-        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
-      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71750,167 +71750,91 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
-function parseAndNormalizeWdaXctestrun(source) {
-  let cursor = 0;
-  const skipWhitespace = () => {
-    while (/\s/.test(source[cursor] ?? ""))
-      cursor += 1;
-  };
-  const consume = (token2) => {
-    if (!source.startsWith(token2, cursor))
-      return false;
-    cursor += token2.length;
-    return true;
-  };
-  const consumePattern = (pattern) => {
-    const match = pattern.exec(source.slice(cursor));
-    if (!match || match.index !== 0)
-      return false;
-    cursor += match[0].length;
-    return true;
-  };
-  const parseTextElement = (tag) => {
-    if (consume(`<${tag}/>`))
-      return "";
-    if (!consume(`<${tag}>`))
-      return null;
-    const close = `</${tag}>`;
-    const end = source.indexOf(close, cursor);
-    if (end < 0)
-      return null;
-    const text = source.slice(cursor, end);
-    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
-      return null;
-    }
-    cursor = end + close.length;
-    return text;
-  };
-  const validScalar = (tag, value) => {
-    if (tag === "string")
-      return true;
-    if (tag === "integer")
-      return /^[+-]?\d+$/.test(value);
-    if (tag === "real") {
-      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
-    }
-    if (tag === "date")
-      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
-    const compact = value.replace(/\s/g, "");
-    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
-  };
-  const parseValue = () => {
-    skipWhitespace();
-    const start = cursor;
-    if (consume("<dict/>"))
-      return { kind: "dict", start, end: cursor, entries: [] };
-    if (consume("<dict>")) {
-      const entries = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</dict>"))
-          return { kind: "dict", start, end: cursor, entries };
-        const entryStart = cursor;
-        const key = parseTextElement("key");
-        if (key === null)
-          return null;
-        const value = parseValue();
-        if (!value)
-          return null;
-        entries.push({ key, start: entryStart, end: value.end, value });
-      }
-    }
-    if (consume("<array/>"))
-      return { kind: "array", start, end: cursor, values: [] };
-    if (consume("<array>")) {
-      const values = [];
-      while (true) {
-        skipWhitespace();
-        if (consume("</array>"))
-          return { kind: "array", start, end: cursor, values };
-        const value = parseValue();
-        if (!value)
-          return null;
-        values.push(value);
-      }
-    }
-    if (consume("<true/>") || consume("<false/>"))
-      return { kind: "scalar", start, end: cursor };
-    for (const tag of ["string", "integer", "real", "date", "data"]) {
-      const before = cursor;
-      const value = parseTextElement(tag);
-      if (value !== null) {
-        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
-      }
-      cursor = before;
-    }
+function runWdaPlutil(args) {
+  if (process.platform !== "darwin" && !testWdaPlutil)
     return null;
-  };
-  skipWhitespace();
-  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+  try {
+    const result = testWdaPlutil ? testWdaPlutil(args) : spawnSync3("plutil", [...args], { encoding: "utf8", timeout: 15e3 });
+    return result.status === 0 ? result.stdout ?? "" : null;
+  } catch {
     return null;
-  skipWhitespace();
-  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
-    return null;
-  skipWhitespace();
-  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
-    return null;
-  const root = parseValue();
-  if (!root || root.kind !== "dict")
-    return null;
-  skipWhitespace();
-  if (!consume("</plist>"))
-    return null;
-  skipWhitespace();
-  if (cursor !== source.length)
-    return null;
-  const portEntries = [];
-  const collectPortEntries = (value) => {
-    if (value.kind === "dict") {
-      for (const entry of value.entries) {
-        if (entry.key === "USE_PORT")
-          portEntries.push(entry);
-        else
-          collectPortEntries(entry.value);
-      }
-    } else if (value.kind === "array") {
-      for (const child of value.values)
-        collectPortEntries(child);
-    }
-  };
-  collectPortEntries(root);
-  let normalized = source;
-  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
-    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
   }
-  return normalized;
+}
+function readWdaXctestrun(xctestrunPath) {
+  const json = runWdaPlutil(["-convert", "json", "-o", "-", xctestrunPath]);
+  if (json === null)
+    return null;
+  try {
+    const plist = JSON.parse(json);
+    return plist !== null && typeof plist === "object" && !Array.isArray(plist) ? plist : null;
+  } catch {
+    return null;
+  }
+}
+function forEachWdaTestTarget(plist, visit) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      if (configuration === null || typeof configuration !== "object")
+        continue;
+      const targets = configuration.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
+          visit(target);
+        }
+      }
+    }
+    return;
+  }
+  for (const [key, target] of Object.entries(plist)) {
+    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
+      visit(target);
+    }
+  }
+}
+function hasInjectedWdaPort(plist) {
+  let found = false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment) && Object.hasOwn(environment, "USE_PORT")) {
+      found = true;
+    }
+  });
+  return found;
 }
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join35(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync8(products, { withFileTypes: true });
     const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync25(join35(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
-      if (!name.endsWith(".app"))
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join35(products, entry.name)) !== null) && entries.some((entry) => {
+      if (!entry.isDirectory())
         return false;
       try {
-        const executable = lstatSync12(join35(products, entry.name, name, name.slice(0, -".app".length)));
+        const executable = lstatSync12(join35(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
         return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
-    }));
+    });
   } catch {
     return false;
   }
 }
 function removeInjectedWdaPort(xctestrunPath) {
-  const source = readFileSync25(xctestrunPath, "utf8");
-  const normalized = parseAndNormalizeWdaXctestrun(source);
-  if (normalized === null)
+  const plist = readWdaXctestrun(xctestrunPath);
+  if (!plist)
     return false;
-  if (normalized !== source)
-    writeFileSync12(xctestrunPath, normalized);
-  return true;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === "object" && !Array.isArray(environment)) {
+      delete environment.USE_PORT;
+    }
+  });
+  writeFileSync12(xctestrunPath, JSON.stringify(plist, null, 2));
+  return runWdaPlutil(["-convert", "xml1", xctestrunPath]) !== null;
 }
 function isRealDirectory(path) {
   try {
@@ -71964,8 +71888,8 @@ function isReusableStoredWdaBuild(keyDir) {
     return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
       if (!entry.isFile())
         return false;
-      const source = readFileSync25(join35(products, entry.name), "utf8");
-      return parseAndNormalizeWdaXctestrun(source) === source;
+      const plist = readWdaXctestrun(join35(products, entry.name));
+      return plist !== null && !hasInjectedWdaPort(plist);
     });
   } catch {
     return false;
@@ -72287,7 +72211,7 @@ function getEngineStatus(resolvers) {
     return Promise.resolve(testStatus);
   return detect(resolvers ?? {}).catch(() => buildReplayEngineStatus("unknown-version", null, false));
 }
-var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testWdaToolchainFingerprint, testStatus, testAttestation;
+var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testWdaToolchainFingerprint, testWdaPlutil, testStatus, testAttestation;
 var init_engine_pin = __esm({
   "packages/rn-dev-agent-core/dist/domain/engine-pin.js"() {
     "use strict";

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71308,7 +71308,7 @@ import { spawnSync as spawnSync3 } from "node:child_process";
 import { createHash as createHash13 } from "node:crypto";
 import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11, writeFileSync as writeFileSync12 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { basename as basename6, dirname as dirname17, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
+import { basename as basename6, dirname as dirname17, isAbsolute as isAbsolute9, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
 import { gunzipSync } from "node:zlib";
 function parseActionEnginePinVersion(enginePin) {
   const match = ACTION_ENGINE_PIN_RE.exec(enginePin.trim());
@@ -71771,28 +71771,50 @@ function readWdaXctestrun(xctestrunPath) {
     return null;
   }
 }
+function asWdaPlistRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
 function forEachWdaTestTarget(plist, visit) {
   const configurations = plist.TestConfigurations;
   if (Array.isArray(configurations)) {
     for (const configuration of configurations) {
-      if (configuration === null || typeof configuration !== "object")
+      const configurationRecord = asWdaPlistRecord(configuration);
+      if (!configurationRecord)
         continue;
-      const targets = configuration.TestTargets;
+      const targets = configurationRecord.TestTargets;
       if (!Array.isArray(targets))
         continue;
       for (const target of targets) {
-        if (target !== null && typeof target === "object" && !Array.isArray(target)) {
-          visit(target);
-        }
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord)
+          visit(targetRecord);
       }
     }
     return;
   }
   for (const [key, target] of Object.entries(plist)) {
-    if (key !== "__xctestrun_metadata__" && target !== null && typeof target === "object" && !Array.isArray(target)) {
-      visit(target);
-    }
+    const targetRecord = asWdaPlistRecord(target);
+    if (key !== "__xctestrun_metadata__" && targetRecord)
+      visit(targetRecord);
   }
+}
+function findWdaTestTarget(plist) {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      const targets = asWdaPlistRecord(configuration)?.TestTargets;
+      if (!Array.isArray(targets))
+        continue;
+      for (const target of targets) {
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord && (targetRecord.TestTargetName === "WebDriverAgentRunner" || targetRecord.BlueprintName === "WebDriverAgentRunner")) {
+          return targetRecord;
+        }
+      }
+    }
+    return null;
+  }
+  return asWdaPlistRecord(plist.WebDriverAgentRunner);
 }
 function hasInjectedWdaPort(plist) {
   let found = false;
@@ -71804,24 +71826,79 @@ function hasInjectedWdaPort(plist) {
   });
   return found;
 }
-function isCompleteWdaBuild(keyDir) {
-  try {
-    const products = join35(keyDir, "DerivedData", "Build", "Products");
-    const entries = readdirSync8(products, { withFileTypes: true });
-    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
-    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && readWdaXctestrun(join35(products, entry.name)) !== null) && entries.some((entry) => {
-      if (!entry.isDirectory())
-        return false;
-      try {
-        const executable = lstatSync12(join35(products, entry.name, "WebDriverAgentRunner-Runner.app", "WebDriverAgentRunner-Runner"));
-        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
-      } catch {
+function isWithinWdaKey(keyDir, candidate) {
+  const path = relative7(keyDir, candidate);
+  return path === "" || path !== ".." && !path.startsWith(`..${sep6}`) && !isAbsolute9(path);
+}
+function isContainedWdaProductTree(keyDir, products) {
+  const lexicalKey = resolve12(keyDir);
+  const realKey = realpathSync13(keyDir);
+  const visit = (directory) => {
+    for (const entry of readdirSync8(directory, { withFileTypes: true })) {
+      const path = join35(directory, entry.name);
+      const stat2 = lstatSync12(path);
+      if (stat2.isSymbolicLink()) {
+        const target = readlinkSync5(path);
+        if (isAbsolute9(target) || !isWithinWdaKey(lexicalKey, resolve12(directory, target)) || !isWithinWdaKey(realKey, realpathSync13(path))) {
+          return false;
+        }
+      } else if (stat2.isDirectory() && !visit(path)) {
         return false;
       }
-    });
-  } catch {
-    return false;
+    }
+    return true;
+  };
+  return visit(products);
+}
+function resolveWdaProductReference(reference, products, testHost) {
+  if (typeof reference !== "string")
+    return null;
+  if (reference.startsWith("__TESTROOT__/")) {
+    return resolve12(products, reference.slice("__TESTROOT__/".length));
   }
+  if (testHost && reference.startsWith("__TESTHOST__/")) {
+    return resolve12(testHost, reference.slice("__TESTHOST__/".length));
+  }
+  return null;
+}
+function readCompleteWdaBuildManifest(keyDir) {
+  try {
+    const derivedData = join35(keyDir, "DerivedData");
+    const build = join35(derivedData, "Build");
+    const products = join35(build, "Products");
+    if (!isRealDirectory(keyDir) || !isRealDirectory(derivedData) || !isRealDirectory(build) || !isRealDirectory(products) || !isContainedWdaProductTree(keyDir, products)) {
+      return null;
+    }
+    const selected = readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)[0];
+    if (!selected?.isFile())
+      return null;
+    const selectedXctestrun = join35(products, selected.name);
+    const plist = readWdaXctestrun(selectedXctestrun);
+    const target = plist && findWdaTestTarget(plist);
+    if (!target)
+      return null;
+    const testHost = resolveWdaProductReference(target.TestHostPath, products);
+    if (!testHost)
+      return null;
+    const hostPath = relative7(products, testHost).split(sep6);
+    if (hostPath.length !== 2 || hostPath[1] !== "WebDriverAgentRunner-Runner.app" || !isRealDirectory(join35(products, hostPath[0])) || !isRealDirectory(testHost)) {
+      return null;
+    }
+    const executable = lstatSync12(join35(testHost, "WebDriverAgentRunner-Runner"));
+    if (!executable.isFile() || executable.isSymbolicLink() || (executable.mode & 73) === 0) {
+      return null;
+    }
+    const testBundle = resolveWdaProductReference(target.TestBundlePath, products, testHost);
+    if (!testBundle || !isWithinWdaKey(resolve12(keyDir), testBundle) || !existsSync24(testBundle)) {
+      return null;
+    }
+    return { products, selectedXctestrun };
+  } catch {
+    return null;
+  }
+}
+function isCompleteWdaBuild(keyDir) {
+  return readCompleteWdaBuildManifest(keyDir) !== null;
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const plist = readWdaXctestrun(xctestrunPath);
@@ -71845,10 +71922,10 @@ function isRealDirectory(path) {
   }
 }
 function copyReusableWdaBuild(sourceKey, stagedKey) {
-  const sourceProducts = join35(sourceKey, "DerivedData", "Build", "Products");
-  if (!isRealDirectory(sourceKey) || !isRealDirectory(join35(sourceKey, "DerivedData")) || !isRealDirectory(join35(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+  const manifest = readCompleteWdaBuildManifest(sourceKey);
+  if (!manifest)
     return false;
-  }
+  const sourceProducts = manifest.products;
   const stagedProducts = join35(stagedKey, "DerivedData", "Build", "Products");
   mkdirSync17(dirname17(stagedProducts), { recursive: true });
   cpSync2(sourceProducts, stagedProducts, {
@@ -72678,7 +72755,7 @@ var init_device_existence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname18, isAbsolute as isAbsolute9, join as join37, resolve as resolve13 } from "node:path";
+import { dirname as dirname18, isAbsolute as isAbsolute10, join as join37, resolve as resolve13 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { createHash as createHash15 } from "node:crypto";
 function sameAndroidMetroReverse(current, next) {
@@ -72764,7 +72841,7 @@ function sessionSourceResolver(status, dependencies) {
   return (root) => resolveSourceIdentity(root, stored?.kind === "declared-root" ? { declaredRoot: stored.contentRoot, declaredManifests: stored.declaredManifests } : {});
 }
 function anchorDeclaredProjectRoot(status, projectRoot) {
-  if (isAbsolute9(projectRoot))
+  if (isAbsolute10(projectRoot))
     return projectRoot;
   const boundAppRoot = status.source?.appRoot;
   return typeof boundAppRoot === "string" && boundAppRoot.length > 0 ? resolve13(boundAppRoot, projectRoot) : projectRoot;
@@ -75781,11 +75858,11 @@ var init_events = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/recorder.js
 import { closeSync as closeSync10, constants as constants8, fstatSync as fstatSync7, openSync as openSync10, readSync as readSync4 } from "node:fs";
-import { isAbsolute as isAbsolute10 } from "node:path";
+import { isAbsolute as isAbsolute11 } from "node:path";
 function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute10(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+  return typeof p === "string" && isAbsolute11(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
 }
 function readShotBounded(p) {
   let fd;
@@ -75878,7 +75955,7 @@ var init_recorder = __esm({
        * whatever path the pipeline actually captured to.
        */
       registerCapturedScreenshot(p) {
-        if (typeof p !== "string" || !isAbsolute10(p))
+        if (typeof p !== "string" || !isAbsolute11(p))
           return;
         this.trustedShotPaths.delete(p);
         this.trustedShotPaths.add(p);
@@ -77538,7 +77615,7 @@ var init_atomic_writer = __esm({
 // packages/rn-dev-agent-core/dist/domain/unfollowed-file.js
 import { execFileSync as execFileSync15 } from "node:child_process";
 import { lstatSync as lstatSync14 } from "node:fs";
-import { isAbsolute as isAbsolute11, join as join39 } from "node:path";
+import { isAbsolute as isAbsolute12, join as join39 } from "node:path";
 function createUnfollowedFileSnapshot(directoryPath, directoryIdentity2) {
   return { directoryPath, directoryIdentity: directoryIdentity2, fileIdentities: /* @__PURE__ */ new Map() };
 }
@@ -77636,7 +77713,7 @@ function readUnfollowedFiles(directoryPath, identity2, relativePaths, expectedId
       throw new Error("Selected file identities did not match the requested paths.");
     }
     const entries = relativePaths.map((relativePath, index) => {
-      if (isAbsolute11(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
+      if (isAbsolute12(relativePath) || relativePath.split("/").some((component) => !component || component === "." || component === "..")) {
         throw new Error(`Invalid relative path: ${relativePath}.`);
       }
       if (expectedIdentities) {
@@ -77824,7 +77901,7 @@ try {
 
 // packages/rn-dev-agent-core/dist/domain/action-store.js
 import { existsSync as existsSync27, lstatSync as lstatSync15, readFileSync as readFileSync28, statSync as statSync14, unlinkSync as unlinkSync13 } from "node:fs";
-import { basename as basename8, dirname as dirname21, isAbsolute as isAbsolute12, join as join40, relative as relative8, resolve as resolve16, sep as sep8 } from "node:path";
+import { basename as basename8, dirname as dirname21, isAbsolute as isAbsolute13, join as join40, relative as relative8, resolve as resolve16, sep as sep8 } from "node:path";
 function actionPathFor(projectRoot, actionId) {
   assertValidActionId(actionId, "actionPathFor");
   const actionsDir = join40(projectRoot, ".rn-agent", "actions");
@@ -77889,11 +77966,11 @@ function ownedActionPathIdentityMatches(entries) {
   }
 }
 function referencedActionPath(parentFile, reference) {
-  if (isAbsolute12(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
+  if (isAbsolute13(reference) || reference.split(/[\\/]/).includes("..") || !/\.ya?ml$/i.test(reference)) {
     return null;
   }
   const child = join40(dirname21(parentFile), reference);
-  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child))
+  if (child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child))
     return null;
   return child;
 }
@@ -78128,7 +78205,7 @@ function captureActionFromContext(context, actionId) {
       flowRoot: snapshot.directory,
       readFileFn: (path) => {
         const child = relative8(snapshot.directory, path);
-        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute12(child)) {
+        if (child === "" || child === ".." || child.startsWith(`..${sep8}`) || isAbsolute13(child)) {
           throw new Error(`Refusing action flow outside ${snapshot.directory}.`);
         }
         const text2 = context.fileContents.get(child);
@@ -80463,7 +80540,7 @@ var init_maestro_device_authority = __esm({
 import { existsSync as existsSync29, readFileSync as readFileSync29, readdirSync as readdirSync11, realpathSync as realpathSync15, rmSync as rmSync11 } from "node:fs";
 import { createHash as createHash16 } from "node:crypto";
 import { tmpdir as tmpdir9 } from "node:os";
-import { isAbsolute as isAbsolute13, join as join43, sep as sep9 } from "node:path";
+import { isAbsolute as isAbsolute14, join as join43, sep as sep9 } from "node:path";
 function idsFrom(value, keys) {
   if (!value || typeof value !== "object")
     return [];
@@ -80602,7 +80679,7 @@ function readStructuredFlowArtifact(reportDir, previous) {
     if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
       return unfinalized;
     const normalizedDataFile = flow.dataFile;
-    if (isAbsolute13(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
       return unfinalized;
     }
     const realDataFile = realpathSync15(join43(reportDir, normalizedDataFile));
@@ -88608,7 +88685,7 @@ var init_startup_integrity = __esm({
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
 import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
-import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute14, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
+import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute15, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
   if (!unparsedArgs || typeof unparsedArgs !== "object" || Array.isArray(unparsedArgs)) {
@@ -88648,7 +88725,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let loadedCoreBundlePath = null;
   let coreBundleSha256 = null;
   try {
-    if (typeof argv[1] === "string" && isAbsolute14(argv[1])) {
+    if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
       executedEntrypointPath = realpathSync16(argv[1]);
     }
   } catch {
@@ -88685,7 +88762,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   const authorityArg = argv[1];
-  if (typeof authorityArg !== "string" || !isAbsolute14(authorityArg))
+  if (typeof authorityArg !== "string" || !isAbsolute15(authorityArg))
     return null;
   let arg;
   try {
@@ -88734,7 +88811,7 @@ function proofCandidateStartupMatches(entrypoint, startup, headCoreBundleSha256)
 }
 function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   const normalizedOverride = (value) => {
-    if (!value || !isAbsolute14(value))
+    if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
       return realpathSync16(value);
@@ -88873,11 +88950,11 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
   }
 }
 function isNormalizedDescendant(root, path) {
-  if (!isAbsolute14(root) || !isAbsolute14(path) || resolve18(root) !== root || resolve18(path) !== path) {
+  if (!isAbsolute15(root) || !isAbsolute15(path) || resolve18(root) !== root || resolve18(path) !== path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute14(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
   const parts = relative9(root, path).split(sep10);
@@ -88926,7 +89003,7 @@ function proofRootExists(args) {
   }
 }
 function resolveProofWorktreeRoot(detectedProjectRoot) {
-  if (!detectedProjectRoot || !isAbsolute14(detectedProjectRoot) || resolve18(detectedProjectRoot) !== detectedProjectRoot) {
+  if (!detectedProjectRoot || !isAbsolute15(detectedProjectRoot) || resolve18(detectedProjectRoot) !== detectedProjectRoot) {
     return null;
   }
   try {
@@ -88934,7 +89011,7 @@ function resolveProofWorktreeRoot(detectedProjectRoot) {
       cwd: detectedProjectRoot,
       encoding: "utf8"
     }).trim();
-    return root && isAbsolute14(root) && resolve18(root) === root ? root : null;
+    return root && isAbsolute15(root) && resolve18(root) === root ? root : null;
   } catch {
     return null;
   }
@@ -89261,7 +89338,7 @@ function createProofCaptureHandler(deps) {
     ].map((path) => repositoryPath(active, path));
     const requiredOutputs = new Set(phase === "finalized" ? [...proofOutputs, repositoryPath(active, active.context.receiptPath)] : proofOutputs);
     const allowedOutputs = phase === "setup" ? observedSetupScreenshots(active) : phase === "clean" ? /* @__PURE__ */ new Set() : requiredOutputs;
-    const invalidChange = git2.changes.some((change) => isAbsolute14(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
+    const invalidChange = git2.changes.some((change) => isAbsolute15(change.path) || change.path === ".." || change.path.startsWith("../") || change.indexStatus !== "?" || change.worktreeStatus !== "?" || change.sourcePath !== void 0);
     const changedPaths = new Set(git2.changes.map((change) => change.path.replaceAll("\\", "/")));
     const unrelated = [...changedPaths].some((path) => !allowedOutputs.has(path));
     const missing = (phase === "validation" || phase === "finalized") && [...requiredOutputs].some((path) => !changedPaths.has(path));
@@ -89876,7 +89953,7 @@ var init_proof_capture2 = __esm({
     init_proof_receipt();
     init_utils();
     init_startup_integrity();
-    absolutePathSchema = external_exports.string().min(1).refine(isAbsolute14, "path must be absolute");
+    absolutePathSchema = external_exports.string().min(1).refine(isAbsolute15, "path must be absolute");
     beginRehearsalSchema = external_exports.object({
       action: external_exports.literal("begin_rehearsal"),
       projectRoot: absolutePathSchema,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71304,8 +71304,9 @@ var init_maestro_runner_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
+import { spawnSync as spawnSync3 } from "node:child_process";
 import { createHash as createHash13 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
+import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename6, dirname as dirname17, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -71716,6 +71717,134 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
     throw new RunnerCacheUnavailableError("cache", cacheErrno(error2));
   }
 }
+function wdaToolchainFingerprint() {
+  if (memoizedWdaToolchainFingerprint !== void 0)
+    return memoizedWdaToolchainFingerprint;
+  try {
+    const probe = spawnSync3("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
+    const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
+    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+  } catch {
+    memoizedWdaToolchainFingerprint = null;
+  }
+  return memoizedWdaToolchainFingerprint;
+}
+function persistentWdaStoreBuildsRoot() {
+  const fingerprint = wdaToolchainFingerprint();
+  if (!fingerprint)
+    return null;
+  const versionsRoot = runnerCacheVersionsRoot();
+  const components = [
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+  ];
+  for (const component of components) {
+    try {
+      const stat2 = lstatSync12(component);
+      if (!stat2.isDirectory() || stat2.isSymbolicLink())
+        return null;
+    } catch {
+      break;
+    }
+  }
+  return components[2];
+}
+function isCompleteWdaBuild(keyDir) {
+  try {
+    const products = join35(keyDir, "DerivedData", "Build", "Products");
+    const entries = readdirSync8(products, { withFileTypes: true });
+    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
+      if (!name.endsWith(".app"))
+        return false;
+      try {
+        const executable = lstatSync12(join35(products, entry.name, name, name.slice(0, -".app".length)));
+        return executable.isFile() && !executable.isSymbolicLink();
+      } catch {
+        return false;
+      }
+    }));
+  } catch {
+    return false;
+  }
+}
+function copyWdaBuildKey(sourceKey, stagedKey) {
+  cpSync2(sourceKey, stagedKey, {
+    recursive: true,
+    mode: constants7.COPYFILE_FICLONE,
+    verbatimSymlinks: true
+  });
+  return isCompleteWdaBuild(stagedKey);
+}
+function seedRunnerSnapshotCacheFromStore(cacheRoot) {
+  let seeded = 0;
+  try {
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    const target = join35(cacheRoot, "wda-builds");
+    for (const entry of readdirSync8(storeBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory())
+        continue;
+      const sourceKey = join35(storeBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      mkdirSync17(target, { recursive: true });
+      const stagedKey = join35(target, `.seed-${entry.name}`);
+      try {
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          renameSync7(stagedKey, join35(target, entry.name));
+          seeded += 1;
+        } else {
+          rmSync10(stagedKey, { recursive: true, force: true });
+        }
+      } catch {
+        try {
+          rmSync10(stagedKey, { recursive: true, force: true });
+        } catch {
+        }
+      }
+    }
+  } catch {
+  }
+  return seeded;
+}
+function publishRunnerSnapshotCacheToStore(cacheRoot) {
+  let published = 0;
+  try {
+    const spawnBuilds = join35(cacheRoot, "wda-builds");
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds)
+      return 0;
+    for (const entry of readdirSync8(spawnBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith("."))
+        continue;
+      const sourceKey = join35(spawnBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey))
+        continue;
+      const storeKey = join35(storeBuilds, entry.name);
+      if (isCompleteWdaBuild(storeKey))
+        continue;
+      mkdirSync17(storeBuilds, { recursive: true, mode: 448 });
+      const stage = mkdtempSync2(join35(storeBuilds, ".stage-"));
+      try {
+        const stagedKey = join35(stage, entry.name);
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          if (existsSync24(storeKey)) {
+            const evicted = join35(stage, "evicted");
+            renameSync7(storeKey, evicted);
+          }
+          renameSync7(stagedKey, storeKey);
+          published += 1;
+        }
+      } finally {
+        rmSync10(stage, { recursive: true, force: true });
+      }
+    }
+  } catch {
+  }
+  return published;
+}
 function provisionRunnerSnapshotCache(snapshotRoot, testHooks = {}, setOwnedCacheRoot = () => {
 }) {
   const cacheRoot = expectedRunnerCacheRoot(snapshotRoot);
@@ -71836,8 +71965,12 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
       }
     }
     chmodSync5(snapshotRoot, 320);
-    if (cacheRoot)
+    if (cacheRoot) {
       assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+      recordRunnerDiagnostic("cache-seed", {
+        seededBuilds: seedRunnerSnapshotCacheFromStore(cacheRoot)
+      });
+    }
     const openedRunner = lstatSync12(snapshotRunner);
     recordRunnerDiagnostic("runner-exec-begin", { runnerPinVersion: MAESTRO_RUNNER_PIN.version });
     if (platform === "ios") {
@@ -71863,6 +71996,11 @@ async function withImmediatePinnedRunner(runnerPath, resolveStatus, execute2, pl
           chmodSync5(entryPath, 384);
       }
     } catch {
+    }
+    if (cacheRoot) {
+      recordRunnerDiagnostic("cache-publish", {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot)
+      });
     }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
@@ -71954,7 +72092,7 @@ function getEngineStatus(resolvers) {
     return Promise.resolve(testStatus);
   return detect(resolvers ?? {}).catch(() => buildReplayEngineStatus("unknown-version", null, false));
 }
-var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testStatus, testAttestation;
+var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, memoizedWdaToolchainFingerprint, testStatus, testAttestation;
 var init_engine_pin = __esm({
   "packages/rn-dev-agent-core/dist/domain/engine-pin.js"() {
     "use strict";
@@ -76825,7 +76963,7 @@ var init_macro_asserts = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
-import { writeFileSync as writeFileSync12, renameSync as renameSync7, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
+import { writeFileSync as writeFileSync12, renameSync as renameSync8, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
 import { dirname as dirname20, basename as basename7 } from "node:path";
 function generateTmpStamp() {
   const rand = Math.random().toString(36).slice(2, 10);
@@ -77134,7 +77272,7 @@ var init_atomic_writer = __esm({
       },
       /** Underlying `fs.renameSync(from, to)`. */
       _rename(from, to) {
-        renameSync7(from, to);
+        renameSync8(from, to);
       },
       /** Underlying `fs.statSync(path).mtimeMs`. */
       _statMtimeMs(path) {
@@ -84369,7 +84507,7 @@ var init_interact = __esm({
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash18, randomBytes as randomBytes8, randomUUID as randomUUID11 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync8, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname24, join as join45 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -84710,7 +84848,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   }
   const temporary = join45(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
   writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
-  renameSync8(temporary, outputPath);
+  renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
@@ -85052,7 +85190,7 @@ var init_evidence = __esm({
             flag: "wx",
             mode: 384
           });
-          renameSync8(temp, this.path);
+          renameSync9(temp, this.path);
           chmodSync7(this.path, 384);
         } catch (error2) {
           try {
@@ -88350,7 +88488,7 @@ var init_startup_integrity = __esm({
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16 } from "node:fs";
 import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute14, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
@@ -88819,7 +88957,7 @@ function writeProofReceiptAtomic(path, receipt2) {
     fsyncSync(descriptor);
     closeSync12(descriptor);
     descriptor = null;
-    renameSync9(temporary, path);
+    renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -94380,7 +94518,7 @@ var init_target = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname32, join as join57 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash23 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join57(projectRoot, ".rn-agent", "e2e");
@@ -94431,7 +94569,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
   };
   const tmp = `${filePath}.tmp`;
   writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
+  renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
@@ -94663,7 +94801,7 @@ var init_lock_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -94723,7 +94861,7 @@ function writeJsonAtomic(file, value) {
   mkdirSync23(join59(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync11(tmp, file);
+  renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
   const file = join59(e2eRunsDirFor(projectRoot), "index.json");
@@ -94776,7 +94914,7 @@ var init_e2e_run = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join60 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 function requestsDir(projectRoot) {
   return join60(e2eRunsDirFor(projectRoot), "requests");
 }
@@ -94789,7 +94927,7 @@ function writeRequest(projectRoot, req) {
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync12(tmp, file);
+  renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71729,15 +71729,16 @@ function wdaToolchainFingerprint() {
   }
   return memoizedWdaToolchainFingerprint;
 }
-function persistentWdaStoreBuildsRoot() {
+function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
-  if (!fingerprint)
+  if (!fingerprint || !pinArchiveCoords(platformKey))
     return null;
   const versionsRoot = runnerCacheVersionsRoot();
   const components = [
     join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
-    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
-    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, "wda-builds")
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint),
+    join35(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint, "wda-builds")
   ];
   for (const component of components) {
     try {
@@ -71748,7 +71749,7 @@ function persistentWdaStoreBuildsRoot() {
       break;
     }
   }
-  return components[2];
+  return components[3];
 }
 function isCompleteWdaBuild(keyDir) {
   try {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71750,11 +71750,146 @@ function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   }
   return components[3];
 }
+function parseAndNormalizeWdaXctestrun(source) {
+  let cursor = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(source[cursor] ?? ""))
+      cursor += 1;
+  };
+  const consume = (token2) => {
+    if (!source.startsWith(token2, cursor))
+      return false;
+    cursor += token2.length;
+    return true;
+  };
+  const consumePattern = (pattern) => {
+    const match = pattern.exec(source.slice(cursor));
+    if (!match || match.index !== 0)
+      return false;
+    cursor += match[0].length;
+    return true;
+  };
+  const parseTextElement = (tag) => {
+    if (consume(`<${tag}/>`))
+      return "";
+    if (!consume(`<${tag}>`))
+      return null;
+    const close = `</${tag}>`;
+    const end = source.indexOf(close, cursor);
+    if (end < 0)
+      return null;
+    const text = source.slice(cursor, end);
+    if (text.includes("<") || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
+      return null;
+    }
+    cursor = end + close.length;
+    return text;
+  };
+  const validScalar = (tag, value) => {
+    if (tag === "string")
+      return true;
+    if (tag === "integer")
+      return /^[+-]?\d+$/.test(value);
+    if (tag === "real") {
+      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
+    }
+    if (tag === "date")
+      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
+    const compact = value.replace(/\s/g, "");
+    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
+  };
+  const parseValue = () => {
+    skipWhitespace();
+    const start = cursor;
+    if (consume("<dict/>"))
+      return { kind: "dict", start, end: cursor, entries: [] };
+    if (consume("<dict>")) {
+      const entries = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</dict>"))
+          return { kind: "dict", start, end: cursor, entries };
+        const entryStart = cursor;
+        const key = parseTextElement("key");
+        if (key === null)
+          return null;
+        const value = parseValue();
+        if (!value)
+          return null;
+        entries.push({ key, start: entryStart, end: value.end, value });
+      }
+    }
+    if (consume("<array/>"))
+      return { kind: "array", start, end: cursor, values: [] };
+    if (consume("<array>")) {
+      const values = [];
+      while (true) {
+        skipWhitespace();
+        if (consume("</array>"))
+          return { kind: "array", start, end: cursor, values };
+        const value = parseValue();
+        if (!value)
+          return null;
+        values.push(value);
+      }
+    }
+    if (consume("<true/>") || consume("<false/>"))
+      return { kind: "scalar", start, end: cursor };
+    for (const tag of ["string", "integer", "real", "date", "data"]) {
+      const before = cursor;
+      const value = parseTextElement(tag);
+      if (value !== null) {
+        return validScalar(tag, value) ? { kind: "scalar", start, end: cursor } : null;
+      }
+      cursor = before;
+    }
+    return null;
+  };
+  skipWhitespace();
+  if (source.startsWith("<?xml", cursor) && !consumePattern(/^<\?xml[^?]*\?>/))
+    return null;
+  skipWhitespace();
+  if (source.startsWith("<!DOCTYPE", cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/))
+    return null;
+  skipWhitespace();
+  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/))
+    return null;
+  const root = parseValue();
+  if (!root || root.kind !== "dict")
+    return null;
+  skipWhitespace();
+  if (!consume("</plist>"))
+    return null;
+  skipWhitespace();
+  if (cursor !== source.length)
+    return null;
+  const portEntries = [];
+  const collectPortEntries = (value) => {
+    if (value.kind === "dict") {
+      for (const entry of value.entries) {
+        if (entry.key === "USE_PORT")
+          portEntries.push(entry);
+        else
+          collectPortEntries(entry.value);
+      }
+    } else if (value.kind === "array") {
+      for (const child of value.values)
+        collectPortEntries(child);
+    }
+  };
+  collectPortEntries(root);
+  let normalized = source;
+  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
+    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
+  }
+  return normalized;
+}
 function isCompleteWdaBuild(keyDir) {
   try {
     const products = join35(keyDir, "DerivedData", "Build", "Products");
     const entries = readdirSync8(products, { withFileTypes: true });
-    return entries.some((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
+    const xctestruns = entries.filter((entry) => entry.name.endsWith(".xctestrun"));
+    return xctestruns.length > 0 && xctestruns.every((entry) => entry.isFile() && parseAndNormalizeWdaXctestrun(readFileSync25(join35(products, entry.name), "utf8")) !== null) && entries.some((entry) => entry.isDirectory() && readdirSync8(join35(products, entry.name)).some((name) => {
       if (!name.endsWith(".app"))
         return false;
       try {
@@ -71770,8 +71905,8 @@ function isCompleteWdaBuild(keyDir) {
 }
 function removeInjectedWdaPort(xctestrunPath) {
   const source = readFileSync25(xctestrunPath, "utf8");
-  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
-  if (normalized.includes("USE_PORT"))
+  const normalized = parseAndNormalizeWdaXctestrun(source);
+  if (normalized === null)
     return false;
   if (normalized !== source)
     writeFileSync12(xctestrunPath, normalized);
@@ -71826,7 +71961,12 @@ function isReusableStoredWdaBuild(keyDir) {
       return false;
     }
     const products = join35(keyDir, "DerivedData", "Build", "Products");
-    return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync25(join35(products, entry.name), "utf8").includes("USE_PORT"));
+    return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.name.endsWith(".xctestrun")).every((entry) => {
+      if (!entry.isFile())
+        return false;
+      const source = readFileSync25(join35(products, entry.name), "utf8");
+      return parseAndNormalizeWdaXctestrun(source) === source;
+    });
   } catch {
     return false;
   }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71306,7 +71306,7 @@ var init_maestro_runner_pin = __esm({
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
 import { spawnSync as spawnSync3 } from "node:child_process";
 import { createHash as createHash13 } from "node:crypto";
-import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11 } from "node:fs";
+import { accessSync, chmodSync as chmodSync5, constants as constants7, copyFileSync as copyFileSync2, cpSync as cpSync2, existsSync as existsSync24, lstatSync as lstatSync12, mkdirSync as mkdirSync17, mkdtempSync as mkdtempSync2, readFileSync as readFileSync25, readdirSync as readdirSync8, readlinkSync as readlinkSync5, realpathSync as realpathSync13, renameSync as renameSync7, rmSync as rmSync10, symlinkSync as symlinkSync3, unlinkSync as unlinkSync11, writeFileSync as writeFileSync12 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { basename as basename6, dirname as dirname17, join as join35, relative as relative7, resolve as resolve12, sep as sep6 } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -71768,13 +71768,68 @@ function isCompleteWdaBuild(keyDir) {
     return false;
   }
 }
-function copyWdaBuildKey(sourceKey, stagedKey) {
-  cpSync2(sourceKey, stagedKey, {
+function removeInjectedWdaPort(xctestrunPath) {
+  const source = readFileSync25(xctestrunPath, "utf8");
+  const normalized = source.replace(/[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g, "");
+  if (normalized.includes("USE_PORT"))
+    return false;
+  if (normalized !== source)
+    writeFileSync12(xctestrunPath, normalized);
+  return true;
+}
+function isRealDirectory(path) {
+  try {
+    const stat2 = lstatSync12(path);
+    return stat2.isDirectory() && !stat2.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function copyReusableWdaBuild(sourceKey, stagedKey) {
+  const sourceProducts = join35(sourceKey, "DerivedData", "Build", "Products");
+  if (!isRealDirectory(sourceKey) || !isRealDirectory(join35(sourceKey, "DerivedData")) || !isRealDirectory(join35(sourceKey, "DerivedData", "Build")) || !isRealDirectory(sourceProducts)) {
+    return false;
+  }
+  const stagedProducts = join35(stagedKey, "DerivedData", "Build", "Products");
+  mkdirSync17(dirname17(stagedProducts), { recursive: true });
+  cpSync2(sourceProducts, stagedProducts, {
     recursive: true,
     mode: constants7.COPYFILE_FICLONE,
     verbatimSymlinks: true
   });
+  for (const entry of readdirSync8(stagedProducts, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".xctestrun") && !removeInjectedWdaPort(join35(stagedProducts, entry.name))) {
+      return false;
+    }
+  }
   return isCompleteWdaBuild(stagedKey);
+}
+function isReusableStoredWdaBuild(keyDir) {
+  try {
+    if (!isCompleteWdaBuild(keyDir))
+      return false;
+    const keyEntries = readdirSync8(keyDir, { withFileTypes: true });
+    const derivedData = keyEntries[0];
+    if (keyEntries.length !== 1 || derivedData?.name !== "DerivedData" || !derivedData.isDirectory()) {
+      return false;
+    }
+    const derivedDataEntries = readdirSync8(join35(keyDir, "DerivedData"), { withFileTypes: true });
+    const build = derivedDataEntries[0];
+    if (derivedDataEntries.length !== 1 || build?.name !== "Build" || !build.isDirectory()) {
+      return false;
+    }
+    const buildEntries = readdirSync8(join35(keyDir, "DerivedData", "Build"), {
+      withFileTypes: true
+    });
+    const productsEntry = buildEntries[0];
+    if (buildEntries.length !== 1 || productsEntry?.name !== "Products" || !productsEntry.isDirectory()) {
+      return false;
+    }
+    const products = join35(keyDir, "DerivedData", "Build", "Products");
+    return readdirSync8(products, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".xctestrun")).every((entry) => !readFileSync25(join35(products, entry.name), "utf8").includes("USE_PORT"));
+  } catch {
+    return false;
+  }
 }
 function seedRunnerSnapshotCacheFromStore(cacheRoot) {
   let seeded = 0;
@@ -71792,7 +71847,7 @@ function seedRunnerSnapshotCacheFromStore(cacheRoot) {
       mkdirSync17(target, { recursive: true });
       const stagedKey = join35(target, `.seed-${entry.name}`);
       try {
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           renameSync7(stagedKey, join35(target, entry.name));
           seeded += 1;
         } else {
@@ -71823,13 +71878,13 @@ function publishRunnerSnapshotCacheToStore(cacheRoot) {
       if (!isCompleteWdaBuild(sourceKey))
         continue;
       const storeKey = join35(storeBuilds, entry.name);
-      if (isCompleteWdaBuild(storeKey))
+      if (isReusableStoredWdaBuild(storeKey))
         continue;
       mkdirSync17(storeBuilds, { recursive: true, mode: 448 });
       const stage = mkdtempSync2(join35(storeBuilds, ".stage-"));
       try {
         const stagedKey = join35(stage, entry.name);
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           if (existsSync24(storeKey)) {
             const evicted = join35(stage, "evicted");
             renameSync7(storeKey, evicted);
@@ -76963,7 +77018,7 @@ var init_macro_asserts = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/atomic-writer.js
-import { writeFileSync as writeFileSync12, renameSync as renameSync8, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
+import { writeFileSync as writeFileSync13, renameSync as renameSync8, statSync as statSync13, mkdirSync as mkdirSync19, existsSync as existsSync26, unlinkSync as unlinkSync12, readdirSync as readdirSync9, openSync as openSync11, closeSync as closeSync11, chmodSync as chmodSync6, fstatSync as fstatSync8, lstatSync as lstatSync13, readFileSync as readFileSync27, linkSync as linkSync2, constants as constants9 } from "node:fs";
 import { dirname as dirname20, basename as basename7 } from "node:path";
 function generateTmpStamp() {
   const rand = Math.random().toString(36).slice(2, 10);
@@ -77006,7 +77061,7 @@ function withPairWriteLock(yamlPath, operation, acquisitionPrecondition) {
   const ownerPath = `${dirname20(yamlPath)}/.rn-action-write-owner.${generateTmpStamp()}`;
   const owner = currentLockOwner();
   const lockFd = openSync11(ownerPath, "wx", 384);
-  writeFileSync12(lockFd, `${JSON.stringify(owner)}
+  writeFileSync13(lockFd, `${JSON.stringify(owner)}
 `, "utf8");
   const deadline = Date.now() + ACTION_WRITE_LOCK_TIMEOUT_MS;
   let acquired = false;
@@ -77260,12 +77315,12 @@ var init_atomic_writer = __esm({
     atomicWriter = {
       /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
       _writeFile(path, content) {
-        writeFileSync12(path, content, "utf8");
+        writeFileSync13(path, content, "utf8");
       },
       _writeFileWithMode(path, content, mode) {
         const fd = openSync11(path, "wx", mode);
         try {
-          writeFileSync12(fd, content, "utf8");
+          writeFileSync13(fd, content, "utf8");
         } finally {
           closeSync11(fd);
         }
@@ -81634,7 +81689,7 @@ var init_cdp_replay_dispatch = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { existsSync as existsSync30, readFileSync as readFileSync30, writeFileSync as writeFileSync13 } from "node:fs";
+import { existsSync as existsSync30, readFileSync as readFileSync30, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
 import { basename as basename10, join as join44, dirname as dirname23 } from "node:path";
 import { randomUUID as randomUUID9 } from "node:crypto";
@@ -82000,7 +82055,7 @@ function createMaestroRunHandler(deps = {}) {
           proofDomain: reactOnlyProof ? "react-tree" : "partitioned"
         });
       }
-      writeFileSync13(flowFile, validatedContent, "utf-8");
+      writeFileSync14(flowFile, validatedContent, "utf-8");
       if (isLoginMetadata(semanticActionMeta) && !loginPostconditionId(validatedCommands)) {
         return failResult("Refusing login replay without a final positive post-submit testID assertion. End the flow with assertVisible.id or extendedWaitUntil.visible.id.", "ASSERTION_FAILED", { proofDomain: "react-tree", postcondition: "missing" });
       }
@@ -82234,7 +82289,7 @@ function createMaestroRunHandler(deps = {}) {
         clearTimeout(deadlineTimer);
       }
     }
-    writeFileSync13(flowFile, validatedContent, "utf-8");
+    writeFileSync14(flowFile, validatedContent, "utf-8");
     const dispatch = selectDispatch({ platform, flowHasHideKeyboard });
     if ("error" in dispatch) {
       return failResult(dispatch.error);
@@ -82422,7 +82477,7 @@ function createMaestroRunHandler(deps = {}) {
         };
         try {
           const stageResult = await (async () => {
-            writeFileSync13(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+            writeFileSync14(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
             const executeOnce = async (beforeDispatch) => {
               if (flowDeadline - now() <= 0) {
                 const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -82831,7 +82886,7 @@ function createMaestroRunHandler(deps = {}) {
     } finally {
       clearTimeout(flowAbortTimer);
       try {
-        writeFileSync13(flowFile, validatedContent, "utf-8");
+        writeFileSync14(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -84507,7 +84562,7 @@ var init_interact = __esm({
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
 import { createHash as createHash18, randomBytes as randomBytes8, randomUUID as randomUUID11 } from "node:crypto";
-import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
+import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync15 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname24, join as join45 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -84813,7 +84868,7 @@ function readOrCreateRunnerDiagnosticsSalt(directory) {
   }
   const salt = randomBytes8(32);
   try {
-    writeFileSync14(path, salt, { flag: "wx", mode: 384 });
+    writeFileSync15(path, salt, { flag: "wx", mode: 384 });
     return salt;
   } catch {
     const raced = readFileSync31(path);
@@ -84847,7 +84902,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
   const temporary = join45(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
-  writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
+  writeFileSync15(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
@@ -84948,7 +85003,7 @@ function exportLatestRunnerDiagnosticsBundle(outputPath, sessionId, directory = 
   const source = latestRunnerDiagnosticsPath(sessionId, directory);
   if (!source)
     throw new Error("No runner diagnostics bundle is available for the exact session.");
-  writeFileSync14(outputPath, readFileSync31(source), { flag: "wx", mode: 384 });
+  writeFileSync15(outputPath, readFileSync31(source), { flag: "wx", mode: 384 });
   chmodSync7(outputPath, 384);
   return outputPath;
 }
@@ -85184,7 +85239,7 @@ var init_evidence = __esm({
             redactionVersion: REDACTION_RULES_VERSION
           });
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-          writeFileSync14(temp, contents.length > 0 ? `${contents}
+          writeFileSync15(temp, contents.length > 0 ? `${contents}
 ` : "", {
             encoding: "utf8",
             flag: "wx",
@@ -86904,7 +86959,7 @@ var init_managed_automation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
-import { writeFileSync as writeFileSync15 } from "node:fs";
+import { writeFileSync as writeFileSync16 } from "node:fs";
 import { join as join46 } from "node:path";
 import { tmpdir as tmpdir11 } from "node:os";
 function yamlEscape(s) {
@@ -86975,7 +87030,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync15(flowFile, content, "utf-8");
+    writeFileSync16(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -88488,7 +88543,7 @@ var init_startup_integrity = __esm({
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync16 } from "node:fs";
+import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
 import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute14, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
@@ -88952,7 +89007,7 @@ function writeProofReceiptAtomic(path, receipt2) {
   let descriptor = null;
   try {
     descriptor = openSync12(temporary, "wx", 384);
-    writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync17(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync12(descriptor);
@@ -92251,7 +92306,7 @@ var init_maestro_generate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-test-all.js
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
 import { basename as basename13, dirname as dirname30, join as join52, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function readNestedFlowEnvelope(result) {
@@ -92501,7 +92556,7 @@ function createMaestroTestAllHandler(deps = {}) {
         continue;
       }
       const safeFlowFile = join52(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
+      writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -92524,7 +92579,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync18(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -94518,7 +94573,7 @@ var init_target = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname32, join as join57 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash23 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join57(projectRoot, ".rn-agent", "e2e");
@@ -94568,7 +94623,7 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
+  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
   renameSync11(tmp, filePath);
   return { ...meta, filePath };
 }
@@ -94801,7 +94856,7 @@ var init_lock_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join59 } from "node:path";
-import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync19, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -94860,7 +94915,7 @@ function e2eRunsDirFor(projectRoot) {
 function writeJsonAtomic(file, value) {
   mkdirSync23(join59(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync19(tmp, JSON.stringify(value, null, 2), "utf8");
+  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
@@ -94914,7 +94969,7 @@ var init_e2e_run = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join60 } from "node:path";
-import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync20, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
+import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 function requestsDir(projectRoot) {
   return join60(e2eRunsDirFor(projectRoot), "requests");
 }
@@ -94926,7 +94981,7 @@ function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
   mkdirSync24(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(req, null, 2), "utf8");
+  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
   renameSync13(tmp, file);
 }
 function loadRequest(projectRoot, runId) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -71718,16 +71718,15 @@ function assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot) {
   }
 }
 function wdaToolchainFingerprint() {
-  if (memoizedWdaToolchainFingerprint !== void 0)
-    return memoizedWdaToolchainFingerprint;
+  if (testWdaToolchainFingerprint !== void 0)
+    return testWdaToolchainFingerprint;
   try {
     const probe = spawnSync3("xcodebuild", ["-version"], { encoding: "utf8", timeout: 15e3 });
     const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? "");
-    memoizedWdaToolchainFingerprint = probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
+    return probe.status === 0 && match && /^[\w.]+$/.test(match[1]) && /^[\w.]+$/.test(match[2]) ? `xcode-${match[1]}-${match[2]}` : null;
   } catch {
-    memoizedWdaToolchainFingerprint = null;
+    return null;
   }
-  return memoizedWdaToolchainFingerprint;
 }
 function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()) {
   const fingerprint = wdaToolchainFingerprint();
@@ -71760,7 +71759,7 @@ function isCompleteWdaBuild(keyDir) {
         return false;
       try {
         const executable = lstatSync12(join35(products, entry.name, name, name.slice(0, -".app".length)));
-        return executable.isFile() && !executable.isSymbolicLink();
+        return executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 73) !== 0;
       } catch {
         return false;
       }
@@ -72093,7 +72092,7 @@ function getEngineStatus(resolvers) {
     return Promise.resolve(testStatus);
   return detect(resolvers ?? {}).catch(() => buildReplayEngineStatus("unknown-version", null, false));
 }
-var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, memoizedWdaToolchainFingerprint, testStatus, testAttestation;
+var MAESTRO_RUNNER_PIN, TRUSTED_DRIFT_SHA256, ACTION_ENGINE_PIN, ACTION_ENGINE_PIN_RE, HOST_PLUGIN_ROOT, PINNED_RUNNER_INSTALL_HINT, PINNED_RUNNER_DIAGNOSE_HINT, MAESTRO_RUNNER_MIN_ANDROID_API, PRE_O_REMEDY, OLDER_SDK_TOKEN, INSTALL_REJECT_CONTEXT, REGEX_METACHARACTERS, TEXT_SELECTOR_KEYS, RELATIVE_SELECTOR_KEYS, RunnerCacheUnavailableError, testWdaToolchainFingerprint, testStatus, testAttestation;
 var init_engine_pin = __esm({
   "packages/rn-dev-agent-core/dist/domain/engine-pin.js"() {
     "use strict";

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -716,27 +716,27 @@ export function assertRunnerSnapshotCacheBinding(snapshotRoot: string, cacheRoot
   }
 }
 
-let memoizedWdaToolchainFingerprint: string | null | undefined;
+let testWdaToolchainFingerprint: string | null | undefined;
 
 export function _setWdaToolchainFingerprintForTest(fingerprint: string | null | undefined): void {
-  memoizedWdaToolchainFingerprint = fingerprint;
+  testWdaToolchainFingerprint = fingerprint;
 }
 
 // Xcode/SDK identity fences the persistent store: a toolchain change lands in a
 // fresh store slot and cold-builds instead of reusing artifacts of unknown drift.
+// Probed on every call, never memoized: an xcode-select switch or in-place
+// Xcode update must change the store key for the very next spawn.
 function wdaToolchainFingerprint(): string | null {
-  if (memoizedWdaToolchainFingerprint !== undefined) return memoizedWdaToolchainFingerprint;
+  if (testWdaToolchainFingerprint !== undefined) return testWdaToolchainFingerprint;
   try {
     const probe = spawnSync('xcodebuild', ['-version'], { encoding: 'utf8', timeout: 15_000 });
     const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? '');
-    memoizedWdaToolchainFingerprint =
-      probe.status === 0 && match && /^[\w.]+$/.test(match[1]!) && /^[\w.]+$/.test(match[2]!)
-        ? `xcode-${match[1]}-${match[2]}`
-        : null;
+    return probe.status === 0 && match && /^[\w.]+$/.test(match[1]!) && /^[\w.]+$/.test(match[2]!)
+      ? `xcode-${match[1]}-${match[2]}`
+      : null;
   } catch {
-    memoizedWdaToolchainFingerprint = null;
+    return null;
   }
-  return memoizedWdaToolchainFingerprint;
 }
 
 export function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()): string | null {
@@ -786,7 +786,11 @@ export function isCompleteWdaBuild(keyDir: string): boolean {
               const executable = lstatSync(
                 join(products, entry.name, name, name.slice(0, -'.app'.length)),
               );
-              return executable.isFile() && !executable.isSymbolicLink();
+              return (
+                executable.isFile() &&
+                !executable.isSymbolicLink() &&
+                (executable.mode & 0o111) !== 0
+              );
             } catch {
               return false;
             }

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -26,6 +26,7 @@ import {
   rmSync,
   symlinkSync,
   unlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
@@ -802,13 +803,90 @@ export function isCompleteWdaBuild(keyDir: string): boolean {
   }
 }
 
-function copyWdaBuildKey(sourceKey: string, stagedKey: string): boolean {
-  cpSync(sourceKey, stagedKey, {
+function removeInjectedWdaPort(xctestrunPath: string): boolean {
+  const source = readFileSync(xctestrunPath, 'utf8');
+  const normalized = source.replace(
+    /[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g,
+    '',
+  );
+  if (normalized.includes('USE_PORT')) return false;
+  if (normalized !== source) writeFileSync(xctestrunPath, normalized);
+  return true;
+}
+
+function isRealDirectory(path: string): boolean {
+  try {
+    const stat = lstatSync(path);
+    return stat.isDirectory() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function copyReusableWdaBuild(sourceKey: string, stagedKey: string): boolean {
+  const sourceProducts = join(sourceKey, 'DerivedData', 'Build', 'Products');
+  if (
+    !isRealDirectory(sourceKey) ||
+    !isRealDirectory(join(sourceKey, 'DerivedData')) ||
+    !isRealDirectory(join(sourceKey, 'DerivedData', 'Build')) ||
+    !isRealDirectory(sourceProducts)
+  ) {
+    return false;
+  }
+  const stagedProducts = join(stagedKey, 'DerivedData', 'Build', 'Products');
+  mkdirSync(dirname(stagedProducts), { recursive: true });
+  cpSync(sourceProducts, stagedProducts, {
     recursive: true,
     mode: constants.COPYFILE_FICLONE,
     verbatimSymlinks: true,
   });
+  for (const entry of readdirSync(stagedProducts, { withFileTypes: true })) {
+    if (
+      entry.isFile() &&
+      entry.name.endsWith('.xctestrun') &&
+      !removeInjectedWdaPort(join(stagedProducts, entry.name))
+    ) {
+      return false;
+    }
+  }
   return isCompleteWdaBuild(stagedKey);
+}
+
+function isReusableStoredWdaBuild(keyDir: string): boolean {
+  try {
+    if (!isCompleteWdaBuild(keyDir)) return false;
+    const keyEntries = readdirSync(keyDir, { withFileTypes: true });
+    const derivedData = keyEntries[0];
+    if (
+      keyEntries.length !== 1 ||
+      derivedData?.name !== 'DerivedData' ||
+      !derivedData.isDirectory()
+    ) {
+      return false;
+    }
+    const derivedDataEntries = readdirSync(join(keyDir, 'DerivedData'), { withFileTypes: true });
+    const build = derivedDataEntries[0];
+    if (derivedDataEntries.length !== 1 || build?.name !== 'Build' || !build.isDirectory()) {
+      return false;
+    }
+    const buildEntries = readdirSync(join(keyDir, 'DerivedData', 'Build'), {
+      withFileTypes: true,
+    });
+    const productsEntry = buildEntries[0];
+    if (
+      buildEntries.length !== 1 ||
+      productsEntry?.name !== 'Products' ||
+      !productsEntry.isDirectory()
+    ) {
+      return false;
+    }
+    const products = join(keyDir, 'DerivedData', 'Build', 'Products');
+    return readdirSync(products, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.xctestrun'))
+      .every((entry) => !readFileSync(join(products, entry.name), 'utf8').includes('USE_PORT'));
+  } catch {
+    return false;
+  }
 }
 
 function seedRunnerSnapshotCacheFromStore(cacheRoot: string): number {
@@ -824,7 +902,7 @@ function seedRunnerSnapshotCacheFromStore(cacheRoot: string): number {
       mkdirSync(target, { recursive: true });
       const stagedKey = join(target, `.seed-${entry.name}`);
       try {
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           renameSync(stagedKey, join(target, entry.name));
           seeded += 1;
         } else {
@@ -851,12 +929,12 @@ function publishRunnerSnapshotCacheToStore(cacheRoot: string): number {
       const sourceKey = join(spawnBuilds, entry.name);
       if (!isCompleteWdaBuild(sourceKey)) continue;
       const storeKey = join(storeBuilds, entry.name);
-      if (isCompleteWdaBuild(storeKey)) continue;
+      if (isReusableStoredWdaBuild(storeKey)) continue;
       mkdirSync(storeBuilds, { recursive: true, mode: 0o700 });
       const stage = mkdtempSync(join(storeBuilds, '.stage-'));
       try {
         const stagedKey = join(stage, entry.name);
-        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+        if (copyReusableWdaBuild(sourceKey, stagedKey)) {
           if (existsSync(storeKey)) {
             // Atomic evict: readers never observe a half-deleted key path.
             const evicted = join(stage, 'evicted');

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -1044,6 +1044,11 @@ export async function withImmediatePinnedRunner<T>(
       '--',
     ]);
   } finally {
+    if (cacheRoot) {
+      recordRunnerDiagnostic('cache-publish', {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot),
+      });
+    }
     try {
       chmodSync(snapshotRoot, 0o700);
       for (const entry of readdirSync(snapshotRoot, { recursive: true, withFileTypes: true })) {
@@ -1053,11 +1058,6 @@ export async function withImmediatePinnedRunner<T>(
         else if (entry.isFile()) chmodSync(entryPath, 0o600);
       }
     } catch {}
-    if (cacheRoot) {
-      recordRunnerDiagnostic('cache-publish', {
-        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot),
-      });
-    }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
 }

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -769,6 +769,144 @@ export function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()): s
   return components[3]!;
 }
 
+interface WdaPlistEntry {
+  readonly key: string;
+  readonly start: number;
+  readonly end: number;
+  readonly value: WdaPlistValue;
+}
+
+type WdaPlistValue =
+  | Readonly<{
+      kind: 'dict';
+      start: number;
+      end: number;
+      entries: ReadonlyArray<WdaPlistEntry>;
+    }>
+  | Readonly<{
+      kind: 'array';
+      start: number;
+      end: number;
+      values: ReadonlyArray<WdaPlistValue>;
+    }>
+  | Readonly<{ kind: 'scalar'; start: number; end: number }>;
+
+function parseAndNormalizeWdaXctestrun(source: string): string | null {
+  let cursor = 0;
+  const skipWhitespace = (): void => {
+    while (/\s/.test(source[cursor] ?? '')) cursor += 1;
+  };
+  const consume = (token: string): boolean => {
+    if (!source.startsWith(token, cursor)) return false;
+    cursor += token.length;
+    return true;
+  };
+  const consumePattern = (pattern: RegExp): boolean => {
+    const match = pattern.exec(source.slice(cursor));
+    if (!match || match.index !== 0) return false;
+    cursor += match[0].length;
+    return true;
+  };
+  const parseTextElement = (
+    tag: 'key' | 'string' | 'integer' | 'real' | 'date' | 'data',
+  ): string | null => {
+    if (consume(`<${tag}/>`)) return '';
+    if (!consume(`<${tag}>`)) return null;
+    const close = `</${tag}>`;
+    const end = source.indexOf(close, cursor);
+    if (end < 0) return null;
+    const text = source.slice(cursor, end);
+    if (text.includes('<') || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
+      return null;
+    }
+    cursor = end + close.length;
+    return text;
+  };
+  const validScalar = (
+    tag: 'string' | 'integer' | 'real' | 'date' | 'data',
+    value: string,
+  ): boolean => {
+    if (tag === 'string') return true;
+    if (tag === 'integer') return /^[+-]?\d+$/.test(value);
+    if (tag === 'real') {
+      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
+    }
+    if (tag === 'date') return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
+    const compact = value.replace(/\s/g, '');
+    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
+  };
+  const parseValue = (): WdaPlistValue | null => {
+    skipWhitespace();
+    const start = cursor;
+    if (consume('<dict/>')) return { kind: 'dict', start, end: cursor, entries: [] };
+    if (consume('<dict>')) {
+      const entries: WdaPlistEntry[] = [];
+      while (true) {
+        skipWhitespace();
+        if (consume('</dict>')) return { kind: 'dict', start, end: cursor, entries };
+        const entryStart = cursor;
+        const key = parseTextElement('key');
+        if (key === null) return null;
+        const value = parseValue();
+        if (!value) return null;
+        entries.push({ key, start: entryStart, end: value.end, value });
+      }
+    }
+    if (consume('<array/>')) return { kind: 'array', start, end: cursor, values: [] };
+    if (consume('<array>')) {
+      const values: WdaPlistValue[] = [];
+      while (true) {
+        skipWhitespace();
+        if (consume('</array>')) return { kind: 'array', start, end: cursor, values };
+        const value = parseValue();
+        if (!value) return null;
+        values.push(value);
+      }
+    }
+    if (consume('<true/>') || consume('<false/>')) return { kind: 'scalar', start, end: cursor };
+    for (const tag of ['string', 'integer', 'real', 'date', 'data'] as const) {
+      const before = cursor;
+      const value = parseTextElement(tag);
+      if (value !== null) {
+        return validScalar(tag, value) ? { kind: 'scalar', start, end: cursor } : null;
+      }
+      cursor = before;
+    }
+    return null;
+  };
+
+  skipWhitespace();
+  if (source.startsWith('<?xml', cursor) && !consumePattern(/^<\?xml[^?]*\?>/)) return null;
+  skipWhitespace();
+  if (source.startsWith('<!DOCTYPE', cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/)) return null;
+  skipWhitespace();
+  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/)) return null;
+  const root = parseValue();
+  if (!root || root.kind !== 'dict') return null;
+  skipWhitespace();
+  if (!consume('</plist>')) return null;
+  skipWhitespace();
+  if (cursor !== source.length) return null;
+
+  const portEntries: WdaPlistEntry[] = [];
+  const collectPortEntries = (value: WdaPlistValue): void => {
+    if (value.kind === 'dict') {
+      for (const entry of value.entries) {
+        if (entry.key === 'USE_PORT') portEntries.push(entry);
+        else collectPortEntries(entry.value);
+      }
+    } else if (value.kind === 'array') {
+      for (const child of value.values) collectPortEntries(child);
+    }
+  };
+  collectPortEntries(root);
+  let normalized = source;
+  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
+    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
+  }
+  return normalized;
+}
+
 // The runner's own reuse marker: build-for-testing emits the .xctestrun in
 // Build/Products once the products exist; require the real test-host executable
 // inside an .app as well so a torn copy or partial delete never counts as cached.
@@ -776,8 +914,14 @@ export function isCompleteWdaBuild(keyDir: string): boolean {
   try {
     const products = join(keyDir, 'DerivedData', 'Build', 'Products');
     const entries = readdirSync(products, { withFileTypes: true });
+    const xctestruns = entries.filter((entry) => entry.name.endsWith('.xctestrun'));
     return (
-      entries.some((entry) => entry.isFile() && entry.name.endsWith('.xctestrun')) &&
+      xctestruns.length > 0 &&
+      xctestruns.every(
+        (entry) =>
+          entry.isFile() &&
+          parseAndNormalizeWdaXctestrun(readFileSync(join(products, entry.name), 'utf8')) !== null,
+      ) &&
       entries.some(
         (entry) =>
           entry.isDirectory() &&
@@ -805,11 +949,8 @@ export function isCompleteWdaBuild(keyDir: string): boolean {
 
 function removeInjectedWdaPort(xctestrunPath: string): boolean {
   const source = readFileSync(xctestrunPath, 'utf8');
-  const normalized = source.replace(
-    /[ \t]*<key>USE_PORT<\/key>[\t\r\n ]*<string>[0-9]+<\/string>[ \t]*(?:\r?\n)?/g,
-    '',
-  );
-  if (normalized.includes('USE_PORT')) return false;
+  const normalized = parseAndNormalizeWdaXctestrun(source);
+  if (normalized === null) return false;
   if (normalized !== source) writeFileSync(xctestrunPath, normalized);
   return true;
 }
@@ -882,8 +1023,12 @@ function isReusableStoredWdaBuild(keyDir: string): boolean {
     }
     const products = join(keyDir, 'DerivedData', 'Build', 'Products');
     return readdirSync(products, { withFileTypes: true })
-      .filter((entry) => entry.isFile() && entry.name.endsWith('.xctestrun'))
-      .every((entry) => !readFileSync(join(products, entry.name), 'utf8').includes('USE_PORT'));
+      .filter((entry) => entry.name.endsWith('.xctestrun'))
+      .every((entry) => {
+        if (!entry.isFile()) return false;
+        const source = readFileSync(join(products, entry.name), 'utf8');
+        return parseAndNormalizeWdaXctestrun(source) === source;
+      });
   } catch {
     return false;
   }

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -29,7 +29,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, dirname, join, relative, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { gunzipSync } from 'node:zlib';
 import { verifiedNativePublicationHelper } from '../session/process-birth.js';
 import { recordRunnerDiagnostic } from '../experience/runner-diagnostics.js';
@@ -805,6 +805,12 @@ function readWdaXctestrun(xctestrunPath: string): Record<string, unknown> | null
   }
 }
 
+function asWdaPlistRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 function forEachWdaTestTarget(
   plist: Record<string, unknown>,
   visit: (target: Record<string, unknown>) => void,
@@ -812,27 +818,43 @@ function forEachWdaTestTarget(
   const configurations = plist.TestConfigurations;
   if (Array.isArray(configurations)) {
     for (const configuration of configurations) {
-      if (configuration === null || typeof configuration !== 'object') continue;
-      const targets = (configuration as Record<string, unknown>).TestTargets;
+      const configurationRecord = asWdaPlistRecord(configuration);
+      if (!configurationRecord) continue;
+      const targets = configurationRecord.TestTargets;
       if (!Array.isArray(targets)) continue;
       for (const target of targets) {
-        if (target !== null && typeof target === 'object' && !Array.isArray(target)) {
-          visit(target as Record<string, unknown>);
-        }
+        const targetRecord = asWdaPlistRecord(target);
+        if (targetRecord) visit(targetRecord);
       }
     }
     return;
   }
   for (const [key, target] of Object.entries(plist)) {
-    if (
-      key !== '__xctestrun_metadata__' &&
-      target !== null &&
-      typeof target === 'object' &&
-      !Array.isArray(target)
-    ) {
-      visit(target as Record<string, unknown>);
-    }
+    const targetRecord = asWdaPlistRecord(target);
+    if (key !== '__xctestrun_metadata__' && targetRecord) visit(targetRecord);
   }
+}
+
+function findWdaTestTarget(plist: Record<string, unknown>): Record<string, unknown> | null {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      const targets = asWdaPlistRecord(configuration)?.TestTargets;
+      if (!Array.isArray(targets)) continue;
+      for (const target of targets) {
+        const targetRecord = asWdaPlistRecord(target);
+        if (
+          targetRecord &&
+          (targetRecord.TestTargetName === 'WebDriverAgentRunner' ||
+            targetRecord.BlueprintName === 'WebDriverAgentRunner')
+        ) {
+          return targetRecord;
+        }
+      }
+    }
+    return null;
+  }
+  return asWdaPlistRecord(plist.WebDriverAgentRunner);
 }
 
 function hasInjectedWdaPort(plist: Record<string, unknown>): boolean {
@@ -851,41 +873,109 @@ function hasInjectedWdaPort(plist: Record<string, unknown>): boolean {
   return found;
 }
 
+function isWithinWdaKey(keyDir: string, candidate: string): boolean {
+  const path = relative(keyDir, candidate);
+  return path === '' || (path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path));
+}
+
+function isContainedWdaProductTree(keyDir: string, products: string): boolean {
+  const lexicalKey = resolve(keyDir);
+  const realKey = realpathSync(keyDir);
+  const visit = (directory: string): boolean => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) {
+        const target = readlinkSync(path);
+        if (
+          isAbsolute(target) ||
+          !isWithinWdaKey(lexicalKey, resolve(directory, target)) ||
+          !isWithinWdaKey(realKey, realpathSync(path))
+        ) {
+          return false;
+        }
+      } else if (stat.isDirectory() && !visit(path)) {
+        return false;
+      }
+    }
+    return true;
+  };
+  return visit(products);
+}
+
+function resolveWdaProductReference(
+  reference: unknown,
+  products: string,
+  testHost?: string,
+): string | null {
+  if (typeof reference !== 'string') return null;
+  if (reference.startsWith('__TESTROOT__/')) {
+    return resolve(products, reference.slice('__TESTROOT__/'.length));
+  }
+  if (testHost && reference.startsWith('__TESTHOST__/')) {
+    return resolve(testHost, reference.slice('__TESTHOST__/'.length));
+  }
+  return null;
+}
+
+interface CompleteWdaBuildManifest {
+  readonly products: string;
+  readonly selectedXctestrun: string;
+}
+
+function readCompleteWdaBuildManifest(keyDir: string): CompleteWdaBuildManifest | null {
+  try {
+    const derivedData = join(keyDir, 'DerivedData');
+    const build = join(derivedData, 'Build');
+    const products = join(build, 'Products');
+    if (
+      !isRealDirectory(keyDir) ||
+      !isRealDirectory(derivedData) ||
+      !isRealDirectory(build) ||
+      !isRealDirectory(products) ||
+      !isContainedWdaProductTree(keyDir, products)
+    ) {
+      return null;
+    }
+    const selected = readdirSync(products, { withFileTypes: true })
+      .filter((entry) => entry.name.endsWith('.xctestrun'))
+      .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))[0];
+    if (!selected?.isFile()) return null;
+    const selectedXctestrun = join(products, selected.name);
+    const plist = readWdaXctestrun(selectedXctestrun);
+    const target = plist && findWdaTestTarget(plist);
+    if (!target) return null;
+
+    const testHost = resolveWdaProductReference(target.TestHostPath, products);
+    if (!testHost) return null;
+    const hostPath = relative(products, testHost).split(sep);
+    if (
+      hostPath.length !== 2 ||
+      hostPath[1] !== 'WebDriverAgentRunner-Runner.app' ||
+      !isRealDirectory(join(products, hostPath[0]!)) ||
+      !isRealDirectory(testHost)
+    ) {
+      return null;
+    }
+    const executable = lstatSync(join(testHost, 'WebDriverAgentRunner-Runner'));
+    if (!executable.isFile() || executable.isSymbolicLink() || (executable.mode & 0o111) === 0) {
+      return null;
+    }
+    const testBundle = resolveWdaProductReference(target.TestBundlePath, products, testHost);
+    if (!testBundle || !isWithinWdaKey(resolve(keyDir), testBundle) || !existsSync(testBundle)) {
+      return null;
+    }
+    return { products, selectedXctestrun };
+  } catch {
+    return null;
+  }
+}
+
 // The runner's own reuse marker: build-for-testing emits the .xctestrun in
 // Build/Products once the products exist; require the real test-host executable
 // at its exact product path as well so a torn copy or partial delete never counts as cached.
 export function isCompleteWdaBuild(keyDir: string): boolean {
-  try {
-    const products = join(keyDir, 'DerivedData', 'Build', 'Products');
-    const entries = readdirSync(products, { withFileTypes: true });
-    const xctestruns = entries.filter((entry) => entry.name.endsWith('.xctestrun'));
-    return (
-      xctestruns.length > 0 &&
-      xctestruns.every(
-        (entry) => entry.isFile() && readWdaXctestrun(join(products, entry.name)) !== null,
-      ) &&
-      entries.some((entry) => {
-        if (!entry.isDirectory()) return false;
-        try {
-          const executable = lstatSync(
-            join(
-              products,
-              entry.name,
-              'WebDriverAgentRunner-Runner.app',
-              'WebDriverAgentRunner-Runner',
-            ),
-          );
-          return (
-            executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 0o111) !== 0
-          );
-        } catch {
-          return false;
-        }
-      })
-    );
-  } catch {
-    return false;
-  }
+  return readCompleteWdaBuildManifest(keyDir) !== null;
 }
 
 function removeInjectedWdaPort(xctestrunPath: string): boolean {
@@ -911,15 +1001,9 @@ function isRealDirectory(path: string): boolean {
 }
 
 function copyReusableWdaBuild(sourceKey: string, stagedKey: string): boolean {
-  const sourceProducts = join(sourceKey, 'DerivedData', 'Build', 'Products');
-  if (
-    !isRealDirectory(sourceKey) ||
-    !isRealDirectory(join(sourceKey, 'DerivedData')) ||
-    !isRealDirectory(join(sourceKey, 'DerivedData', 'Build')) ||
-    !isRealDirectory(sourceProducts)
-  ) {
-    return false;
-  }
+  const manifest = readCompleteWdaBuildManifest(sourceKey);
+  if (!manifest) return false;
+  const sourceProducts = manifest.products;
   const stagedProducts = join(stagedKey, 'DerivedData', 'Build', 'Products');
   mkdirSync(dirname(stagedProducts), { recursive: true });
   cpSync(sourceProducts, stagedProducts, {

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -739,14 +739,21 @@ function wdaToolchainFingerprint(): string | null {
   return memoizedWdaToolchainFingerprint;
 }
 
-export function persistentWdaStoreBuildsRoot(): string | null {
+export function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()): string | null {
   const fingerprint = wdaToolchainFingerprint();
-  if (!fingerprint) return null;
+  if (!fingerprint || !pinArchiveCoords(platformKey)) return null;
   const versionsRoot = runnerCacheVersionsRoot();
   const components = [
     join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
-    join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
-    join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, 'wda-builds'),
+    join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey),
+    join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, platformKey, fingerprint),
+    join(
+      versionsRoot,
+      `.wda-store-${MAESTRO_RUNNER_PIN.version}`,
+      platformKey,
+      fingerprint,
+      'wda-builds',
+    ),
   ];
   // Symlink fence: an existing component that is not a real directory would
   // redirect seeding, publication, and eviction outside the store tree.
@@ -758,7 +765,7 @@ export function persistentWdaStoreBuildsRoot(): string | null {
       break;
     }
   }
-  return components[2]!;
+  return components[3]!;
 }
 
 // The runner's own reuse marker: build-for-testing emits the .xctestrun beside

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -6,12 +6,14 @@
 //   3. Reconcile knownQuirks (retest each listed quirk; add/remove entries).
 //   4. Update version + sha256 here AND in ensure-maestro-runner.sh; add a changeset.
 
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   accessSync,
   chmodSync,
   constants,
   copyFileSync,
+  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -20,6 +22,7 @@ import {
   readdirSync,
   readlinkSync,
   realpathSync,
+  renameSync,
   rmSync,
   symlinkSync,
   unlinkSync,
@@ -713,6 +716,154 @@ export function assertRunnerSnapshotCacheBinding(snapshotRoot: string, cacheRoot
   }
 }
 
+let memoizedWdaToolchainFingerprint: string | null | undefined;
+
+export function _setWdaToolchainFingerprintForTest(fingerprint: string | null | undefined): void {
+  memoizedWdaToolchainFingerprint = fingerprint;
+}
+
+// Xcode/SDK identity fences the persistent store: a toolchain change lands in a
+// fresh store slot and cold-builds instead of reusing artifacts of unknown drift.
+function wdaToolchainFingerprint(): string | null {
+  if (memoizedWdaToolchainFingerprint !== undefined) return memoizedWdaToolchainFingerprint;
+  try {
+    const probe = spawnSync('xcodebuild', ['-version'], { encoding: 'utf8', timeout: 15_000 });
+    const match = /Xcode\s+(\S+)[\s\S]*Build version\s+(\S+)/.exec(probe.stdout ?? '');
+    memoizedWdaToolchainFingerprint =
+      probe.status === 0 && match && /^[\w.]+$/.test(match[1]!) && /^[\w.]+$/.test(match[2]!)
+        ? `xcode-${match[1]}-${match[2]}`
+        : null;
+  } catch {
+    memoizedWdaToolchainFingerprint = null;
+  }
+  return memoizedWdaToolchainFingerprint;
+}
+
+export function persistentWdaStoreBuildsRoot(): string | null {
+  const fingerprint = wdaToolchainFingerprint();
+  if (!fingerprint) return null;
+  const versionsRoot = runnerCacheVersionsRoot();
+  const components = [
+    join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`),
+    join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint),
+    join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`, fingerprint, 'wda-builds'),
+  ];
+  // Symlink fence: an existing component that is not a real directory would
+  // redirect seeding, publication, and eviction outside the store tree.
+  for (const component of components) {
+    try {
+      const stat = lstatSync(component);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+    } catch {
+      break;
+    }
+  }
+  return components[2]!;
+}
+
+// The runner's own reuse marker: build-for-testing emits the .xctestrun beside
+// Build/Products once the products exist; require the test-host .app as well so
+// a torn copy or partial delete never counts as a cached build.
+export function isCompleteWdaBuild(keyDir: string): boolean {
+  try {
+    const products = join(keyDir, 'DerivedData', 'Build', 'Products');
+    const entries = readdirSync(products, { withFileTypes: true });
+    return (
+      entries.some((entry) => entry.isFile() && entry.name.endsWith('.xctestrun')) &&
+      entries.some(
+        (entry) =>
+          entry.isDirectory() &&
+          readdirSync(join(products, entry.name)).some((name) => {
+            if (!name.endsWith('.app')) return false;
+            try {
+              const executable = lstatSync(
+                join(products, entry.name, name, name.slice(0, -'.app'.length)),
+              );
+              return executable.isFile() && !executable.isSymbolicLink();
+            } catch {
+              return false;
+            }
+          }),
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+function copyWdaBuildKey(sourceKey: string, stagedKey: string): boolean {
+  cpSync(sourceKey, stagedKey, {
+    recursive: true,
+    mode: constants.COPYFILE_FICLONE,
+    verbatimSymlinks: true,
+  });
+  return isCompleteWdaBuild(stagedKey);
+}
+
+function seedRunnerSnapshotCacheFromStore(cacheRoot: string): number {
+  let seeded = 0;
+  try {
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds) return 0;
+    const target = join(cacheRoot, 'wda-builds');
+    for (const entry of readdirSync(storeBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const sourceKey = join(storeBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey)) continue;
+      mkdirSync(target, { recursive: true });
+      const stagedKey = join(target, `.seed-${entry.name}`);
+      try {
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          renameSync(stagedKey, join(target, entry.name));
+          seeded += 1;
+        } else {
+          rmSync(stagedKey, { recursive: true, force: true });
+        }
+      } catch {
+        try {
+          rmSync(stagedKey, { recursive: true, force: true });
+        } catch {}
+      }
+    }
+  } catch {}
+  return seeded;
+}
+
+function publishRunnerSnapshotCacheToStore(cacheRoot: string): number {
+  let published = 0;
+  try {
+    const spawnBuilds = join(cacheRoot, 'wda-builds');
+    const storeBuilds = persistentWdaStoreBuildsRoot();
+    if (!storeBuilds) return 0;
+    for (const entry of readdirSync(spawnBuilds, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      const sourceKey = join(spawnBuilds, entry.name);
+      if (!isCompleteWdaBuild(sourceKey)) continue;
+      const storeKey = join(storeBuilds, entry.name);
+      if (isCompleteWdaBuild(storeKey)) continue;
+      mkdirSync(storeBuilds, { recursive: true, mode: 0o700 });
+      const stage = mkdtempSync(join(storeBuilds, '.stage-'));
+      try {
+        const stagedKey = join(stage, entry.name);
+        if (copyWdaBuildKey(sourceKey, stagedKey)) {
+          if (existsSync(storeKey)) {
+            // Atomic evict: readers never observe a half-deleted key path.
+            const evicted = join(stage, 'evicted');
+            renameSync(storeKey, evicted);
+          }
+          // No-clobber claim: a concurrent publisher that recreated the key
+          // wins (rename throws) and this spawn's copy is discarded with stage.
+          renameSync(stagedKey, storeKey);
+          published += 1;
+        }
+      } finally {
+        rmSync(stage, { recursive: true, force: true });
+      }
+    }
+  } catch {}
+  return published;
+}
+
 export interface RunnerSnapshotTestHooks {
   beforeCacheProvision?: (expectedCacheRoot: string) => void;
   beforeCacheBinding?: (ownedCacheRoot: string) => void;
@@ -864,7 +1015,15 @@ export async function withImmediatePinnedRunner<T>(
       }
     }
     chmodSync(snapshotRoot, 0o500);
-    if (cacheRoot) assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+    if (cacheRoot) {
+      assertRunnerSnapshotCacheBinding(snapshotRoot, cacheRoot);
+      // Seed strictly after sealing: the recursive seal walk descends through
+      // the cache symlink, and sealed seed content breaks the runner's own
+      // xctestrun port rewrite on the warm path.
+      recordRunnerDiagnostic('cache-seed', {
+        seededBuilds: seedRunnerSnapshotCacheFromStore(cacheRoot),
+      });
+    }
     const openedRunner = lstatSync(snapshotRunner);
     recordRunnerDiagnostic('runner-exec-begin', { runnerPinVersion: MAESTRO_RUNNER_PIN.version });
     if (platform === 'ios') {
@@ -887,6 +1046,11 @@ export async function withImmediatePinnedRunner<T>(
         else if (entry.isFile()) chmodSync(entryPath, 0o600);
       }
     } catch {}
+    if (cacheRoot) {
+      recordRunnerDiagnostic('cache-publish', {
+        publishedBuilds: publishRunnerSnapshotCacheToStore(cacheRoot),
+      });
+    }
     removeRunnerSnapshotAndCache(snapshotRoot, cacheRoot);
   }
 }

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -769,147 +769,91 @@ export function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()): s
   return components[3]!;
 }
 
-interface WdaPlistEntry {
-  readonly key: string;
-  readonly start: number;
-  readonly end: number;
-  readonly value: WdaPlistValue;
+type WdaPlutil = (args: ReadonlyArray<string>) => {
+  readonly status: number | null;
+  readonly stdout?: string;
+};
+
+let testWdaPlutil: WdaPlutil | undefined;
+
+export function _setWdaPlutilForTest(plutil: WdaPlutil | undefined): void {
+  testWdaPlutil = plutil;
 }
 
-type WdaPlistValue =
-  | Readonly<{
-      kind: 'dict';
-      start: number;
-      end: number;
-      entries: ReadonlyArray<WdaPlistEntry>;
-    }>
-  | Readonly<{
-      kind: 'array';
-      start: number;
-      end: number;
-      values: ReadonlyArray<WdaPlistValue>;
-    }>
-  | Readonly<{ kind: 'scalar'; start: number; end: number }>;
-
-function parseAndNormalizeWdaXctestrun(source: string): string | null {
-  let cursor = 0;
-  const skipWhitespace = (): void => {
-    while (/\s/.test(source[cursor] ?? '')) cursor += 1;
-  };
-  const consume = (token: string): boolean => {
-    if (!source.startsWith(token, cursor)) return false;
-    cursor += token.length;
-    return true;
-  };
-  const consumePattern = (pattern: RegExp): boolean => {
-    const match = pattern.exec(source.slice(cursor));
-    if (!match || match.index !== 0) return false;
-    cursor += match[0].length;
-    return true;
-  };
-  const parseTextElement = (
-    tag: 'key' | 'string' | 'integer' | 'real' | 'date' | 'data',
-  ): string | null => {
-    if (consume(`<${tag}/>`)) return '';
-    if (!consume(`<${tag}>`)) return null;
-    const close = `</${tag}>`;
-    const end = source.indexOf(close, cursor);
-    if (end < 0) return null;
-    const text = source.slice(cursor, end);
-    if (text.includes('<') || /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[\dA-Fa-f]+);)/.test(text)) {
-      return null;
-    }
-    cursor = end + close.length;
-    return text;
-  };
-  const validScalar = (
-    tag: 'string' | 'integer' | 'real' | 'date' | 'data',
-    value: string,
-  ): boolean => {
-    if (tag === 'string') return true;
-    if (tag === 'integer') return /^[+-]?\d+$/.test(value);
-    if (tag === 'real') {
-      return /^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?|inf|nan)$/i.test(value);
-    }
-    if (tag === 'date') return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value);
-    const compact = value.replace(/\s/g, '');
-    return compact.length % 4 === 0 && /^[\dA-Za-z+/]*={0,2}$/.test(compact);
-  };
-  const parseValue = (): WdaPlistValue | null => {
-    skipWhitespace();
-    const start = cursor;
-    if (consume('<dict/>')) return { kind: 'dict', start, end: cursor, entries: [] };
-    if (consume('<dict>')) {
-      const entries: WdaPlistEntry[] = [];
-      while (true) {
-        skipWhitespace();
-        if (consume('</dict>')) return { kind: 'dict', start, end: cursor, entries };
-        const entryStart = cursor;
-        const key = parseTextElement('key');
-        if (key === null) return null;
-        const value = parseValue();
-        if (!value) return null;
-        entries.push({ key, start: entryStart, end: value.end, value });
-      }
-    }
-    if (consume('<array/>')) return { kind: 'array', start, end: cursor, values: [] };
-    if (consume('<array>')) {
-      const values: WdaPlistValue[] = [];
-      while (true) {
-        skipWhitespace();
-        if (consume('</array>')) return { kind: 'array', start, end: cursor, values };
-        const value = parseValue();
-        if (!value) return null;
-        values.push(value);
-      }
-    }
-    if (consume('<true/>') || consume('<false/>')) return { kind: 'scalar', start, end: cursor };
-    for (const tag of ['string', 'integer', 'real', 'date', 'data'] as const) {
-      const before = cursor;
-      const value = parseTextElement(tag);
-      if (value !== null) {
-        return validScalar(tag, value) ? { kind: 'scalar', start, end: cursor } : null;
-      }
-      cursor = before;
-    }
+function runWdaPlutil(args: ReadonlyArray<string>): string | null {
+  if (process.platform !== 'darwin' && !testWdaPlutil) return null;
+  try {
+    const result = testWdaPlutil
+      ? testWdaPlutil(args)
+      : spawnSync('plutil', [...args], { encoding: 'utf8', timeout: 15_000 });
+    return result.status === 0 ? (result.stdout ?? '') : null;
+  } catch {
     return null;
-  };
-
-  skipWhitespace();
-  if (source.startsWith('<?xml', cursor) && !consumePattern(/^<\?xml[^?]*\?>/)) return null;
-  skipWhitespace();
-  if (source.startsWith('<!DOCTYPE', cursor) && !consumePattern(/^<!DOCTYPE[^>]*>/)) return null;
-  skipWhitespace();
-  if (!consumePattern(/^<plist(?:\s+version="1\.0")?\s*>/)) return null;
-  const root = parseValue();
-  if (!root || root.kind !== 'dict') return null;
-  skipWhitespace();
-  if (!consume('</plist>')) return null;
-  skipWhitespace();
-  if (cursor !== source.length) return null;
-
-  const portEntries: WdaPlistEntry[] = [];
-  const collectPortEntries = (value: WdaPlistValue): void => {
-    if (value.kind === 'dict') {
-      for (const entry of value.entries) {
-        if (entry.key === 'USE_PORT') portEntries.push(entry);
-        else collectPortEntries(entry.value);
-      }
-    } else if (value.kind === 'array') {
-      for (const child of value.values) collectPortEntries(child);
-    }
-  };
-  collectPortEntries(root);
-  let normalized = source;
-  for (const entry of portEntries.sort((left, right) => right.start - left.start)) {
-    normalized = normalized.slice(0, entry.start) + normalized.slice(entry.end);
   }
-  return normalized;
+}
+
+function readWdaXctestrun(xctestrunPath: string): Record<string, unknown> | null {
+  const json = runWdaPlutil(['-convert', 'json', '-o', '-', xctestrunPath]);
+  if (json === null) return null;
+  try {
+    const plist: unknown = JSON.parse(json);
+    return plist !== null && typeof plist === 'object' && !Array.isArray(plist)
+      ? (plist as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function forEachWdaTestTarget(
+  plist: Record<string, unknown>,
+  visit: (target: Record<string, unknown>) => void,
+): void {
+  const configurations = plist.TestConfigurations;
+  if (Array.isArray(configurations)) {
+    for (const configuration of configurations) {
+      if (configuration === null || typeof configuration !== 'object') continue;
+      const targets = (configuration as Record<string, unknown>).TestTargets;
+      if (!Array.isArray(targets)) continue;
+      for (const target of targets) {
+        if (target !== null && typeof target === 'object' && !Array.isArray(target)) {
+          visit(target as Record<string, unknown>);
+        }
+      }
+    }
+    return;
+  }
+  for (const [key, target] of Object.entries(plist)) {
+    if (
+      key !== '__xctestrun_metadata__' &&
+      target !== null &&
+      typeof target === 'object' &&
+      !Array.isArray(target)
+    ) {
+      visit(target as Record<string, unknown>);
+    }
+  }
+}
+
+function hasInjectedWdaPort(plist: Record<string, unknown>): boolean {
+  let found = false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (
+      environment !== null &&
+      typeof environment === 'object' &&
+      !Array.isArray(environment) &&
+      Object.hasOwn(environment, 'USE_PORT')
+    ) {
+      found = true;
+    }
+  });
+  return found;
 }
 
 // The runner's own reuse marker: build-for-testing emits the .xctestrun in
 // Build/Products once the products exist; require the real test-host executable
-// inside an .app as well so a torn copy or partial delete never counts as cached.
+// at its exact product path as well so a torn copy or partial delete never counts as cached.
 export function isCompleteWdaBuild(keyDir: string): boolean {
   try {
     const products = join(keyDir, 'DerivedData', 'Build', 'Products');
@@ -918,29 +862,26 @@ export function isCompleteWdaBuild(keyDir: string): boolean {
     return (
       xctestruns.length > 0 &&
       xctestruns.every(
-        (entry) =>
-          entry.isFile() &&
-          parseAndNormalizeWdaXctestrun(readFileSync(join(products, entry.name), 'utf8')) !== null,
+        (entry) => entry.isFile() && readWdaXctestrun(join(products, entry.name)) !== null,
       ) &&
-      entries.some(
-        (entry) =>
-          entry.isDirectory() &&
-          readdirSync(join(products, entry.name)).some((name) => {
-            if (!name.endsWith('.app')) return false;
-            try {
-              const executable = lstatSync(
-                join(products, entry.name, name, name.slice(0, -'.app'.length)),
-              );
-              return (
-                executable.isFile() &&
-                !executable.isSymbolicLink() &&
-                (executable.mode & 0o111) !== 0
-              );
-            } catch {
-              return false;
-            }
-          }),
-      )
+      entries.some((entry) => {
+        if (!entry.isDirectory()) return false;
+        try {
+          const executable = lstatSync(
+            join(
+              products,
+              entry.name,
+              'WebDriverAgentRunner-Runner.app',
+              'WebDriverAgentRunner-Runner',
+            ),
+          );
+          return (
+            executable.isFile() && !executable.isSymbolicLink() && (executable.mode & 0o111) !== 0
+          );
+        } catch {
+          return false;
+        }
+      })
     );
   } catch {
     return false;
@@ -948,11 +889,16 @@ export function isCompleteWdaBuild(keyDir: string): boolean {
 }
 
 function removeInjectedWdaPort(xctestrunPath: string): boolean {
-  const source = readFileSync(xctestrunPath, 'utf8');
-  const normalized = parseAndNormalizeWdaXctestrun(source);
-  if (normalized === null) return false;
-  if (normalized !== source) writeFileSync(xctestrunPath, normalized);
-  return true;
+  const plist = readWdaXctestrun(xctestrunPath);
+  if (!plist) return false;
+  forEachWdaTestTarget(plist, (target) => {
+    const environment = target.EnvironmentVariables;
+    if (environment !== null && typeof environment === 'object' && !Array.isArray(environment)) {
+      delete (environment as Record<string, unknown>).USE_PORT;
+    }
+  });
+  writeFileSync(xctestrunPath, JSON.stringify(plist, null, 2));
+  return runWdaPlutil(['-convert', 'xml1', xctestrunPath]) !== null;
 }
 
 function isRealDirectory(path: string): boolean {
@@ -1026,8 +972,8 @@ function isReusableStoredWdaBuild(keyDir: string): boolean {
       .filter((entry) => entry.name.endsWith('.xctestrun'))
       .every((entry) => {
         if (!entry.isFile()) return false;
-        const source = readFileSync(join(products, entry.name), 'utf8');
-        return parseAndNormalizeWdaXctestrun(source) === source;
+        const plist = readWdaXctestrun(join(products, entry.name));
+        return plist !== null && !hasInjectedWdaPort(plist);
       });
   } catch {
     return false;

--- a/packages/rn-dev-agent-core/src/domain/engine-pin.ts
+++ b/packages/rn-dev-agent-core/src/domain/engine-pin.ts
@@ -768,9 +768,9 @@ export function persistentWdaStoreBuildsRoot(platformKey = nodePlatformKey()): s
   return components[3]!;
 }
 
-// The runner's own reuse marker: build-for-testing emits the .xctestrun beside
-// Build/Products once the products exist; require the test-host .app as well so
-// a torn copy or partial delete never counts as a cached build.
+// The runner's own reuse marker: build-for-testing emits the .xctestrun in
+// Build/Products once the products exist; require the real test-host executable
+// inside an .app as well so a torn copy or partial delete never counts as cached.
 export function isCompleteWdaBuild(keyDir: string): boolean {
   try {
     const products = join(keyDir, 'DerivedData', 'Build', 'Products');

--- a/packages/rn-dev-agent-core/src/experience/runner-diagnostics.ts
+++ b/packages/rn-dev-agent-core/src/experience/runner-diagnostics.ts
@@ -7,6 +7,8 @@ export type RunnerDiagnosticEventType =
   | 'spawn-begin'
   | 'payload-verify'
   | 'cache-provision'
+  | 'cache-seed'
+  | 'cache-publish'
   | 'runner-exec-begin'
   | 'wda-bootstrap-begin'
   | 'typed-failure'

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -9,6 +9,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -41,12 +42,26 @@ const fixtureBinary =
 
 const WDA_KEY = 'sim-ios26.4-iphone';
 
+function wdaTestHostExecutable(keyDir: string): string {
+  return join(
+    keyDir,
+    'DerivedData',
+    'Build',
+    'Products',
+    'Debug-iphonesimulator',
+    'WebDriverAgentRunner-Runner.app',
+    'WebDriverAgentRunner-Runner',
+  );
+}
+
 function writeCompleteWdaBuild(keyDir: string): void {
   const products = join(keyDir, 'DerivedData', 'Build', 'Products');
   const app = join(products, 'Debug-iphonesimulator', 'WebDriverAgentRunner-Runner.app');
   mkdirSync(app, { recursive: true });
   writeFileSync(join(products, 'WebDriverAgentRunner_iphonesimulator26.5-arm64.xctestrun'), 'p');
-  writeFileSync(join(app, 'WebDriverAgentRunner-Runner'), 'binary');
+  const executable = wdaTestHostExecutable(keyDir);
+  writeFileSync(executable, 'binary');
+  chmodSync(executable, 0o755);
 }
 
 test('isCompleteWdaBuild requires the xctestrun and the test-host executable', () => {
@@ -56,15 +71,7 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     assert.equal(isCompleteWdaBuild(keyDir), false);
     writeCompleteWdaBuild(keyDir);
     assert.equal(isCompleteWdaBuild(keyDir), true);
-    const executable = join(
-      keyDir,
-      'DerivedData',
-      'Build',
-      'Products',
-      'Debug-iphonesimulator',
-      'WebDriverAgentRunner-Runner.app',
-      'WebDriverAgentRunner-Runner',
-    );
+    const executable = wdaTestHostExecutable(keyDir);
     rmSync(executable);
     assert.equal(isCompleteWdaBuild(keyDir), false);
     mkdirSync(executable);
@@ -148,6 +155,7 @@ test(
         writeCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
       });
       assert.equal(isCompleteWdaBuild(join(storeBuilds!, WDA_KEY)), true);
+      assert.notEqual(statSync(wdaTestHostExecutable(join(storeBuilds!, WDA_KEY))).mode & 0o111, 0);
 
       // Warm run: the spawn cache is pre-seeded before the runner starts, and
       // the seeded xctestrun stays writable — the runner rewrites it to inject

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -72,6 +72,10 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     writeCompleteWdaBuild(keyDir);
     assert.equal(isCompleteWdaBuild(keyDir), true);
     const executable = wdaTestHostExecutable(keyDir);
+    chmodSync(executable, 0o644);
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'a mode-stripped test host is not runnable');
+    chmodSync(executable, 0o755);
+    assert.equal(isCompleteWdaBuild(keyDir), true);
     rmSync(executable);
     assert.equal(isCompleteWdaBuild(keyDir), false);
     mkdirSync(executable);
@@ -83,6 +87,38 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test(
+  'a changed toolchain selects a different store slot on the very next probe',
+  { skip: process.platform === 'win32' ? 'POSIX shell shim' : false },
+  () => {
+    const shim = mkdtempSync(join(tmpdir(), 'wda-xcb-shim-'));
+    const cache = mkdtempSync(join(tmpdir(), 'wda-xcb-cache-'));
+    const previousPath = process.env.PATH;
+    const previousCache = process.env.RN_DEV_AGENT_RUNNER_CACHE;
+    _setWdaToolchainFingerprintForTest(undefined);
+    try {
+      process.env.RN_DEV_AGENT_RUNNER_CACHE = cache;
+      const fakeXcodebuild = join(shim, 'xcodebuild');
+      writeFileSync(fakeXcodebuild, '#!/bin/sh\necho "Xcode 1.0"\necho "Build version AAA1"\n');
+      chmodSync(fakeXcodebuild, 0o755);
+      process.env.PATH = `${shim}:${previousPath ?? ''}`;
+      const before = persistentWdaStoreBuildsRoot('darwin-arm64');
+      assert.match(before ?? '', /xcode-1\.0-AAA1/);
+      writeFileSync(fakeXcodebuild, '#!/bin/sh\necho "Xcode 2.0"\necho "Build version BBB2"\n');
+      const after = persistentWdaStoreBuildsRoot('darwin-arm64');
+      assert.match(after ?? '', /xcode-2\.0-BBB2/);
+      assert.notEqual(before, after);
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousCache === undefined) delete process.env.RN_DEV_AGENT_RUNNER_CACHE;
+      else process.env.RN_DEV_AGENT_RUNNER_CACHE = previousCache;
+      _setWdaToolchainFingerprintForTest(undefined);
+      rmSync(shim, { recursive: true, force: true });
+      rmSync(cache, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   'consecutive iOS spawns reuse the published WDA build and controls rebuild cold',

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { after, before, test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   chmodSync,
@@ -27,6 +27,7 @@ import {
   _resetEngineStatusForTest,
   _setEngineStatusForTest,
   _setPinnedRunnerAttestationForTest,
+  _setWdaPlutilForTest,
   _setWdaToolchainFingerprintForTest,
 } from '../../dist/domain/engine-pin.js';
 
@@ -91,6 +92,48 @@ function writeCompleteWdaBuild(keyDir: string, port?: number): void {
   chmodSync(executable, 0o755);
 }
 
+before(() => {
+  if (process.platform === 'darwin') return;
+  _setWdaPlutilForTest((args: ReadonlyArray<string>) => {
+    const xctestrunPath = args.at(-1);
+    if (!xctestrunPath) return { status: 1 };
+    const source = readFileSync(xctestrunPath, 'utf8');
+    if (args[1] === 'xml1') {
+      try {
+        JSON.parse(source);
+        return { status: 0 };
+      } catch {
+        return { status: 1 };
+      }
+    }
+    if (args[1] !== 'json' || source.includes('&#x110000;')) return { status: 1 };
+    if (source.trimStart().startsWith('{')) {
+      try {
+        JSON.parse(source);
+        return { status: 0, stdout: source };
+      } catch {
+        return { status: 1 };
+      }
+    }
+    if (!source.includes('<plist') || !source.trimEnd().endsWith('</plist>')) {
+      return { status: 1 };
+    }
+    const port = /<key>USE_PORT<\/key>\s*<string>([^<]+)<\/string>/.exec(source)?.[1];
+    return {
+      status: 0,
+      stdout: JSON.stringify({
+        WebDriverAgentRunner: {
+          EnvironmentVariables: port === undefined ? {} : { USE_PORT: port },
+        },
+      }),
+    };
+  });
+});
+
+after(() => {
+  _setWdaPlutilForTest(undefined);
+});
+
 test('isCompleteWdaBuild requires the xctestrun and the test-host executable', () => {
   const root = mkdtempSync(join(tmpdir(), 'wda-complete-'));
   try {
@@ -100,6 +143,11 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     assert.equal(isCompleteWdaBuild(keyDir), true);
     writeFileSync(wdaXctestrunPath(keyDir), '<plist version="1.0"><dict>');
     assert.equal(isCompleteWdaBuild(keyDir), false, 'a truncated xctestrun is not reusable');
+    writeFileSync(
+      wdaXctestrunPath(keyDir),
+      wdaXctestrun().replace('</dict>', '<key>INVALID</key><string>&#x110000;</string></dict>'),
+    );
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'an XML-invalid xctestrun is not reusable');
     writeFileSync(wdaXctestrunPath(keyDir), wdaXctestrun());
     assert.equal(isCompleteWdaBuild(keyDir), true);
     const executable = wdaTestHostExecutable(keyDir);
@@ -109,6 +157,11 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     assert.equal(isCompleteWdaBuild(keyDir), true);
     rmSync(executable);
     assert.equal(isCompleteWdaBuild(keyDir), false);
+    const unrelatedExecutable = join(dirname(dirname(executable)), 'Unrelated.app', 'Unrelated');
+    mkdirSync(dirname(unrelatedExecutable), { recursive: true });
+    writeFileSync(unrelatedExecutable, 'binary');
+    chmodSync(unrelatedExecutable, 0o755);
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'an unrelated app is not the WDA test host');
     mkdirSync(executable);
     assert.equal(isCompleteWdaBuild(keyDir), false, 'a directory is not an executable');
     rmSync(executable, { recursive: true });

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -1,0 +1,261 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  MAESTRO_RUNNER_PIN,
+  buildReplayEngineStatus,
+  isCompleteWdaBuild,
+  persistentWdaStoreBuildsRoot,
+  withImmediatePinnedRunner,
+  _resetEngineStatusForTest,
+  _setEngineStatusForTest,
+  _setPinnedRunnerAttestationForTest,
+  _setWdaToolchainFingerprintForTest,
+} from '../../dist/domain/engine-pin.js';
+
+const publicationHelperSupported =
+  process.platform === 'darwin' ||
+  (process.platform === 'linux' && (process.arch === 'x64' || process.arch === 'arm64'));
+
+const nativeDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'native');
+const fixtureBinary =
+  process.platform === 'darwin'
+    ? join(nativeDir, 'darwin-process-birth')
+    : join(nativeDir, `linux-conditional-publication-${process.arch}`);
+
+const WDA_KEY = 'sim-ios26.4-iphone';
+
+function writeCompleteWdaBuild(keyDir: string): void {
+  const products = join(keyDir, 'DerivedData', 'Build', 'Products');
+  const app = join(products, 'Debug-iphonesimulator', 'WebDriverAgentRunner-Runner.app');
+  mkdirSync(app, { recursive: true });
+  writeFileSync(join(products, 'WebDriverAgentRunner_iphonesimulator26.5-arm64.xctestrun'), 'p');
+  writeFileSync(join(app, 'WebDriverAgentRunner-Runner'), 'binary');
+}
+
+test('isCompleteWdaBuild requires the xctestrun and the test-host executable', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wda-complete-'));
+  try {
+    const keyDir = join(root, WDA_KEY);
+    assert.equal(isCompleteWdaBuild(keyDir), false);
+    writeCompleteWdaBuild(keyDir);
+    assert.equal(isCompleteWdaBuild(keyDir), true);
+    const executable = join(
+      keyDir,
+      'DerivedData',
+      'Build',
+      'Products',
+      'Debug-iphonesimulator',
+      'WebDriverAgentRunner-Runner.app',
+      'WebDriverAgentRunner-Runner',
+    );
+    rmSync(executable);
+    assert.equal(isCompleteWdaBuild(keyDir), false);
+    mkdirSync(executable);
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'a directory is not an executable');
+    rmSync(executable, { recursive: true });
+    symlinkSync('/usr/bin/true', executable);
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'a symlink is not an executable');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test(
+  'consecutive iOS spawns reuse the published WDA build and controls rebuild cold',
+  { skip: publicationHelperSupported ? false : 'POSIX publication helper is unavailable' },
+  async () => {
+    const cache = mkdtempSync(join(tmpdir(), 'wda-store-reuse-'));
+    const previousCache = process.env.RN_DEV_AGENT_RUNNER_CACHE;
+    process.env.RN_DEV_AGENT_RUNNER_CACHE = cache;
+    _setWdaToolchainFingerprintForTest('xcode-26.5-23F81a');
+    try {
+      const packed = join(cache, 'packed', 'maestro-runner');
+      mkdirSync(join(packed, 'bin'), { recursive: true });
+      copyFileSync(fixtureBinary, join(packed, 'bin', 'maestro-runner'));
+      chmodSync(join(packed, 'bin', 'maestro-runner'), 0o755);
+      const archive = join(cache, 'maestro-runner.tar.gz');
+      const packedTar = spawnSync('tar', [
+        '-czf',
+        archive,
+        '-C',
+        join(cache, 'packed'),
+        'maestro-runner',
+      ]);
+      assert.equal(packedTar.status, 0, String(packedTar.stderr));
+
+      const pinRoot = join(cache, 'maestro-runner', MAESTRO_RUNNER_PIN.version);
+      mkdirSync(join(pinRoot, 'bin'), { recursive: true });
+      const runnerPath = join(pinRoot, 'bin', 'maestro-runner');
+      copyFileSync(join(packed, 'bin', 'maestro-runner'), runnerPath);
+      chmodSync(runnerPath, 0o755);
+      copyFileSync(archive, join(pinRoot, '.payload.tar.gz'));
+      _setPinnedRunnerAttestationForTest({
+        sha256: createHash('sha256').update(readFileSync(runnerPath)).digest('hex'),
+        archiveSha256: createHash('sha256').update(readFileSync(archive)).digest('hex'),
+      });
+      const status = buildReplayEngineStatus('pinned-ok', MAESTRO_RUNNER_PIN.version, false, {
+        selectedPath: runnerPath,
+        provenance: 'pin-cache',
+      });
+      _setEngineStatusForTest(status);
+
+      const runIos = (onCache: (cacheLink: string) => void): Promise<{ status: number | null }> =>
+        withImmediatePinnedRunner(
+          runnerPath,
+          async () => status,
+          async (boundPath) => {
+            onCache(join(dirname(boundPath), 'cache'));
+            return { status: 0 };
+          },
+          'ios',
+        );
+
+      const storeBuilds = persistentWdaStoreBuildsRoot();
+      assert.ok(storeBuilds);
+      assert.match(
+        storeBuilds!,
+        new RegExp(`\\.wda-store-${MAESTRO_RUNNER_PIN.version.replaceAll('.', '\\.')}`),
+      );
+      assert.match(storeBuilds!, /xcode-26\.5-23F81a/);
+
+      // Cold run: cache starts unseeded, the "runner" builds, publish captures it.
+      await runIos((cacheLink) => {
+        assert.equal(existsSync(join(cacheLink, 'wda-builds')), false);
+        writeCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
+      });
+      assert.equal(isCompleteWdaBuild(join(storeBuilds!, WDA_KEY)), true);
+
+      // Warm run: the spawn cache is pre-seeded before the runner starts, and
+      // the seeded xctestrun stays writable — the runner rewrites it to inject
+      // the WDA port, and the snapshot seal walk must not have reached it. The
+      // rewrite must land on the spawn copy only, never the store artifact.
+      const xctestrunTail = [
+        'DerivedData',
+        'Build',
+        'Products',
+        'WebDriverAgentRunner_iphonesimulator26.5-arm64.xctestrun',
+      ] as const;
+      let warmSeeded = false;
+      await runIos((cacheLink) => {
+        warmSeeded = isCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
+        writeFileSync(join(cacheLink, 'wda-builds', WDA_KEY, ...xctestrunTail), 'port-injected');
+      });
+      assert.equal(warmSeeded, true);
+      assert.equal(readFileSync(join(storeBuilds!, WDA_KEY, ...xctestrunTail), 'utf8'), 'p');
+
+      // The per-spawn caches are still removed; only the store persists.
+      const versionsRoot = join(cache, 'maestro-runner');
+      const leftovers = readdirSync(versionsRoot).filter(
+        (name) => name.startsWith('.wda-cache-') || name.startsWith('.spawn-'),
+      );
+      assert.deepEqual(leftovers, []);
+      const storeEntries = readdirSync(storeBuilds!).filter((name) => name.startsWith('.stage-'));
+      assert.deepEqual(storeEntries, []);
+
+      // Control: an incompatible toolchain fingerprint does not consume the store.
+      _setWdaToolchainFingerprintForTest('xcode-27.0-99Z99z');
+      await runIos((cacheLink) => {
+        assert.equal(existsSync(join(cacheLink, 'wda-builds', WDA_KEY)), false);
+      });
+      _setWdaToolchainFingerprintForTest('xcode-26.5-23F81a');
+
+      // Control: an unknown toolchain refuses persistence entirely — no seed,
+      // and the complete build is not published into any store location.
+      _setWdaToolchainFingerprintForTest(null);
+      const rootBefore = readdirSync(versionsRoot).sort();
+      await runIos((cacheLink) => {
+        assert.equal(existsSync(join(cacheLink, 'wda-builds')), false);
+        writeCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
+      });
+      assert.deepEqual(readdirSync(versionsRoot).sort(), rootBefore);
+      _setWdaToolchainFingerprintForTest('xcode-26.5-23F81a');
+
+      // Control: a corrupt store artifact is not seeded and is replaced on the
+      // next complete publish instead of being consumed.
+      rmSync(
+        join(
+          storeBuilds!,
+          WDA_KEY,
+          'DerivedData',
+          'Build',
+          'Products',
+          'Debug-iphonesimulator',
+          'WebDriverAgentRunner-Runner.app',
+          'WebDriverAgentRunner-Runner',
+        ),
+      );
+      await runIos((cacheLink) => {
+        assert.equal(existsSync(join(cacheLink, 'wda-builds', WDA_KEY)), false);
+        writeCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
+      });
+      assert.equal(isCompleteWdaBuild(join(storeBuilds!, WDA_KEY)), true);
+
+      // Control: an unreadable store never masks the runner result — the run
+      // still succeeds cold and best-effort persistence swallows the failure.
+      if (process.getuid?.() !== 0) {
+        const storeRoot = join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`);
+        chmodSync(storeRoot, 0o000);
+        try {
+          await runIos((cacheLink) => {
+            assert.equal(existsSync(join(cacheLink, 'wda-builds', WDA_KEY)), false);
+            writeCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
+          });
+        } finally {
+          chmodSync(storeRoot, 0o700);
+        }
+      }
+
+      // Control: a partial spawn build (no xctestrun) is never published.
+      rmSync(join(storeBuilds!, WDA_KEY), { recursive: true, force: true });
+      await runIos((cacheLink) => {
+        const partial = join(cacheLink, 'wda-builds', WDA_KEY);
+        writeCompleteWdaBuild(partial);
+        rmSync(
+          join(
+            partial,
+            'DerivedData',
+            'Build',
+            'Products',
+            'WebDriverAgentRunner_iphonesimulator26.5-arm64.xctestrun',
+          ),
+        );
+      });
+      assert.equal(existsSync(join(storeBuilds!, WDA_KEY)), false);
+
+      // Control (UID-independent): a store path occupied by a non-directory
+      // trips the symlink/realness fence — no seed, no publish, result intact.
+      const storePath = join(versionsRoot, `.wda-store-${MAESTRO_RUNNER_PIN.version}`);
+      rmSync(storePath, { recursive: true, force: true });
+      writeFileSync(storePath, 'occupied');
+      const fenced = await runIos((cacheLink) => {
+        assert.equal(existsSync(join(cacheLink, 'wda-builds')), false);
+        writeCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
+      });
+      assert.equal(fenced.status, 0);
+      assert.equal(readFileSync(storePath, 'utf8'), 'occupied');
+    } finally {
+      _resetEngineStatusForTest();
+      _setWdaToolchainFingerprintForTest(undefined);
+      if (previousCache === undefined) delete process.env.RN_DEV_AGENT_RUNNER_CACHE;
+      else process.env.RN_DEV_AGENT_RUNNER_CACHE = previousCache;
+      rmSync(cache, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -8,6 +8,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -16,7 +17,7 @@ import {
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   MAESTRO_RUNNER_PIN,
@@ -55,6 +56,14 @@ function wdaTestHostExecutable(keyDir: string): string {
   );
 }
 
+function wdaTestHostApp(keyDir: string): string {
+  return dirname(wdaTestHostExecutable(keyDir));
+}
+
+function wdaTestBundlePath(keyDir: string): string {
+  return join(wdaTestHostApp(keyDir), 'PlugIns', 'WebDriverAgentRunner.xctest');
+}
+
 function wdaXctestrunPath(keyDir: string): string {
   return join(
     keyDir,
@@ -73,6 +82,10 @@ function wdaXctestrun(port?: number): string {
 <dict>
 \t<key>WebDriverAgentRunner</key>
 \t<dict>
+\t\t<key>TestHostPath</key>
+\t\t<string>__TESTROOT__/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app</string>
+\t\t<key>TestBundlePath</key>
+\t\t<string>__TESTHOST__/PlugIns/WebDriverAgentRunner.xctest</string>
 \t\t<key>EnvironmentVariables</key>
 \t\t<dict>${environment}
 \t\t</dict>
@@ -86,6 +99,7 @@ function writeCompleteWdaBuild(keyDir: string, port?: number): void {
   const products = join(keyDir, 'DerivedData', 'Build', 'Products');
   const app = join(products, 'Debug-iphonesimulator', 'WebDriverAgentRunner-Runner.app');
   mkdirSync(app, { recursive: true });
+  mkdirSync(wdaTestBundlePath(keyDir), { recursive: true });
   writeFileSync(wdaXctestrunPath(keyDir), wdaXctestrun(port));
   const executable = wdaTestHostExecutable(keyDir);
   writeFileSync(executable, 'binary');
@@ -118,11 +132,16 @@ before(() => {
     if (!source.includes('<plist') || !source.trimEnd().endsWith('</plist>')) {
       return { status: 1 };
     }
+    if (!source.includes('<key>WebDriverAgentRunner</key>')) {
+      return { status: 0, stdout: '{}' };
+    }
     const port = /<key>USE_PORT<\/key>\s*<string>([^<]+)<\/string>/.exec(source)?.[1];
     return {
       status: 0,
       stdout: JSON.stringify({
         WebDriverAgentRunner: {
+          TestHostPath: '__TESTROOT__/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app',
+          TestBundlePath: '__TESTHOST__/PlugIns/WebDriverAgentRunner.xctest',
           EnvironmentVariables: port === undefined ? {} : { USE_PORT: port },
         },
       }),
@@ -141,6 +160,8 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     assert.equal(isCompleteWdaBuild(keyDir), false);
     writeCompleteWdaBuild(keyDir);
     assert.equal(isCompleteWdaBuild(keyDir), true);
+    writeFileSync(wdaXctestrunPath(keyDir), '<plist version="1.0"><dict/></plist>');
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'an empty xctestrun is not reusable');
     writeFileSync(wdaXctestrunPath(keyDir), '<plist version="1.0"><dict>');
     assert.equal(isCompleteWdaBuild(keyDir), false, 'a truncated xctestrun is not reusable');
     writeFileSync(
@@ -150,6 +171,49 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     assert.equal(isCompleteWdaBuild(keyDir), false, 'an XML-invalid xctestrun is not reusable');
     writeFileSync(wdaXctestrunPath(keyDir), wdaXctestrun());
     assert.equal(isCompleteWdaBuild(keyDir), true);
+    const testBundle = wdaTestBundlePath(keyDir);
+    rmSync(testBundle, { recursive: true });
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'a missing referenced product is incomplete');
+    mkdirSync(testBundle, { recursive: true });
+    assert.equal(isCompleteWdaBuild(keyDir), true);
+
+    const frameworks = join(wdaTestHostApp(keyDir), 'Frameworks');
+    mkdirSync(frameworks);
+    const internalTarget = join(
+      keyDir,
+      'DerivedData',
+      'Build',
+      'Products',
+      'InternalSupport',
+      'payload',
+    );
+    mkdirSync(dirname(internalTarget), { recursive: true });
+    writeFileSync(internalTarget, 'internal');
+    const internalLink = join(frameworks, 'internal-link');
+    symlinkSync(relative(frameworks, internalTarget), internalLink);
+    assert.equal(isCompleteWdaBuild(keyDir), true, 'an internal relative symlink stays reusable');
+    rmSync(internalLink);
+
+    const absoluteEscape = join(frameworks, 'absolute-escape');
+    symlinkSync('/usr/bin/true', absoluteEscape);
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'a deep absolute symlink escapes the key');
+    rmSync(absoluteEscape);
+    const externalTarget = join(root, 'external-product');
+    writeFileSync(externalTarget, 'external');
+    const relativeEscape = join(frameworks, 'relative-escape');
+    symlinkSync(relative(frameworks, externalTarget), relativeEscape);
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'a deep relative symlink escapes the key');
+    rmSync(relativeEscape);
+
+    const app = wdaTestHostApp(keyDir);
+    const externalApp = join(root, 'external-WDA.app');
+    renameSync(app, externalApp);
+    symlinkSync(externalApp, app);
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'the test-host app cannot escape the key');
+    rmSync(app);
+    renameSync(externalApp, app);
+    assert.equal(isCompleteWdaBuild(keyDir), true);
+
     const executable = wdaTestHostExecutable(keyDir);
     chmodSync(executable, 0o644);
     assert.equal(isCompleteWdaBuild(keyDir), false, 'a mode-stripped test host is not runnable');

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -128,7 +128,14 @@ test(
         );
 
       const storeBuilds = persistentWdaStoreBuildsRoot();
+      const arm64StoreBuilds = persistentWdaStoreBuildsRoot('darwin-arm64');
+      const x64StoreBuilds = persistentWdaStoreBuildsRoot('darwin-x64');
       assert.ok(storeBuilds);
+      assert.ok(arm64StoreBuilds);
+      assert.ok(x64StoreBuilds);
+      assert.notEqual(arm64StoreBuilds, x64StoreBuilds);
+      assert.match(arm64StoreBuilds!, /darwin-arm64/);
+      assert.match(x64StoreBuilds!, /darwin-x64/);
       assert.match(
         storeBuilds!,
         new RegExp(`\\.wda-store-${MAESTRO_RUNNER_PIN.version.replaceAll('.', '\\.')}`),

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -98,6 +98,10 @@ test('isCompleteWdaBuild requires the xctestrun and the test-host executable', (
     assert.equal(isCompleteWdaBuild(keyDir), false);
     writeCompleteWdaBuild(keyDir);
     assert.equal(isCompleteWdaBuild(keyDir), true);
+    writeFileSync(wdaXctestrunPath(keyDir), '<plist version="1.0"><dict>');
+    assert.equal(isCompleteWdaBuild(keyDir), false, 'a truncated xctestrun is not reusable');
+    writeFileSync(wdaXctestrunPath(keyDir), wdaXctestrun());
+    assert.equal(isCompleteWdaBuild(keyDir), true);
     const executable = wdaTestHostExecutable(keyDir);
     chmodSync(executable, 0o644);
     assert.equal(isCompleteWdaBuild(keyDir), false, 'a mode-stripped test host is not runnable');

--- a/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts
@@ -54,11 +54,38 @@ function wdaTestHostExecutable(keyDir: string): string {
   );
 }
 
-function writeCompleteWdaBuild(keyDir: string): void {
+function wdaXctestrunPath(keyDir: string): string {
+  return join(
+    keyDir,
+    'DerivedData',
+    'Build',
+    'Products',
+    'WebDriverAgentRunner_iphonesimulator26.5-arm64.xctestrun',
+  );
+}
+
+function wdaXctestrun(port?: number): string {
+  const environment =
+    port === undefined ? '' : `\n\t\t\t<key>USE_PORT</key>\n\t\t\t<string>${port}</string>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>WebDriverAgentRunner</key>
+\t<dict>
+\t\t<key>EnvironmentVariables</key>
+\t\t<dict>${environment}
+\t\t</dict>
+\t</dict>
+</dict>
+</plist>
+`;
+}
+
+function writeCompleteWdaBuild(keyDir: string, port?: number): void {
   const products = join(keyDir, 'DerivedData', 'Build', 'Products');
   const app = join(products, 'Debug-iphonesimulator', 'WebDriverAgentRunner-Runner.app');
   mkdirSync(app, { recursive: true });
-  writeFileSync(join(products, 'WebDriverAgentRunner_iphonesimulator26.5-arm64.xctestrun'), 'p');
+  writeFileSync(wdaXctestrunPath(keyDir), wdaXctestrun(port));
   const executable = wdaTestHostExecutable(keyDir);
   writeFileSync(executable, 'binary');
   chmodSync(executable, 0o755);
@@ -188,10 +215,20 @@ test(
       // Cold run: cache starts unseeded, the "runner" builds, publish captures it.
       await runIos((cacheLink) => {
         assert.equal(existsSync(join(cacheLink, 'wda-builds')), false);
-        writeCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
+        const keyDir = join(cacheLink, 'wda-builds', WDA_KEY);
+        writeCompleteWdaBuild(keyDir, 8447);
+        mkdirSync(join(keyDir, 'logs'), { recursive: true });
+        writeFileSync(join(keyDir, 'logs', 'runner.log'), 'device output');
+        mkdirSync(join(keyDir, 'DerivedData', 'Logs', 'Test'), { recursive: true });
+        writeFileSync(join(keyDir, 'DerivedData', 'Logs', 'Test', 'run.xcresult'), 'run output');
+        writeFileSync(join(keyDir, 'session.json'), '{"device":"current"}');
       });
-      assert.equal(isCompleteWdaBuild(join(storeBuilds!, WDA_KEY)), true);
-      assert.notEqual(statSync(wdaTestHostExecutable(join(storeBuilds!, WDA_KEY))).mode & 0o111, 0);
+      const storeKey = join(storeBuilds!, WDA_KEY);
+      assert.equal(isCompleteWdaBuild(storeKey), true);
+      assert.notEqual(statSync(wdaTestHostExecutable(storeKey)).mode & 0o111, 0);
+      assert.doesNotMatch(readFileSync(wdaXctestrunPath(storeKey), 'utf8'), /USE_PORT|8447/);
+      assert.deepEqual(readdirSync(storeKey), ['DerivedData']);
+      assert.equal(existsSync(join(storeKey, 'DerivedData', 'Logs')), false);
 
       // Warm run: the spawn cache is pre-seeded before the runner starts, and
       // the seeded xctestrun stays writable — the runner rewrites it to inject
@@ -204,12 +241,25 @@ test(
         'WebDriverAgentRunner_iphonesimulator26.5-arm64.xctestrun',
       ] as const;
       let warmSeeded = false;
+      let warmSeedOmittedRunState = false;
+      let warmSeedHasNoPriorPort = false;
       await runIos((cacheLink) => {
-        warmSeeded = isCompleteWdaBuild(join(cacheLink, 'wda-builds', WDA_KEY));
-        writeFileSync(join(cacheLink, 'wda-builds', WDA_KEY, ...xctestrunTail), 'port-injected');
+        const keyDir = join(cacheLink, 'wda-builds', WDA_KEY);
+        warmSeeded = isCompleteWdaBuild(keyDir);
+        warmSeedOmittedRunState =
+          !existsSync(join(keyDir, 'logs')) && !existsSync(join(keyDir, 'DerivedData', 'Logs'));
+        warmSeedHasNoPriorPort = !/USE_PORT|8447/.test(
+          readFileSync(join(keyDir, ...xctestrunTail), 'utf8'),
+        );
+        writeFileSync(join(keyDir, ...xctestrunTail), wdaXctestrun(8558));
       });
       assert.equal(warmSeeded, true);
-      assert.equal(readFileSync(join(storeBuilds!, WDA_KEY, ...xctestrunTail), 'utf8'), 'p');
+      assert.equal(warmSeedOmittedRunState, true);
+      assert.equal(warmSeedHasNoPriorPort, true);
+      assert.doesNotMatch(
+        readFileSync(join(storeBuilds!, WDA_KEY, ...xctestrunTail), 'utf8'),
+        /USE_PORT|8447|8558/,
+      );
 
       // The per-spawn caches are still removed; only the store persists.
       const versionsRoot = join(cache, 'maestro-runner');


### PR DESCRIPTION
## Intent

Fix the proven rn-dev-agent maestro-runner WDA cache reuse defect: consecutive invocations on the same simulator each print 'Building WebDriverAgent for the first time' and pay roughly 75-81 seconds, despite claiming cached builds are reused. Ship an independent PR from origin/main 4c417dc5 (PR 884); do not modify PR 881 or PR 882; do not merge. Required: the minimum safe cache ownership correction so compatible consecutive invocations reuse the built WDA artifact; cache identity must remain correct across runner version, Xcode/SDK, platform/runtime, architecture, simulator/device class, and build inputs already used by the project, without broader invalidation than evidence requires; preserve concurrent-run isolation, corruption recovery, ownership fences, cleanup of run-owned temporary state, and explicit cold-build fallback; never share session authority or device state through the build cache; no daemon, generalized cache service, new dependency, external issue, or merge. Acceptance includes causal cold/warm runnable checks, controls (incompatible key rebuilds, missing/corrupt artifact rebuilds safely, concurrent callers cannot consume a partial build), and a final two-run local-Mac cold/warm measurement at the exact final pushed head (to be repeated after this run lands - the prior 86a61d47 measurement is not claimed for a moved head).

Prior accepted state: the fix persists completed WDA builds in a store beside the pin-cache, .wda-store-<runner version>/<platformKey>/<xcode fingerprint>/wda-builds/<key>, seeded into each fresh per-spawn cache strictly AFTER the snapshot seal walk (Node's recursive readdirSync descends through the cache symlink; sealed seed content breaks the runner's warm-path xctestrun port rewrite) and published back via staging plus same-volume atomic rename, complete builds only, best-effort with cold-build fallback; per-spawn cache fences are byte-identical to before. Two earlier pipeline fixes are accepted on the branch: architecture partitioning of the store (nodePlatformKey(), gated on pinArchiveCoords) and publish-before-unseal so store artifacts keep executable modes.

This head adds two accepted current-head Codex P2 review corrections (firstmate-directed, bounded): (1) wdaToolchainFingerprint no longer memoizes for the supervisor lifetime - it probes xcodebuild -version on every call so an xcode-select switch or in-place Xcode update lands in a different store slot on the very next spawn; the test seam is preserved for unit control, and the regression swaps a PATH-shimmed fake xcodebuild between two probes and asserts the selected store slot changes; deliberately no invalidation subsystem, per the accepted preference for removing stale memoization. (2) isCompleteWdaBuild requires at least one execute bit on the test-host executable so a mode-stripped stored build is skipped and the runner cold-builds instead of repeatedly launching an unusable cache; regression proves a 0644 test host is rejected. Two xcodebuild -version subprocesses per iOS spawn (seed and publish) are an accepted cost against a multi-second runner invocation. Deliberately out of scope, previously accepted: store retention/eviction policy, synchronized concurrency race unit tests (atomicity is delegated to rename(2)), Windows test portability (pin has no win32 coords; the new shim regression skips on win32). Six macOS-only local test failures (action-engine-compat x5, save-as-action overwrite) are the AGENTS.md-documented TMPDIR known set failing identically on main; required CI runs Linux. Per the user's standing rule, no AI-attribution footers in commits or the PR body.

## What Changed

- Persist completed WebDriverAgent build products in a runner-version, host platform/architecture, and freshly probed Xcode toolchain store, then seed compatible per-spawn caches for reuse.
- Validate product containment, referenced bundles, and the runnable test-host executable; normalize run-specific ports and use staged atomic publication with cold-build fallback for missing, corrupt, incompatible, or unavailable entries.
- Add cache seed/publish diagnostics, troubleshooting guidance, and unit coverage for cold/warm reuse, toolchain and architecture partitioning, corruption recovery, and per-spawn cleanup.

## Risk Assessment

✅ Low: The cache reuse change is well-bounded and preserves per-spawn isolation, toolchain and architecture partitioning, atomic publication, containment checks, device-state normalization, and cold-build fallback without a substantiated remaining source defect.

## Testing

No prior baseline results were supplied. On darwin-arm64 at the target commit, focused cache, native-runner, and diagnostics tests passed; executable evidence demonstrated cold publish → warm seed/reuse, stripped device/run state, preserved executable mode, distinct architecture slots, and safe cold fallback for toolchain drift and corruption. This is non-UI engine behavior, so visual evidence does not apply; the accepted live-simulator timing measurement remains reserved for the final pushed head after checks pass.

<details>
<summary>Evidence: WDA cold/warm cache contract</summary>

`Cold build published one complete cache entry; the next spawn seeded it and used warm reuse. Incompatible toolchain and corrupted artifact controls cold-built safely.`

```text
{
  "candidateHead": "b0a6d2770396955f44df806abfec03f881f1a084",
  "platform": "darwin-arm64",
  "cold": {
    "result": "COLD_BUILD",
    "priorDevicePortSeen": false,
    "hardenedNativeRunnerLaunched": true,
    "seededBuilds": 0,
    "publishedBuilds": 1
  },
  "storeAfterCold": {
    "complete": true,
    "executableMode": "755",
    "priorDevicePortPersisted": false,
    "runOwnedStatePersisted": false,
    "rootEntries": [
      "DerivedData"
    ]
  },
  "warm": {
    "result": "WARM_REUSE",
    "priorDevicePortSeen": false,
    "hardenedNativeRunnerLaunched": true,
    "seededBuilds": 1,
    "publishedBuilds": 0
  },
  "controls": {
    "incompatibleToolchain": {
      "result": "COLD_BUILD",
      "priorDevicePortSeen": false,
      "hardenedNativeRunnerLaunched": true,
      "seededBuilds": 0,
      "publishedBuilds": 1
    },
    "corruptArtifact": {
      "result": "COLD_BUILD",
      "priorDevicePortSeen": false,
      "hardenedNativeRunnerLaunched": true,
      "seededBuilds": 0,
      "publishedBuilds": 1
    },
    "architectureSlotsAreDistinct": true
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cc2552d0cc1a1a50672b24c3f50f42ea64e42f7c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (4) ✅</summary>

- 🚨 `packages/rn-dev-agent-core/src/domain/engine-pin.ts:806` - Intent forbids sharing session authority or device state through the build cache, but this recursively publishes the entire per-spawn key after execution. The pinned runner has already injected the current device-derived WDA port into the `.xctestrun` and written device-specific runner logs beneath that key, so both persist and seed later spawns. Publish only reusable build material and normalize/remove run-owned port and log state before the atomic rename, or explicitly authorize this exception.

🔧 Fix: Persist only reusable device-neutral WDA build products
1 error still open:

- 🚨 `packages/rn-dev-agent-core/src/domain/engine-pin.ts:780` - The required “missing/corrupt artifact rebuilds safely” invariant remains false for a truncated or malformed `.xctestrun`: this predicate accepts any regular file with that suffix when the app executable remains. The pinned runner then finds that file, skips its cold build, and fails while parsing it for port injection, so no cold fallback occurs ([runner v1.1.24 behavior](https://github.com/devicelab-dev/maestro-runner/blob/v1.1.24/pkg/driver/wda/runner.go#L135-L140)). Validate that the xctestrun is structurally usable at this shared completeness boundary and add the corresponding corruption control.

🔧 Fix: Reject malformed WDA xctestrun cache artifacts
2 errors still open:

- 🚨 `packages/rn-dev-agent-core/src/domain/engine-pin.ts:819` - The custom plist parser accepts XML-invalid numeric references such as `&amp;#0;;` its entity check permits every decimal reference, so `isCompleteWdaBuild` can classify the artifact complete. The pinned runner then skips rebuilding because the xctestrun exists, but its `plutil -convert json` step rejects the file, violating the required corruption fallback. Because this parser was substantial prior-fixer machinery, replace it with the minimal exact `plutil` parse/normalization path rather than extending the custom grammar.
- 🚨 `packages/rn-dev-agent-core/src/domain/engine-pin.ts:925` - Completeness accepts any executable `.app`, not specifically the WDA test host. A valid xctestrun plus `Unrelated.app/Unrelated`, with `WebDriverAgentRunner-Runner.app` missing, returns true; the runner skips its cold build and `test-without-building` fails on the absent product. Require the exact `WebDriverAgentRunner-Runner.app/WebDriverAgentRunner-Runner` executable at this shared boundary.

🔧 Fix: Validate exact WDA artifacts through plutil
2 errors still open:

- 🚨 `packages/rn-dev-agent-core/src/domain/engine-pin.ts:864` - Acceptance requires “missing/corrupt artifact rebuilds safely,” but this accepts any plutil-parseable `.xctestrun`. With a valid empty plist (or an unrelated plist sorting before the WDA plist) plus the executable, the build is seeded as complete; the pinned runner finds the file, skips its cold build, injects no usable target, and fails at `test-without-building` ([cache check](https://github.com/devicelab-dev/maestro-runner/blob/v1.1.24/pkg/driver/wda/runner.go#L127-L130), [port injection](https://github.com/devicelab-dev/maestro-runner/blob/v1.1.24/pkg/driver/wda/runner.go#L323-L385)). At this shared boundary, validate that the runner-selected plist contains the WDA target and references present host/test products; the broader semantic predicate needs authorization because the prior correction was explicitly parse-only.
- 🚨 `packages/rn-dev-agent-core/src/domain/engine-pin.ts:870` - The required ownership fence remains bypassable because `lstatSync` checks only the final executable and follows an intermediate `WebDriverAgentRunner-Runner.app` symlink. A store containing `...app -&gt; /external/WDA.app` and a regular executable there passes completeness; `cpSync(..., verbatimSymlinks: true)` preserves the escape, so later spawns consume mutable state outside the store. Require the `.app` ancestor itself to be a real non-symlink directory before accepting the executable.

🔧 Fix: Enforce WDA manifest completeness and cache containment
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `corepack yarn build:core`
- `node --test packages/rn-dev-agent-core/test/unit/wda-cache-store-reuse.test.ts`
- `node --test --test-reporter=spec packages/rn-dev-agent-core/test/unit/with-immediate-pinned-runner.test.ts`
- `node --test --test-reporter=spec --test-name-pattern='runner diagnostics retain terminal lifecycle events' packages/rn-dev-agent-core/test/unit/runner-diagnostics.test.ts`
- <code>`node .tmp-wda-cache-evidence.mjs` — temporary evidence driver through the production cache wrapper and hardened native helper; removed afterward</code>
- <code>Parsed and validated `wda-cache-cold-warm-contract.json` against target commit `b0a6d2770396955f44df806abfec03f881f1a084`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
