### PR TITLE
fix(core): designate bare TextInputs for replay typing and unify stock TextInput typeText targets

### DIFF
--- a/.changeset/replay-textinput-designation.md
+++ b/.changeset/replay-textinput-designation.md
@@ -3,4 +3,4 @@
 'rn-dev-agent-plugin': patch
 ---
 
-Allow React-tree replay taps to designate an exact editable TextInput for only the adjacent inputText step without dispatching press or focus callbacks.
+Allow React-tree replay taps to designate an exact editable TextInput for only the adjacent inputText step without dispatching press or focus callbacks, and resolve a stock TextInput whose composite and host fibers share one onChangeText as a single typeText target instead of refusing it as ambiguous.

--- a/.changeset/replay-textinput-designation.md
+++ b/.changeset/replay-textinput-designation.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Allow React-tree replay taps to designate an exact editable TextInput for only the adjacent inputText step without dispatching press or focus callbacks.

--- a/apps/docs-site/src/content/docs/actions/index.mdx
+++ b/apps/docs-site/src/content/docs/actions/index.mdx
@@ -182,7 +182,10 @@ system-dialog, permission, and SpringBoard stages use XCTest/WDA. Results label 
 `react-tree`, `xctest-native`, or `partitioned`. A React-tree pass proves deterministic React
 identity and controlled fiber text read-back, not IME composition, AutoFill, keyboard
 occlusion, or secure native-entry fidelity, and it never promotes an action to
-Maestro-certified active status. Native WDA blindness is reported as
+Maestro-certified active status. A `tapOn` whose exact target is an editable `TextInput`
+without `onPress` only designates that input for the immediately following `inputText`: it
+dispatches no press and no `onFocus`, the step is reported as `focusOnly`, and a designation
+that the next step does not consume fails the replay. Native WDA blindness is reported as
 `NATIVE_SURFACE_BLIND` only when a bounded same-screen native snapshot saw the selector WDA
 missed; runtime version alone is never proof, and ordinary selector misses stay ordinary.
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -30509,7 +30509,7 @@ async function performExactFill(args, _client, tiers) {
     verification
   });
 }
-async function performReactTreeInput(testID, text, client2, signal) {
+async function performReactTreeInput(testID, text, client2, signal, options = {}) {
   const pathsTried = ["react-tree"];
   if (!client2) {
     return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" cannot be verified because the authoritative bundle is unavailable.`, { mutation: "none", pathsTried });
@@ -30533,28 +30533,47 @@ async function performReactTreeInput(testID, text, client2, signal) {
       return null;
     }
   };
-  const before = await readInput();
-  if (signal?.aborted) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
-      mutation: "none",
-      pathsTried
-    });
+  const designated = typeof options.designationToken === "string";
+  let requestedText = text;
+  if (!designated) {
+    const before = await readInput();
+    if (signal?.aborted) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
+        mutation: "none",
+        pathsTried
+      });
+    }
+    if (!before?.controlled) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
+    }
+    requestedText = `${before.value ?? ""}${text}`;
   }
-  if (!before?.controlled) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
-  }
-  const expected = `${before.value ?? ""}${text}`;
   let dispatch;
   try {
-    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({ action: "typeText", testID, text: expected, verify: true }) + ")");
+    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({
+      action: "typeText",
+      testID,
+      text: requestedText,
+      verify: true,
+      ...designated ? {
+        requireLiveInputDesignation: true,
+        designationToken: options.designationToken
+      } : {}
+    }) + ")");
     if (result.error || typeof result.value !== "string") {
       dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
     } else {
       const parsed = JSON.parse(result.value);
-      if (parsed.error)
-        dispatch = { error: parsed.error, mutation: "none" };
-      else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0) {
-        dispatch = { handler: parsed.handlerCalled };
+      if (parsed.error) {
+        const designationCode = parsed.code === "AMBIGUOUS_TESTID" || parsed.code === "ASSERTION_FAILED" || parsed.code === "INTERACTION_NOT_ACTUATED" ? parsed.code : void 0;
+        dispatch = {
+          error: parsed.error,
+          mutation: "none",
+          ...designationCode ? { code: designationCode } : {},
+          ...parsed.focusOnly === true ? { focusOnly: true } : {}
+        };
+      } else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0 && typeof parsed.text === "string") {
+        dispatch = { handler: parsed.handlerCalled, resultingText: parsed.text };
       } else {
         dispatch = { error: "dispatch result is inconclusive", mutation: "possible" };
       }
@@ -30563,6 +30582,14 @@ async function performReactTreeInput(testID, text, client2, signal) {
     dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
   }
   if ("error" in dispatch) {
+    if (dispatch.focusOnly) {
+      return failResult(`React-tree input "${testID}" refused: ${dispatch.error}`, dispatch.code ?? "TEXT_ENTRY_UNVERIFIED", {
+        mutation: dispatch.mutation,
+        pathsTried,
+        focusOnly: true,
+        hint: "No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying."
+      });
+    }
     return fillFailure("TEXT_ENTRY_UNVERIFIED", dispatch.mutation === "possible" ? `React-tree input "${testID}" may have mutated but its onChangeText result is unknown.` : `React-tree input "${testID}" has no verifiable controlled onChangeText path.`, { mutation: dispatch.mutation, pathsTried });
   }
   if (signal?.aborted) {
@@ -30571,6 +30598,7 @@ async function performReactTreeInput(testID, text, client2, signal) {
       pathsTried
     });
   }
+  const expected = dispatch.resultingText;
   let verification = "unreadable";
   let previous = null;
   let last = null;
@@ -51543,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 51;
+var HELPERS_VERSION = 56;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53732,7 +53760,261 @@ var INJECTED_HELPERS = `
     };
   }
 
+  function textInputDesignationDisabled(candidateProps) {
+    return candidateProps.disabled === true
+      || candidateProps.editable === false
+      || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+  }
+
+  function textInputDesignationInteractivity(input, selector) {
+    var current = input;
+    var seen = new WeakSet();
+    var depth = 0;
+    while (current && depth < 1000) {
+      if (seen.has(current)) {
+        return {
+          error: 'TextInput designation interactivity resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      seen.add(current);
+      if (isSubtreeInaccessible(current)) {
+        return {
+          error: 'TextInput designation target is hidden or occluded',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      var props = current.memoizedProps || {};
+      var pointerEvents = props.pointerEvents;
+      if (
+        current === input
+        && (pointerEvents === 'none' || pointerEvents === 'box-none')
+      ) {
+        return {
+          error: 'TextInput designation target is not user-interactable with pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      if (
+        current !== input
+        && (pointerEvents === 'none' || pointerEvents === 'box-only')
+      ) {
+        return {
+          error: 'TextInput designation target is blocked beneath pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      current = current.return;
+      depth++;
+    }
+    if (current) {
+      return {
+        error: 'TextInput designation interactivity resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    return null;
+  }
+
+  var activeTextInputDesignation = null;
+  var textInputDesignationSequence = 0;
+
+  function retainTextInputDesignation(input, selector) {
+    textInputDesignationSequence++;
+    var token = Date.now().toString(36) + '-' + textInputDesignationSequence.toString(36);
+    activeTextInputDesignation = {
+      token: token,
+      input: input,
+      selector: selector
+    };
+    return token;
+  }
+
+  function consumeTextInputDesignation(token, selector) {
+    var designation = activeTextInputDesignation;
+    if (
+      !designation
+      || designation.token !== token
+      || designation.selector !== selector
+    ) {
+      return null;
+    }
+    activeTextInputDesignation = null;
+    return designation;
+  }
+
+  function releaseInputDesignation(token) {
+    var released = !!activeTextInputDesignation
+      && activeTextInputDesignation.token === token;
+    if (released) activeTextInputDesignation = null;
+    return JSON.stringify({ released: released });
+  }
+
+  function isSameDesignatedInput(left, right) {
+    return !!left && !!right && (
+      left === right
+      || left.alternate === right
+      || right.alternate === left
+    );
+  }
+
+  function resolveTextInputDesignation(owner, selector) {
+    if (!owner) return null;
+    var designationStack = [owner];
+    var designationSeen = new WeakSet();
+    var designationMatches = [];
+    var designationInputs = [];
+    var designationWork = 0;
+    while (designationStack.length > 0 && designationWork < 2000) {
+      var designationFiber = designationStack.pop();
+      if (designationSeen.has(designationFiber)) continue;
+      designationSeen.add(designationFiber);
+      designationWork++;
+      var designationProps = designationFiber.memoizedProps || {};
+      var designationMatchesSelector = designationProps.testID === selector
+        || designationProps.nativeID === selector;
+      if (designationMatchesSelector) {
+        designationMatches.push(designationFiber);
+      }
+      if (
+        designationFiber.tag === 5
+        && typeof designationFiber.type === 'string'
+        && hostKind(designationFiber) === 'textinput'
+        && designationMatchesSelector
+      ) {
+        designationInputs.push(designationFiber);
+      }
+      var designationChild = designationFiber.child;
+      while (designationChild) {
+        designationStack.push(designationChild);
+        designationChild = designationChild.sibling;
+      }
+    }
+    if (designationStack.length > 0) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    if (designationInputs.length > 1) {
+      return {
+        error: 'Ambiguous TextInput designation target',
+        testID: selector,
+        count: designationInputs.length,
+        focusOnly: true
+      };
+    }
+    if (designationInputs.length !== 1) return null;
+    var designationInput = designationInputs[0];
+    var designationInputProps = designationInput.memoizedProps || {};
+    var designationLineage = new WeakSet();
+    var designationLineageFiber = designationInput;
+    var designationLineageDepth = 0;
+    while (designationLineageFiber && designationLineageDepth < 1000) {
+      if (designationLineage.has(designationLineageFiber)) {
+        return {
+          error: 'TextInput designation resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      designationLineage.add(designationLineageFiber);
+      if (designationLineageFiber === owner) break;
+      designationLineageFiber = designationLineageFiber.return;
+      designationLineageDepth++;
+    }
+    if (designationLineageFiber !== owner) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    for (var designationIndex = 0; designationIndex < designationMatches.length; designationIndex++) {
+      var designationMatch = designationMatches[designationIndex];
+      if (!designationLineage.has(designationMatch)) {
+        return {
+          error: 'Ambiguous TextInput designation target',
+          testID: selector,
+          count: designationMatches.length,
+          focusOnly: true
+        };
+      }
+      if (textInputDesignationDisabled(designationMatch.memoizedProps || {})) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          component: typeTextFiberName(designationInput),
+          testID: selector,
+          focusOnly: true
+        };
+      }
+    }
+    var designationInteractivity = textInputDesignationInteractivity(
+      designationInput,
+      selector
+    );
+    if (designationInteractivity) return designationInteractivity;
+    if (typeof designationInputProps.onPress === 'function') return null;
+    return {
+      success: true,
+      action: 'designateTextInput',
+      component: typeTextFiberName(designationInput),
+      testID: selector,
+      focusOnly: true,
+      inputFiber: designationInput
+    };
+  }
+
   function executeTypeTextTransaction(opts) {
+    var designationSelector = opts.testID;
+    var boundDesignation = null;
+    if (opts.requireLiveInputDesignation === true) {
+      boundDesignation = consumeTextInputDesignation(
+        opts.designationToken,
+        designationSelector
+      );
+      if (!boundDesignation) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveFrontmost;
+      try {
+        liveFrontmost = JSON.parse(isTestIdFrontmost(designationSelector));
+      } catch (_) {
+        liveFrontmost = null;
+      }
+      if (!liveFrontmost || liveFrontmost.visible !== true) {
+        return {
+          error: liveFrontmost && liveFrontmost.reason
+            ? liveFrontmost.reason
+            : 'TextInput designation frontmost state is unreadable',
+          code: liveFrontmost && liveFrontmost.code
+            ? liveFrontmost.code
+            : (liveFrontmost && liveFrontmost.matchCount > 1
+              ? 'AMBIGUOUS_TESTID'
+              : 'ASSERTION_FAILED'),
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var resolution = resolveTypeTextTarget(opts);
     if (resolution.error) return resolution;
     var binding = resolution.binding;
@@ -53747,7 +54029,107 @@ var INJECTED_HELPERS = `
         hint: 'Inspected every matching fiber and its bounded ownership graph \u2014 no typeable handler exists. Use cdp_component_tree to inspect the field, or pass the inner field testID directly.'
       };
     }
+    if (opts.requireLiveInputDesignation === true) {
+      var designationSourceProps = binding.sourceFiber.memoizedProps || {};
+      if (
+        typeof designationSelector !== 'string'
+        || !designationSelector
+        || hostKind(binding.sourceFiber) !== 'textinput'
+        || (
+          designationSourceProps.testID !== designationSelector
+          && designationSourceProps.nativeID !== designationSelector
+        )
+      ) {
+        return {
+          error: 'TextInput designation no longer resolves to the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationOwner = binding.sourceFiber;
+      var designationOwnerCursor = binding.sourceFiber.return;
+      var designationOwnerSeen = new WeakSet();
+      var designationOwnerDepth = 0;
+      while (designationOwnerCursor && designationOwnerDepth < 1000) {
+        if (designationOwnerSeen.has(designationOwnerCursor)) {
+          designationOwnerCursor = null;
+          designationOwnerDepth = 1000;
+          break;
+        }
+        designationOwnerSeen.add(designationOwnerCursor);
+        designationOwnerDepth++;
+        var designationOwnerProps = designationOwnerCursor.memoizedProps || {};
+        if (
+          designationOwnerProps.testID === designationSelector
+          || designationOwnerProps.nativeID === designationSelector
+        ) {
+          designationOwner = designationOwnerCursor;
+        }
+        designationOwnerCursor = designationOwnerCursor.return;
+      }
+      if (designationOwnerCursor || designationOwnerDepth >= 1000) {
+        return {
+          error: 'TextInput designation ownership resolution truncated',
+          code: 'ASSERTION_FAILED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveDesignation = resolveTextInputDesignation(designationOwner, designationSelector);
+      if (!liveDesignation || liveDesignation.success !== true) {
+        if (!liveDesignation) {
+          return {
+            error: 'TextInput designation no longer resolves to the exact host input',
+            code: 'INTERACTION_NOT_ACTUATED',
+            testID: designationSelector,
+            focusOnly: true,
+            handlerCalled: false
+          };
+        }
+        liveDesignation.code = liveDesignation.truncated === true
+          ? 'ASSERTION_FAILED'
+          : 'INTERACTION_NOT_ACTUATED';
+        liveDesignation.handlerCalled = false;
+        return liveDesignation;
+      }
+      if (
+        !isSameDesignatedInput(boundDesignation.input, binding.sourceFiber)
+        || !isSameDesignatedInput(boundDesignation.input, liveDesignation.inputFiber)
+      ) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationCandidateProps = binding.candidateFiber.memoizedProps || {};
+      if (textInputDesignationDisabled(designationCandidateProps)) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          component: binding.component,
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      if (binding.controlled !== true) {
+        return {
+          error: 'TextInput designation is uncontrolled or unreadable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var text = opts.text !== undefined ? opts.text : '';
+    if (boundDesignation) text = (binding.valueBefore || '') + text;
     try {
       if (binding.contract === 'onChangeText:string') binding.handler(text);
       else binding.handler({ nativeEvent: { text: text } });
@@ -54082,70 +54464,16 @@ var INJECTED_HELPERS = `
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
           if (opts.allowInputDesignation === true && opts.testID) {
-            var designationStack = [found];
-            var designationSeen = new WeakSet();
-            var designationInputs = [];
-            var designationWork = 0;
-            while (designationStack.length > 0 && designationWork < 2000) {
-              var designationFiber = designationStack.pop();
-              if (designationSeen.has(designationFiber)) continue;
-              designationSeen.add(designationFiber);
-              designationWork++;
-              var designationProps = designationFiber.memoizedProps || {};
-              if (
-                designationFiber.tag === 5
-                && typeof designationFiber.type === 'string'
-                && hostKind(designationFiber) === 'textinput'
-                && (designationProps.testID === selector || designationProps.nativeID === selector)
-              ) {
-                designationInputs.push(designationFiber);
+            var designation = resolveTextInputDesignation(found, selector);
+            if (designation) {
+              if (designation.success === true) {
+                designation.designationToken = retainTextInputDesignation(
+                  designation.inputFiber,
+                  selector
+                );
+                delete designation.inputFiber;
               }
-              var designationChild = designationFiber.child;
-              while (designationChild) {
-                designationStack.push(designationChild);
-                designationChild = designationChild.sibling;
-              }
-            }
-            if (designationStack.length > 0) {
-              return JSON.stringify({
-                error: 'TextInput designation resolution truncated',
-                testID: selector,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length > 1) {
-              return JSON.stringify({
-                error: 'Ambiguous TextInput designation target',
-                testID: selector,
-                count: designationInputs.length,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length === 1) {
-              var designationInput = designationInputs[0];
-              var designationInputProps = designationInput.memoizedProps || {};
-              var designationDisabled = function(candidateProps) {
-                return candidateProps.disabled === true
-                  || candidateProps.editable === false
-                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
-              };
-              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
-                return JSON.stringify({
-                  error: 'TextInput is disabled or non-editable',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
-              if (typeof designationInputProps.onPress !== 'function') {
-                return JSON.stringify({
-                  success: true,
-                  action: 'designateTextInput',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
+              return JSON.stringify(designation);
             }
           }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
@@ -55682,6 +56010,7 @@ var INJECTED_HELPERS = `
     getStoreState: getStoreState,
     getComponentState: getComponentState,
     readInputValue: readInputValue,
+    releaseInputDesignation: releaseInputDesignation,
     dispatchAction: dispatchAction,
     getErrors: getErrors,
     clearErrors: clearErrors,
@@ -79384,6 +79713,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
+  let staleDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -79398,12 +79728,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
       throw new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline");
     }
   };
+  const releaseDesignation = async (token2) => {
+    try {
+      await dispatch.releaseDesignation?.(token2);
+    } catch {
+    }
+  };
+  const releasePendingDesignation = async () => {
+    const designation = pendingDesignation;
+    pendingDesignation = null;
+    if (designation)
+      await releaseDesignation(designation.token);
+  };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
-    if (pendingDesignation && s.t !== "type")
+    let stepFocusOnly;
+    if (pendingDesignation && s.t !== "type") {
+      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      const staleToken = pendingDesignation.token;
       pendingDesignation = null;
+      await releaseDesignation(staleToken);
+    }
     try {
       requireNotAborted();
       switch (s.t) {
@@ -79419,28 +79766,38 @@ async function replayFlow(steps, dispatch, opts = {}) {
           break;
         case "tap":
           const pressResult = await dispatch.press(s.id);
-          requireNotAborted();
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = s.id;
+            pendingDesignation = { id: s.id, token: pressResult.token };
+            stepFocusOnly = true;
           } else {
             lastTapped = s.id;
           }
+          requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
-            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
+            ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          const target = pendingDesignation ?? lastTapped;
+          const designation = pendingDesignation;
+          const target = designation?.id ?? lastTapped;
           if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
-          await dispatch.type(target, s.text);
+          try {
+            await dispatch.type(target, s.text, designation ? {
+              focusOnlyDesignation: true,
+              designationToken: designation.token
+            } : void 0);
+          } finally {
+            if (designation)
+              await releaseDesignation(designation.token);
+          }
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -79529,10 +79886,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
       }
     } catch (e) {
       const waitedMs = Date.now() - startedAt;
+      await releasePendingDesignation();
       trace.push({
         sourceIndex: sourceIndex(i),
         t: evidenceType,
         target: "id" in s ? s.id : void 0,
+        ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
         ok: false,
         durationMs: waitedMs
       });
@@ -79541,10 +79900,15 @@ async function replayFlow(steps, dispatch, opts = {}) {
     }
   }
   if (opts.signal?.aborted) {
+    await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  if (pendingDesignation) {
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  if (unconsumedDesignation) {
+    if (pendingDesignation) {
+      await releasePendingDesignation();
+    }
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -79839,10 +80203,14 @@ function createReplayPressByTestId(interact) {
     }
     if (envelope.data?.action !== "designateTextInput")
       return { kind: "press" };
-    if (envelope.data.focusOnly !== true) {
+    if (envelope.data.focusOnly !== true || typeof envelope.data.designationToken !== "string" || envelope.data.designationToken.length === 0) {
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
     }
-    return { kind: "designation", focusOnly: true };
+    return {
+      kind: "designation",
+      focusOnly: true,
+      token: envelope.data.designationToken
+    };
   };
 }
 function nodeProps(treeJson, id) {
@@ -79946,10 +80314,13 @@ function buildCdpDispatch(deps, signal) {
       requireNotAborted();
       return deps.pressByTestId(id);
     },
-    async type(id, text) {
+    async type(id, text, context) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.typeByTestId(id, text);
+      await deps.typeByTestId(id, text, context);
+    },
+    async releaseDesignation(token2) {
+      await deps.releaseInputDesignation?.(token2);
     },
     async visibility(id) {
       await deps.treeFor(id);
@@ -94502,8 +94873,14 @@ var makeReplayDeps = (_args, signal) => {
   const tree = createComponentTreeHandler(getClient);
   return {
     pressByTestId: createReplayPressByTestId(interact),
-    typeByTestId: async (id, text) => {
-      mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
+    typeByTestId: async (id, text, context) => {
+      mustOk(await performReactTreeInput(id, text, getClient(), signal, context ? { designationToken: context.designationToken } : {}), `type "${id}"`);
+    },
+    releaseInputDesignation: async (token2) => {
+      try {
+        await getClient().evaluate(`__RN_AGENT.releaseInputDesignation(${JSON.stringify(token2)})`);
+      } catch {
+      }
     },
     treeFor: async (id) => {
       const fetchTree = async (interactiveOnly) => JSON.parse((await tree({

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51571,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 56;
+var HELPERS_VERSION = 57;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53763,6 +53763,7 @@ var INJECTED_HELPERS = `
   function textInputDesignationDisabled(candidateProps) {
     return candidateProps.disabled === true
       || candidateProps.editable === false
+      || candidateProps.readOnly === true
       || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
   }
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79747,7 +79747,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const startedAt = Date.now();
     let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      staleDesignation = staleDesignation ?? {
+        id: pendingDesignation.id,
+        index: pendingDesignation.index
+      };
       const staleToken = pendingDesignation.token;
       pendingDesignation = null;
       await releaseDesignation(staleToken);
@@ -79769,7 +79772,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const pressResult = await dispatch.press(s.id);
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = { id: s.id, token: pressResult.token };
+            pendingDesignation = { id: s.id, token: pressResult.token, index: i };
             stepFocusOnly = true;
           } else {
             lastTapped = s.id;
@@ -79904,12 +79907,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
     await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
   if (unconsumedDesignation) {
     if (pendingDesignation) {
       await releasePendingDesignation();
     }
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
+    return fail3(unconsumedDesignation.index, `TextInput designation for "${unconsumedDesignation.id}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation.id, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 50;
+var HELPERS_VERSION = 51;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -54081,6 +54081,73 @@ var INJECTED_HELPERS = `
 
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
+          if (opts.allowInputDesignation === true && opts.testID) {
+            var designationStack = [found];
+            var designationSeen = new WeakSet();
+            var designationInputs = [];
+            var designationWork = 0;
+            while (designationStack.length > 0 && designationWork < 2000) {
+              var designationFiber = designationStack.pop();
+              if (designationSeen.has(designationFiber)) continue;
+              designationSeen.add(designationFiber);
+              designationWork++;
+              var designationProps = designationFiber.memoizedProps || {};
+              if (
+                designationFiber.tag === 5
+                && typeof designationFiber.type === 'string'
+                && hostKind(designationFiber) === 'textinput'
+                && (designationProps.testID === selector || designationProps.nativeID === selector)
+              ) {
+                designationInputs.push(designationFiber);
+              }
+              var designationChild = designationFiber.child;
+              while (designationChild) {
+                designationStack.push(designationChild);
+                designationChild = designationChild.sibling;
+              }
+            }
+            if (designationStack.length > 0) {
+              return JSON.stringify({
+                error: 'TextInput designation resolution truncated',
+                testID: selector,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length > 1) {
+              return JSON.stringify({
+                error: 'Ambiguous TextInput designation target',
+                testID: selector,
+                count: designationInputs.length,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length === 1) {
+              var designationInput = designationInputs[0];
+              var designationInputProps = designationInput.memoizedProps || {};
+              var designationDisabled = function(candidateProps) {
+                return candidateProps.disabled === true
+                  || candidateProps.editable === false
+                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+              };
+              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
+                return JSON.stringify({
+                  error: 'TextInput is disabled or non-editable',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+              if (typeof designationInputProps.onPress !== 'function') {
+                return JSON.stringify({
+                  success: true,
+                  action: 'designateTextInput',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+            }
+          }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
         }
         if (opts.value !== undefined) {
@@ -79316,6 +79383,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
+  let pendingDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -79334,6 +79402,8 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    if (pendingDesignation && s.t !== "type")
+      pendingDesignation = null;
     try {
       requireNotAborted();
       switch (s.t) {
@@ -79348,26 +79418,34 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         case "tap":
-          await dispatch.press(s.id);
+          const pressResult = await dispatch.press(s.id);
           requireNotAborted();
-          lastTapped = s.id;
+          if (pressResult?.kind === "designation") {
+            lastTapped = null;
+            pendingDesignation = s.id;
+          } else {
+            lastTapped = s.id;
+          }
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
+            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          if (!lastTapped)
+          const target = pendingDesignation ?? lastTapped;
+          if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
-          await dispatch.type(lastTapped, s.text);
+          pendingDesignation = null;
+          await dispatch.type(target, s.text);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
-            target: lastTapped,
+            target,
             ok: true,
             durationMs: Date.now() - startedAt
           });
@@ -79464,6 +79542,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   if (opts.signal?.aborted) {
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
+  }
+  if (pendingDesignation) {
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -79744,6 +79825,26 @@ function replayTreeData(envelope) {
     }
   });
 }
+function createReplayPressByTestId(interact) {
+  return async (id) => {
+    const result = await interact({
+      action: "press",
+      testID: id,
+      animated: false,
+      allowInputDesignation: true
+    });
+    const envelope = JSON.parse(result.content[0]?.text ?? "{}");
+    if (envelope.ok === false) {
+      throw new ReplayDispatchError(envelope.code ?? "INTERACTION_NOT_ACTUATED", `press "${id}" failed: ${envelope.error ?? "ok:false"}`, envelope.meta);
+    }
+    if (envelope.data?.action !== "designateTextInput")
+      return { kind: "press" };
+    if (envelope.data.focusOnly !== true) {
+      throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
+    }
+    return { kind: "designation", focusOnly: true };
+  };
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -79843,7 +79944,7 @@ function buildCdpDispatch(deps, signal) {
     async press(id) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.pressByTestId(id);
+      return deps.pressByTestId(id);
     },
     async type(id, text) {
       await assertExactInteractable(id);
@@ -80388,9 +80489,12 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
-              if (step.t === "tap" && step.target)
-                reactFocusId = step.target;
+              if (step.t === "tap" && step.target) {
+                reactFocusId = step.focusOnly ? void 0 : step.target;
+              }
             }
+            if (replay.finalFocusId === null)
+              reactFocusId = void 0;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;
@@ -80400,6 +80504,7 @@ function createMaestroRunHandler(deps = {}) {
                 index: sourceIndices[step.sourceIndex] ?? step.sourceIndex,
                 name: step.t,
                 verb: step.t,
+                ...step.focusOnly ? { focusOnly: true } : {},
                 status: step.ok ? "pass" : "fail",
                 durationMs: step.durationMs
               });
@@ -80475,6 +80580,7 @@ function createMaestroRunHandler(deps = {}) {
                 name: String(record2.t ?? "unknown"),
                 verb: String(record2.t ?? "unknown"),
                 ...record2.target !== void 0 ? { target: String(record2.target) } : {},
+                ...record2.focusOnly === true ? { focusOnly: true } : {},
                 status: record2.ok === false ? "fail" : "pass",
                 durationMs: Number(record2.durationMs ?? 0)
               });
@@ -80489,6 +80595,7 @@ function createMaestroRunHandler(deps = {}) {
               index: failure.sourceIndices[step.sourceIndex] ?? step.sourceIndex,
               name: step.t,
               verb: step.t,
+              ...step.focusOnly ? { focusOnly: true } : {},
               status: step.ok ? "pass" : "fail",
               durationMs: step.durationMs
             });
@@ -82629,6 +82736,8 @@ function createInteractHandler(getClient2) {
       opts.includeHidden = args.includeHidden;
     if (args.walkUp !== void 0)
       opts.walkUp = args.walkUp;
+    if (args.allowInputDesignation !== void 0)
+      opts.allowInputDesignation = args.allowInputDesignation;
     const result = await client2.evaluate(`__RN_AGENT.interact(${JSON.stringify(opts)})`);
     if (result.error) {
       return failResult(`Interact error: ${result.error}`);
@@ -94392,9 +94501,7 @@ var makeReplayDeps = (_args, signal) => {
   const interact = createInteractHandler(getClient);
   const tree = createComponentTreeHandler(getClient);
   return {
-    pressByTestId: async (id) => {
-      mustOk(await interact({ action: "press", testID: id, animated: false }), `press "${id}"`);
-    },
+    pressByTestId: createReplayPressByTestId(interact),
     typeByTestId: async (id, text) => {
       mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
     },

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51571,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 58;
+var HELPERS_VERSION = 59;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53724,6 +53724,38 @@ var INJECTED_HELPERS = `
         });
       }
     }
+
+    function bindingDescendsFrom(descendant, ancestor) {
+      var cursor = descendant.candidateFiber.return;
+      var returnSeen = new WeakSet();
+      while (cursor) {
+        if (!consumeWork()) return false;
+        if (returnSeen.has(cursor)) {
+          state.truncated = true;
+          state.reason = 'cycle';
+          return false;
+        }
+        returnSeen.add(cursor);
+        if (sameTypeTextFiber(cursor, ancestor.candidateFiber)) return true;
+        cursor = cursor.return;
+      }
+      return false;
+    }
+
+    // RN TextInput renders one element as a composite fiber plus its host child sharing one handler; keep the deepest (press's match-deepest-only rule).
+    function collapseLineageBindings(all) {
+      return all.filter(function(binding) {
+        return !all.some(function(other) {
+          return !state.truncated
+            && other !== binding
+            && other.handler === binding.handler
+            && other.contract === binding.contract
+            && bindingDescendsFrom(other, binding);
+        });
+      });
+    }
+
+    if (!state.truncated && bindings.length > 1) bindings = collapseLineageBindings(bindings);
 
     if (state.truncated) return typeTextTruncation(state);
     if (bindings.length > 1) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51571,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 57;
+var HELPERS_VERSION = 58;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53775,6 +53775,7 @@ var INJECTED_HELPERS = `
       if (seen.has(current)) {
         return {
           error: 'TextInput designation interactivity resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -53816,6 +53817,7 @@ var INJECTED_HELPERS = `
     if (current) {
       return {
         error: 'TextInput designation interactivity resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -53901,6 +53903,7 @@ var INJECTED_HELPERS = `
     if (designationStack.length > 0) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -53924,6 +53927,7 @@ var INJECTED_HELPERS = `
       if (designationLineage.has(designationLineageFiber)) {
         return {
           error: 'TextInput designation resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -53937,6 +53941,7 @@ var INJECTED_HELPERS = `
     if (designationLineageFiber !== owner) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -83130,7 +83135,8 @@ function createInteractHandler(getClient2) {
       return failResult(`Interact returned non-JSON: ${result.value.slice(0, 200)}`);
     }
     if (parsed.error) {
-      return failResult(`Interact failed: ${parsed.error}`, pickDefined(parsed, REFUSAL_FIELDS));
+      const refusal = pickDefined(parsed, REFUSAL_FIELDS);
+      return parsed.code === "ASSERTION_FAILED" ? failResult(`Interact failed: ${parsed.error}`, "ASSERTION_FAILED", refusal) : failResult(`Interact failed: ${parsed.error}`, refusal);
     }
     if (parsed.action_executed && parsed.handler_error) {
       return failResult(`Action executed but handler threw: ${parsed.handler_error}`, {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79715,6 +79715,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
   let staleDesignation = null;
+  let consumedDesignationId = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -79791,8 +79792,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const designation = pendingDesignation;
           const target = designation?.id ?? lastTapped;
           if (!target)
-            return fail3(i, "inputText before any tapOn \u2014 no focus target");
+            return fail3(i, consumedDesignationId ? `the TextInput designation for "${consumedDesignationId}" was already consumed \u2014 tapOn the field again before typing` : "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
+          if (designation)
+            consumedDesignationId = designation.id;
           try {
             await dispatch.type(target, s.text, designation ? {
               focusOnlyDesignation: true,
@@ -80850,7 +80853,7 @@ function createMaestroRunHandler(deps = {}) {
             });
           }
           let stageCursor = 0;
-          let reactFocusId = retainedReactFocusId ?? segment.initialReactFocusId;
+          let reactFocusId = retainedReactFocusId === void 0 ? segment.initialReactFocusId : retainedReactFocusId;
           const stageResults = await executeMaestroAuthorityStages(segment.commands, async (commands) => {
             const sourceIndices = segment.sourceIndices.slice(stageCursor, stageCursor + commands.length);
             stageCursor += commands.length;
@@ -80858,18 +80861,18 @@ function createMaestroRunHandler(deps = {}) {
               ...replayDependencies,
               launchApp: async () => {
               }
-            }, { signal: controller.signal, initialFocusId: reactFocusId });
+            }, { signal: controller.signal, initialFocusId: reactFocusId ?? void 0 });
             if (!replay.passed)
               throw new ReactReplayFailure(replay, sourceIndices);
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
               if (step.t === "tap" && step.target) {
-                reactFocusId = step.focusOnly ? void 0 : step.target;
+                reactFocusId = step.focusOnly ? null : step.target;
               }
             }
             if (replay.finalFocusId === null)
-              reactFocusId = void 0;
+              reactFocusId = null;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15650,6 +15650,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
+  let staleDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -15668,8 +15669,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
-    if (pendingDesignation && s.t !== "type")
+    if (pendingDesignation && s.t !== "type") {
+      staleDesignation = staleDesignation ?? pendingDesignation;
       pendingDesignation = null;
+    }
     try {
       requireNotAborted();
       switch (s.t) {
@@ -15810,8 +15813,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   if (opts.signal?.aborted) {
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  if (pendingDesignation) {
-    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
+  if (unconsumedDesignation) {
+    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15665,13 +15665,28 @@ async function replayFlow(steps, dispatch, opts = {}) {
       throw new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline");
     }
   };
+  const releaseDesignation = async (token2) => {
+    try {
+      await dispatch.releaseDesignation?.(token2);
+    } catch {
+    }
+  };
+  const releasePendingDesignation = async () => {
+    const designation = pendingDesignation;
+    pendingDesignation = null;
+    if (designation)
+      await releaseDesignation(designation.token);
+  };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation;
+      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      const staleToken = pendingDesignation.token;
       pendingDesignation = null;
+      await releaseDesignation(staleToken);
     }
     try {
       requireNotAborted();
@@ -15688,29 +15703,38 @@ async function replayFlow(steps, dispatch, opts = {}) {
           break;
         case "tap":
           const pressResult = await dispatch.press(s.id);
-          requireNotAborted();
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = s.id;
+            pendingDesignation = { id: s.id, token: pressResult.token };
+            stepFocusOnly = true;
           } else {
             lastTapped = s.id;
           }
+          requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
-            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
+            ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          const target = pendingDesignation ?? lastTapped;
+          const designation = pendingDesignation;
+          const target = designation?.id ?? lastTapped;
           if (!target)
             return fail(i, "inputText before any tapOn \u2014 no focus target");
-          const focusOnlyDesignation = pendingDesignation !== null;
           pendingDesignation = null;
-          await dispatch.type(target, s.text, focusOnlyDesignation ? { focusOnlyDesignation: true } : void 0);
+          try {
+            await dispatch.type(target, s.text, designation ? {
+              focusOnlyDesignation: true,
+              designationToken: designation.token
+            } : void 0);
+          } finally {
+            if (designation)
+              await releaseDesignation(designation.token);
+          }
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -15799,10 +15823,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
       }
     } catch (e) {
       const waitedMs = Date.now() - startedAt;
+      await releasePendingDesignation();
       trace.push({
         sourceIndex: sourceIndex(i),
         t: evidenceType,
         target: "id" in s ? s.id : void 0,
+        ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
         ok: false,
         durationMs: waitedMs
       });
@@ -15811,10 +15837,14 @@ async function replayFlow(steps, dispatch, opts = {}) {
     }
   }
   if (opts.signal?.aborted) {
+    await releasePendingDesignation();
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
   if (unconsumedDesignation) {
+    if (pendingDesignation) {
+      await releasePendingDesignation();
+    }
     return fail(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
@@ -16167,6 +16197,9 @@ function buildCdpDispatch(deps, signal) {
       await assertExactInteractable(id);
       requireNotAborted();
       await deps.typeByTestId(id, text, context);
+    },
+    async releaseDesignation(token2) {
+      await deps.releaseInputDesignation?.(token2);
     },
     async visibility(id) {
       await deps.treeFor(id);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15705,8 +15705,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const target = pendingDesignation ?? lastTapped;
           if (!target)
             return fail(i, "inputText before any tapOn \u2014 no focus target");
+          const focusOnlyDesignation = pendingDesignation !== null;
           pendingDesignation = null;
-          await dispatch.type(target, s.text);
+          await dispatch.type(target, s.text, focusOnlyDesignation ? { focusOnlyDesignation: true } : void 0);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -16158,10 +16159,10 @@ function buildCdpDispatch(deps, signal) {
       requireNotAborted();
       return deps.pressByTestId(id);
     },
-    async type(id, text) {
+    async type(id, text, context) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.typeByTestId(id, text);
+      await deps.typeByTestId(id, text, context);
     },
     async visibility(id) {
       await deps.treeFor(id);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15649,6 +15649,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
+  let pendingDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -15667,6 +15668,8 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    if (pendingDesignation && s.t !== "type")
+      pendingDesignation = null;
     try {
       requireNotAborted();
       switch (s.t) {
@@ -15681,26 +15684,34 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         case "tap":
-          await dispatch.press(s.id);
+          const pressResult = await dispatch.press(s.id);
           requireNotAborted();
-          lastTapped = s.id;
+          if (pressResult?.kind === "designation") {
+            lastTapped = null;
+            pendingDesignation = s.id;
+          } else {
+            lastTapped = s.id;
+          }
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
+            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          if (!lastTapped)
+          const target = pendingDesignation ?? lastTapped;
+          if (!target)
             return fail(i, "inputText before any tapOn \u2014 no focus target");
-          await dispatch.type(lastTapped, s.text);
+          pendingDesignation = null;
+          await dispatch.type(target, s.text);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
-            target: lastTapped,
+            target,
             ok: true,
             durationMs: Date.now() - startedAt
           });
@@ -15797,6 +15808,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   if (opts.signal?.aborted) {
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
+  }
+  if (pendingDesignation) {
+    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -16142,7 +16156,7 @@ function buildCdpDispatch(deps, signal) {
     async press(id) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.pressByTestId(id);
+      return deps.pressByTestId(id);
     },
     async type(id, text) {
       await assertExactInteractable(id);
@@ -16687,9 +16701,12 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
-              if (step.t === "tap" && step.target)
-                reactFocusId = step.target;
+              if (step.t === "tap" && step.target) {
+                reactFocusId = step.focusOnly ? void 0 : step.target;
+              }
             }
+            if (replay.finalFocusId === null)
+              reactFocusId = void 0;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;
@@ -16699,6 +16716,7 @@ function createMaestroRunHandler(deps = {}) {
                 index: sourceIndices[step.sourceIndex] ?? step.sourceIndex,
                 name: step.t,
                 verb: step.t,
+                ...step.focusOnly ? { focusOnly: true } : {},
                 status: step.ok ? "pass" : "fail",
                 durationMs: step.durationMs
               });
@@ -16774,6 +16792,7 @@ function createMaestroRunHandler(deps = {}) {
                 name: String(record.t ?? "unknown"),
                 verb: String(record.t ?? "unknown"),
                 ...record.target !== void 0 ? { target: String(record.target) } : {},
+                ...record.focusOnly === true ? { focusOnly: true } : {},
                 status: record.ok === false ? "fail" : "pass",
                 durationMs: Number(record.durationMs ?? 0)
               });
@@ -16788,6 +16807,7 @@ function createMaestroRunHandler(deps = {}) {
               index: failure.sourceIndices[step.sourceIndex] ?? step.sourceIndex,
               name: step.t,
               verb: step.t,
+              ...step.focusOnly ? { focusOnly: true } : {},
               status: step.ok ? "pass" : "fail",
               durationMs: step.durationMs
             });

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15651,6 +15651,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
   let staleDesignation = null;
+  let consumedDesignationId = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -15727,8 +15728,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const designation = pendingDesignation;
           const target = designation?.id ?? lastTapped;
           if (!target)
-            return fail(i, "inputText before any tapOn \u2014 no focus target");
+            return fail(i, consumedDesignationId ? `the TextInput designation for "${consumedDesignationId}" was already consumed \u2014 tapOn the field again before typing` : "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
+          if (designation)
+            consumedDesignationId = designation.id;
           try {
             await dispatch.type(target, s.text, designation ? {
               focusOnlyDesignation: true,
@@ -16728,7 +16731,7 @@ function createMaestroRunHandler(deps = {}) {
             });
           }
           let stageCursor = 0;
-          let reactFocusId = retainedReactFocusId ?? segment.initialReactFocusId;
+          let reactFocusId = retainedReactFocusId === void 0 ? segment.initialReactFocusId : retainedReactFocusId;
           const stageResults = await executeMaestroAuthorityStages(segment.commands, async (commands) => {
             const sourceIndices = segment.sourceIndices.slice(stageCursor, stageCursor + commands.length);
             stageCursor += commands.length;
@@ -16736,18 +16739,18 @@ function createMaestroRunHandler(deps = {}) {
               ...replayDependencies,
               launchApp: async () => {
               }
-            }, { signal: controller.signal, initialFocusId: reactFocusId });
+            }, { signal: controller.signal, initialFocusId: reactFocusId ?? void 0 });
             if (!replay.passed)
               throw new ReactReplayFailure(replay, sourceIndices);
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
               if (step.t === "tap" && step.target) {
-                reactFocusId = step.focusOnly ? void 0 : step.target;
+                reactFocusId = step.focusOnly ? null : step.target;
               }
             }
             if (replay.finalFocusId === null)
-              reactFocusId = void 0;
+              reactFocusId = null;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15683,7 +15683,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const startedAt = Date.now();
     let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      staleDesignation = staleDesignation ?? {
+        id: pendingDesignation.id,
+        index: pendingDesignation.index
+      };
       const staleToken = pendingDesignation.token;
       pendingDesignation = null;
       await releaseDesignation(staleToken);
@@ -15705,7 +15708,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const pressResult = await dispatch.press(s.id);
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = { id: s.id, token: pressResult.token };
+            pendingDesignation = { id: s.id, token: pressResult.token, index: i };
             stepFocusOnly = true;
           } else {
             lastTapped = s.id;
@@ -15840,12 +15843,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
     await releasePendingDesignation();
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
   if (unconsumedDesignation) {
     if (pendingDesignation) {
       await releasePendingDesignation();
     }
-    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
+    return fail(unconsumedDesignation.index, `TextInput designation for "${unconsumedDesignation.id}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation.id, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63945,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 57;
+    HELPERS_VERSION = 58;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66149,6 +66149,7 @@ var init_injected_helpers = __esm({
       if (seen.has(current)) {
         return {
           error: 'TextInput designation interactivity resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -66190,6 +66191,7 @@ var init_injected_helpers = __esm({
     if (current) {
       return {
         error: 'TextInput designation interactivity resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -66275,6 +66277,7 @@ var init_injected_helpers = __esm({
     if (designationStack.length > 0) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -66298,6 +66301,7 @@ var init_injected_helpers = __esm({
       if (designationLineage.has(designationLineageFiber)) {
         return {
           error: 'TextInput designation resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -66311,6 +66315,7 @@ var init_injected_helpers = __esm({
     if (designationLineageFiber !== owner) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -85282,7 +85287,8 @@ function createInteractHandler(getClient2) {
       return failResult(`Interact returned non-JSON: ${result.value.slice(0, 200)}`);
     }
     if (parsed.error) {
-      return failResult(`Interact failed: ${parsed.error}`, pickDefined(parsed, REFUSAL_FIELDS));
+      const refusal = pickDefined(parsed, REFUSAL_FIELDS);
+      return parsed.code === "ASSERTION_FAILED" ? failResult(`Interact failed: ${parsed.error}`, "ASSERTION_FAILED", refusal) : failResult(`Interact failed: ${parsed.error}`, refusal);
     }
     if (parsed.action_executed && parsed.handler_error) {
       return failResult(`Action executed but handler threw: ${parsed.handler_error}`, {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63945,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 58;
+    HELPERS_VERSION = 59;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66098,6 +66098,38 @@ var init_injected_helpers = __esm({
         });
       }
     }
+
+    function bindingDescendsFrom(descendant, ancestor) {
+      var cursor = descendant.candidateFiber.return;
+      var returnSeen = new WeakSet();
+      while (cursor) {
+        if (!consumeWork()) return false;
+        if (returnSeen.has(cursor)) {
+          state.truncated = true;
+          state.reason = 'cycle';
+          return false;
+        }
+        returnSeen.add(cursor);
+        if (sameTypeTextFiber(cursor, ancestor.candidateFiber)) return true;
+        cursor = cursor.return;
+      }
+      return false;
+    }
+
+    // RN TextInput renders one element as a composite fiber plus its host child sharing one handler; keep the deepest (press's match-deepest-only rule).
+    function collapseLineageBindings(all) {
+      return all.filter(function(binding) {
+        return !all.some(function(other) {
+          return !state.truncated
+            && other !== binding
+            && other.handler === binding.handler
+            && other.contract === binding.contract
+            && bindingDescendsFrom(other, binding);
+        });
+      });
+    }
+
+    if (!state.truncated && bindings.length > 1) bindings = collapseLineageBindings(bindings);
 
     if (state.truncated) return typeTextTruncation(state);
     if (bindings.length > 1) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81766,7 +81766,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const startedAt = Date.now();
     let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      staleDesignation = staleDesignation ?? {
+        id: pendingDesignation.id,
+        index: pendingDesignation.index
+      };
       const staleToken = pendingDesignation.token;
       pendingDesignation = null;
       await releaseDesignation(staleToken);
@@ -81788,7 +81791,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const pressResult = await dispatch.press(s.id);
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = { id: s.id, token: pressResult.token };
+            pendingDesignation = { id: s.id, token: pressResult.token, index: i };
             stepFocusOnly = true;
           } else {
             lastTapped = s.id;
@@ -81923,12 +81926,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
     await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
   if (unconsumedDesignation) {
     if (pendingDesignation) {
       await releasePendingDesignation();
     }
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
+    return fail3(unconsumedDesignation.index, `TextInput designation for "${unconsumedDesignation.id}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation.id, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63945,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 56;
+    HELPERS_VERSION = 57;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66137,6 +66137,7 @@ var init_injected_helpers = __esm({
   function textInputDesignationDisabled(candidateProps) {
     return candidateProps.disabled === true
       || candidateProps.editable === false
+      || candidateProps.readOnly === true
       || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
   }
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81734,6 +81734,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
   let staleDesignation = null;
+  let consumedDesignationId = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -81810,8 +81811,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const designation = pendingDesignation;
           const target = designation?.id ?? lastTapped;
           if (!target)
-            return fail3(i, "inputText before any tapOn \u2014 no focus target");
+            return fail3(i, consumedDesignationId ? `the TextInput designation for "${consumedDesignationId}" was already consumed \u2014 tapOn the field again before typing` : "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
+          if (designation)
+            consumedDesignationId = designation.id;
           try {
             await dispatch.type(target, s.text, designation ? {
               focusOnlyDesignation: true,
@@ -82892,7 +82895,7 @@ function createMaestroRunHandler(deps = {}) {
             });
           }
           let stageCursor = 0;
-          let reactFocusId = retainedReactFocusId ?? segment.initialReactFocusId;
+          let reactFocusId = retainedReactFocusId === void 0 ? segment.initialReactFocusId : retainedReactFocusId;
           const stageResults = await executeMaestroAuthorityStages(segment.commands, async (commands) => {
             const sourceIndices = segment.sourceIndices.slice(stageCursor, stageCursor + commands.length);
             stageCursor += commands.length;
@@ -82900,18 +82903,18 @@ function createMaestroRunHandler(deps = {}) {
               ...replayDependencies,
               launchApp: async () => {
               }
-            }, { signal: controller.signal, initialFocusId: reactFocusId });
+            }, { signal: controller.signal, initialFocusId: reactFocusId ?? void 0 });
             if (!replay.passed)
               throw new ReactReplayFailure(replay, sourceIndices);
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
               if (step.t === "tap" && step.target) {
-                reactFocusId = step.focusOnly ? void 0 : step.target;
+                reactFocusId = step.focusOnly ? null : step.target;
               }
             }
             if (replay.finalFocusId === null)
-              reactFocusId = void 0;
+              reactFocusId = null;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -31725,7 +31725,7 @@ async function performExactFill(args, _client, tiers) {
     verification
   });
 }
-async function performReactTreeInput(testID, text, client2, signal) {
+async function performReactTreeInput(testID, text, client2, signal, options = {}) {
   const pathsTried = ["react-tree"];
   if (!client2) {
     return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" cannot be verified because the authoritative bundle is unavailable.`, { mutation: "none", pathsTried });
@@ -31749,28 +31749,47 @@ async function performReactTreeInput(testID, text, client2, signal) {
       return null;
     }
   };
-  const before = await readInput();
-  if (signal?.aborted) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
-      mutation: "none",
-      pathsTried
-    });
+  const designated = typeof options.designationToken === "string";
+  let requestedText = text;
+  if (!designated) {
+    const before = await readInput();
+    if (signal?.aborted) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
+        mutation: "none",
+        pathsTried
+      });
+    }
+    if (!before?.controlled) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
+    }
+    requestedText = `${before.value ?? ""}${text}`;
   }
-  if (!before?.controlled) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
-  }
-  const expected = `${before.value ?? ""}${text}`;
   let dispatch;
   try {
-    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({ action: "typeText", testID, text: expected, verify: true }) + ")");
+    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({
+      action: "typeText",
+      testID,
+      text: requestedText,
+      verify: true,
+      ...designated ? {
+        requireLiveInputDesignation: true,
+        designationToken: options.designationToken
+      } : {}
+    }) + ")");
     if (result.error || typeof result.value !== "string") {
       dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
     } else {
       const parsed = JSON.parse(result.value);
-      if (parsed.error)
-        dispatch = { error: parsed.error, mutation: "none" };
-      else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0) {
-        dispatch = { handler: parsed.handlerCalled };
+      if (parsed.error) {
+        const designationCode = parsed.code === "AMBIGUOUS_TESTID" || parsed.code === "ASSERTION_FAILED" || parsed.code === "INTERACTION_NOT_ACTUATED" ? parsed.code : void 0;
+        dispatch = {
+          error: parsed.error,
+          mutation: "none",
+          ...designationCode ? { code: designationCode } : {},
+          ...parsed.focusOnly === true ? { focusOnly: true } : {}
+        };
+      } else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0 && typeof parsed.text === "string") {
+        dispatch = { handler: parsed.handlerCalled, resultingText: parsed.text };
       } else {
         dispatch = { error: "dispatch result is inconclusive", mutation: "possible" };
       }
@@ -31779,6 +31798,14 @@ async function performReactTreeInput(testID, text, client2, signal) {
     dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
   }
   if ("error" in dispatch) {
+    if (dispatch.focusOnly) {
+      return failResult(`React-tree input "${testID}" refused: ${dispatch.error}`, dispatch.code ?? "TEXT_ENTRY_UNVERIFIED", {
+        mutation: dispatch.mutation,
+        pathsTried,
+        focusOnly: true,
+        hint: "No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying."
+      });
+    }
     return fillFailure("TEXT_ENTRY_UNVERIFIED", dispatch.mutation === "possible" ? `React-tree input "${testID}" may have mutated but its onChangeText result is unknown.` : `React-tree input "${testID}" has no verifiable controlled onChangeText path.`, { mutation: dispatch.mutation, pathsTried });
   }
   if (signal?.aborted) {
@@ -31787,6 +31814,7 @@ async function performReactTreeInput(testID, text, client2, signal) {
       pathsTried
     });
   }
+  const expected = dispatch.resultingText;
   let verification = "unreadable";
   let previous = null;
   let last = null;
@@ -63917,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 51;
+    HELPERS_VERSION = 56;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66106,7 +66134,261 @@ var init_injected_helpers = __esm({
     };
   }
 
+  function textInputDesignationDisabled(candidateProps) {
+    return candidateProps.disabled === true
+      || candidateProps.editable === false
+      || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+  }
+
+  function textInputDesignationInteractivity(input, selector) {
+    var current = input;
+    var seen = new WeakSet();
+    var depth = 0;
+    while (current && depth < 1000) {
+      if (seen.has(current)) {
+        return {
+          error: 'TextInput designation interactivity resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      seen.add(current);
+      if (isSubtreeInaccessible(current)) {
+        return {
+          error: 'TextInput designation target is hidden or occluded',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      var props = current.memoizedProps || {};
+      var pointerEvents = props.pointerEvents;
+      if (
+        current === input
+        && (pointerEvents === 'none' || pointerEvents === 'box-none')
+      ) {
+        return {
+          error: 'TextInput designation target is not user-interactable with pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      if (
+        current !== input
+        && (pointerEvents === 'none' || pointerEvents === 'box-only')
+      ) {
+        return {
+          error: 'TextInput designation target is blocked beneath pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      current = current.return;
+      depth++;
+    }
+    if (current) {
+      return {
+        error: 'TextInput designation interactivity resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    return null;
+  }
+
+  var activeTextInputDesignation = null;
+  var textInputDesignationSequence = 0;
+
+  function retainTextInputDesignation(input, selector) {
+    textInputDesignationSequence++;
+    var token = Date.now().toString(36) + '-' + textInputDesignationSequence.toString(36);
+    activeTextInputDesignation = {
+      token: token,
+      input: input,
+      selector: selector
+    };
+    return token;
+  }
+
+  function consumeTextInputDesignation(token, selector) {
+    var designation = activeTextInputDesignation;
+    if (
+      !designation
+      || designation.token !== token
+      || designation.selector !== selector
+    ) {
+      return null;
+    }
+    activeTextInputDesignation = null;
+    return designation;
+  }
+
+  function releaseInputDesignation(token) {
+    var released = !!activeTextInputDesignation
+      && activeTextInputDesignation.token === token;
+    if (released) activeTextInputDesignation = null;
+    return JSON.stringify({ released: released });
+  }
+
+  function isSameDesignatedInput(left, right) {
+    return !!left && !!right && (
+      left === right
+      || left.alternate === right
+      || right.alternate === left
+    );
+  }
+
+  function resolveTextInputDesignation(owner, selector) {
+    if (!owner) return null;
+    var designationStack = [owner];
+    var designationSeen = new WeakSet();
+    var designationMatches = [];
+    var designationInputs = [];
+    var designationWork = 0;
+    while (designationStack.length > 0 && designationWork < 2000) {
+      var designationFiber = designationStack.pop();
+      if (designationSeen.has(designationFiber)) continue;
+      designationSeen.add(designationFiber);
+      designationWork++;
+      var designationProps = designationFiber.memoizedProps || {};
+      var designationMatchesSelector = designationProps.testID === selector
+        || designationProps.nativeID === selector;
+      if (designationMatchesSelector) {
+        designationMatches.push(designationFiber);
+      }
+      if (
+        designationFiber.tag === 5
+        && typeof designationFiber.type === 'string'
+        && hostKind(designationFiber) === 'textinput'
+        && designationMatchesSelector
+      ) {
+        designationInputs.push(designationFiber);
+      }
+      var designationChild = designationFiber.child;
+      while (designationChild) {
+        designationStack.push(designationChild);
+        designationChild = designationChild.sibling;
+      }
+    }
+    if (designationStack.length > 0) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    if (designationInputs.length > 1) {
+      return {
+        error: 'Ambiguous TextInput designation target',
+        testID: selector,
+        count: designationInputs.length,
+        focusOnly: true
+      };
+    }
+    if (designationInputs.length !== 1) return null;
+    var designationInput = designationInputs[0];
+    var designationInputProps = designationInput.memoizedProps || {};
+    var designationLineage = new WeakSet();
+    var designationLineageFiber = designationInput;
+    var designationLineageDepth = 0;
+    while (designationLineageFiber && designationLineageDepth < 1000) {
+      if (designationLineage.has(designationLineageFiber)) {
+        return {
+          error: 'TextInput designation resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      designationLineage.add(designationLineageFiber);
+      if (designationLineageFiber === owner) break;
+      designationLineageFiber = designationLineageFiber.return;
+      designationLineageDepth++;
+    }
+    if (designationLineageFiber !== owner) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    for (var designationIndex = 0; designationIndex < designationMatches.length; designationIndex++) {
+      var designationMatch = designationMatches[designationIndex];
+      if (!designationLineage.has(designationMatch)) {
+        return {
+          error: 'Ambiguous TextInput designation target',
+          testID: selector,
+          count: designationMatches.length,
+          focusOnly: true
+        };
+      }
+      if (textInputDesignationDisabled(designationMatch.memoizedProps || {})) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          component: typeTextFiberName(designationInput),
+          testID: selector,
+          focusOnly: true
+        };
+      }
+    }
+    var designationInteractivity = textInputDesignationInteractivity(
+      designationInput,
+      selector
+    );
+    if (designationInteractivity) return designationInteractivity;
+    if (typeof designationInputProps.onPress === 'function') return null;
+    return {
+      success: true,
+      action: 'designateTextInput',
+      component: typeTextFiberName(designationInput),
+      testID: selector,
+      focusOnly: true,
+      inputFiber: designationInput
+    };
+  }
+
   function executeTypeTextTransaction(opts) {
+    var designationSelector = opts.testID;
+    var boundDesignation = null;
+    if (opts.requireLiveInputDesignation === true) {
+      boundDesignation = consumeTextInputDesignation(
+        opts.designationToken,
+        designationSelector
+      );
+      if (!boundDesignation) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveFrontmost;
+      try {
+        liveFrontmost = JSON.parse(isTestIdFrontmost(designationSelector));
+      } catch (_) {
+        liveFrontmost = null;
+      }
+      if (!liveFrontmost || liveFrontmost.visible !== true) {
+        return {
+          error: liveFrontmost && liveFrontmost.reason
+            ? liveFrontmost.reason
+            : 'TextInput designation frontmost state is unreadable',
+          code: liveFrontmost && liveFrontmost.code
+            ? liveFrontmost.code
+            : (liveFrontmost && liveFrontmost.matchCount > 1
+              ? 'AMBIGUOUS_TESTID'
+              : 'ASSERTION_FAILED'),
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var resolution = resolveTypeTextTarget(opts);
     if (resolution.error) return resolution;
     var binding = resolution.binding;
@@ -66121,7 +66403,107 @@ var init_injected_helpers = __esm({
         hint: 'Inspected every matching fiber and its bounded ownership graph \u2014 no typeable handler exists. Use cdp_component_tree to inspect the field, or pass the inner field testID directly.'
       };
     }
+    if (opts.requireLiveInputDesignation === true) {
+      var designationSourceProps = binding.sourceFiber.memoizedProps || {};
+      if (
+        typeof designationSelector !== 'string'
+        || !designationSelector
+        || hostKind(binding.sourceFiber) !== 'textinput'
+        || (
+          designationSourceProps.testID !== designationSelector
+          && designationSourceProps.nativeID !== designationSelector
+        )
+      ) {
+        return {
+          error: 'TextInput designation no longer resolves to the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationOwner = binding.sourceFiber;
+      var designationOwnerCursor = binding.sourceFiber.return;
+      var designationOwnerSeen = new WeakSet();
+      var designationOwnerDepth = 0;
+      while (designationOwnerCursor && designationOwnerDepth < 1000) {
+        if (designationOwnerSeen.has(designationOwnerCursor)) {
+          designationOwnerCursor = null;
+          designationOwnerDepth = 1000;
+          break;
+        }
+        designationOwnerSeen.add(designationOwnerCursor);
+        designationOwnerDepth++;
+        var designationOwnerProps = designationOwnerCursor.memoizedProps || {};
+        if (
+          designationOwnerProps.testID === designationSelector
+          || designationOwnerProps.nativeID === designationSelector
+        ) {
+          designationOwner = designationOwnerCursor;
+        }
+        designationOwnerCursor = designationOwnerCursor.return;
+      }
+      if (designationOwnerCursor || designationOwnerDepth >= 1000) {
+        return {
+          error: 'TextInput designation ownership resolution truncated',
+          code: 'ASSERTION_FAILED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveDesignation = resolveTextInputDesignation(designationOwner, designationSelector);
+      if (!liveDesignation || liveDesignation.success !== true) {
+        if (!liveDesignation) {
+          return {
+            error: 'TextInput designation no longer resolves to the exact host input',
+            code: 'INTERACTION_NOT_ACTUATED',
+            testID: designationSelector,
+            focusOnly: true,
+            handlerCalled: false
+          };
+        }
+        liveDesignation.code = liveDesignation.truncated === true
+          ? 'ASSERTION_FAILED'
+          : 'INTERACTION_NOT_ACTUATED';
+        liveDesignation.handlerCalled = false;
+        return liveDesignation;
+      }
+      if (
+        !isSameDesignatedInput(boundDesignation.input, binding.sourceFiber)
+        || !isSameDesignatedInput(boundDesignation.input, liveDesignation.inputFiber)
+      ) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationCandidateProps = binding.candidateFiber.memoizedProps || {};
+      if (textInputDesignationDisabled(designationCandidateProps)) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          component: binding.component,
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      if (binding.controlled !== true) {
+        return {
+          error: 'TextInput designation is uncontrolled or unreadable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var text = opts.text !== undefined ? opts.text : '';
+    if (boundDesignation) text = (binding.valueBefore || '') + text;
     try {
       if (binding.contract === 'onChangeText:string') binding.handler(text);
       else binding.handler({ nativeEvent: { text: text } });
@@ -66456,70 +66838,16 @@ var init_injected_helpers = __esm({
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
           if (opts.allowInputDesignation === true && opts.testID) {
-            var designationStack = [found];
-            var designationSeen = new WeakSet();
-            var designationInputs = [];
-            var designationWork = 0;
-            while (designationStack.length > 0 && designationWork < 2000) {
-              var designationFiber = designationStack.pop();
-              if (designationSeen.has(designationFiber)) continue;
-              designationSeen.add(designationFiber);
-              designationWork++;
-              var designationProps = designationFiber.memoizedProps || {};
-              if (
-                designationFiber.tag === 5
-                && typeof designationFiber.type === 'string'
-                && hostKind(designationFiber) === 'textinput'
-                && (designationProps.testID === selector || designationProps.nativeID === selector)
-              ) {
-                designationInputs.push(designationFiber);
+            var designation = resolveTextInputDesignation(found, selector);
+            if (designation) {
+              if (designation.success === true) {
+                designation.designationToken = retainTextInputDesignation(
+                  designation.inputFiber,
+                  selector
+                );
+                delete designation.inputFiber;
               }
-              var designationChild = designationFiber.child;
-              while (designationChild) {
-                designationStack.push(designationChild);
-                designationChild = designationChild.sibling;
-              }
-            }
-            if (designationStack.length > 0) {
-              return JSON.stringify({
-                error: 'TextInput designation resolution truncated',
-                testID: selector,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length > 1) {
-              return JSON.stringify({
-                error: 'Ambiguous TextInput designation target',
-                testID: selector,
-                count: designationInputs.length,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length === 1) {
-              var designationInput = designationInputs[0];
-              var designationInputProps = designationInput.memoizedProps || {};
-              var designationDisabled = function(candidateProps) {
-                return candidateProps.disabled === true
-                  || candidateProps.editable === false
-                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
-              };
-              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
-                return JSON.stringify({
-                  error: 'TextInput is disabled or non-editable',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
-              if (typeof designationInputProps.onPress !== 'function') {
-                return JSON.stringify({
-                  success: true,
-                  action: 'designateTextInput',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
+              return JSON.stringify(designation);
             }
           }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
@@ -68056,6 +68384,7 @@ var init_injected_helpers = __esm({
     getStoreState: getStoreState,
     getComponentState: getComponentState,
     readInputValue: readInputValue,
+    releaseInputDesignation: releaseInputDesignation,
     dispatchAction: dispatchAction,
     getErrors: getErrors,
     clearErrors: clearErrors,
@@ -81403,6 +81732,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
+  let staleDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -81417,12 +81747,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
       throw new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline");
     }
   };
+  const releaseDesignation = async (token2) => {
+    try {
+      await dispatch.releaseDesignation?.(token2);
+    } catch {
+    }
+  };
+  const releasePendingDesignation = async () => {
+    const designation = pendingDesignation;
+    pendingDesignation = null;
+    if (designation)
+      await releaseDesignation(designation.token);
+  };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
-    if (pendingDesignation && s.t !== "type")
+    let stepFocusOnly;
+    if (pendingDesignation && s.t !== "type") {
+      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      const staleToken = pendingDesignation.token;
       pendingDesignation = null;
+      await releaseDesignation(staleToken);
+    }
     try {
       requireNotAborted();
       switch (s.t) {
@@ -81438,28 +81785,38 @@ async function replayFlow(steps, dispatch, opts = {}) {
           break;
         case "tap":
           const pressResult = await dispatch.press(s.id);
-          requireNotAborted();
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = s.id;
+            pendingDesignation = { id: s.id, token: pressResult.token };
+            stepFocusOnly = true;
           } else {
             lastTapped = s.id;
           }
+          requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
-            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
+            ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          const target = pendingDesignation ?? lastTapped;
+          const designation = pendingDesignation;
+          const target = designation?.id ?? lastTapped;
           if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
-          await dispatch.type(target, s.text);
+          try {
+            await dispatch.type(target, s.text, designation ? {
+              focusOnlyDesignation: true,
+              designationToken: designation.token
+            } : void 0);
+          } finally {
+            if (designation)
+              await releaseDesignation(designation.token);
+          }
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -81548,10 +81905,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
       }
     } catch (e) {
       const waitedMs = Date.now() - startedAt;
+      await releasePendingDesignation();
       trace.push({
         sourceIndex: sourceIndex(i),
         t: evidenceType,
         target: "id" in s ? s.id : void 0,
+        ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
         ok: false,
         durationMs: waitedMs
       });
@@ -81560,10 +81919,15 @@ async function replayFlow(steps, dispatch, opts = {}) {
     }
   }
   if (opts.signal?.aborted) {
+    await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  if (pendingDesignation) {
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  if (unconsumedDesignation) {
+    if (pendingDesignation) {
+      await releasePendingDesignation();
+    }
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -81895,10 +82259,14 @@ function createReplayPressByTestId(interact) {
     }
     if (envelope.data?.action !== "designateTextInput")
       return { kind: "press" };
-    if (envelope.data.focusOnly !== true) {
+    if (envelope.data.focusOnly !== true || typeof envelope.data.designationToken !== "string" || envelope.data.designationToken.length === 0) {
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
     }
-    return { kind: "designation", focusOnly: true };
+    return {
+      kind: "designation",
+      focusOnly: true,
+      token: envelope.data.designationToken
+    };
   };
 }
 function nodeProps(treeJson, id) {
@@ -82002,10 +82370,13 @@ function buildCdpDispatch(deps, signal) {
       requireNotAborted();
       return deps.pressByTestId(id);
     },
-    async type(id, text) {
+    async type(id, text, context) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.typeByTestId(id, text);
+      await deps.typeByTestId(id, text, context);
+    },
+    async releaseDesignation(token2) {
+      await deps.releaseInputDesignation?.(token2);
     },
     async visibility(id) {
       await deps.treeFor(id);
@@ -97339,8 +97710,14 @@ var init_index = __esm({
       const tree = createComponentTreeHandler(getClient);
       return {
         pressByTestId: createReplayPressByTestId(interact),
-        typeByTestId: async (id, text) => {
-          mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
+        typeByTestId: async (id, text, context) => {
+          mustOk(await performReactTreeInput(id, text, getClient(), signal, context ? { designationToken: context.designationToken } : {}), `type "${id}"`);
+        },
+        releaseInputDesignation: async (token2) => {
+          try {
+            await getClient().evaluate(`__RN_AGENT.releaseInputDesignation(${JSON.stringify(token2)})`);
+          } catch {
+          }
         },
         treeFor: async (id) => {
           const fetchTree = async (interactiveOnly) => JSON.parse((await tree({

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 50;
+    HELPERS_VERSION = 51;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66455,6 +66455,73 @@ var init_injected_helpers = __esm({
 
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
+          if (opts.allowInputDesignation === true && opts.testID) {
+            var designationStack = [found];
+            var designationSeen = new WeakSet();
+            var designationInputs = [];
+            var designationWork = 0;
+            while (designationStack.length > 0 && designationWork < 2000) {
+              var designationFiber = designationStack.pop();
+              if (designationSeen.has(designationFiber)) continue;
+              designationSeen.add(designationFiber);
+              designationWork++;
+              var designationProps = designationFiber.memoizedProps || {};
+              if (
+                designationFiber.tag === 5
+                && typeof designationFiber.type === 'string'
+                && hostKind(designationFiber) === 'textinput'
+                && (designationProps.testID === selector || designationProps.nativeID === selector)
+              ) {
+                designationInputs.push(designationFiber);
+              }
+              var designationChild = designationFiber.child;
+              while (designationChild) {
+                designationStack.push(designationChild);
+                designationChild = designationChild.sibling;
+              }
+            }
+            if (designationStack.length > 0) {
+              return JSON.stringify({
+                error: 'TextInput designation resolution truncated',
+                testID: selector,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length > 1) {
+              return JSON.stringify({
+                error: 'Ambiguous TextInput designation target',
+                testID: selector,
+                count: designationInputs.length,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length === 1) {
+              var designationInput = designationInputs[0];
+              var designationInputProps = designationInput.memoizedProps || {};
+              var designationDisabled = function(candidateProps) {
+                return candidateProps.disabled === true
+                  || candidateProps.editable === false
+                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+              };
+              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
+                return JSON.stringify({
+                  error: 'TextInput is disabled or non-editable',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+              if (typeof designationInputProps.onPress !== 'function') {
+                return JSON.stringify({
+                  success: true,
+                  action: 'designateTextInput',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+            }
+          }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
         }
         if (opts.value !== undefined) {
@@ -81335,6 +81402,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
+  let pendingDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -81353,6 +81421,8 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    if (pendingDesignation && s.t !== "type")
+      pendingDesignation = null;
     try {
       requireNotAborted();
       switch (s.t) {
@@ -81367,26 +81437,34 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         case "tap":
-          await dispatch.press(s.id);
+          const pressResult = await dispatch.press(s.id);
           requireNotAborted();
-          lastTapped = s.id;
+          if (pressResult?.kind === "designation") {
+            lastTapped = null;
+            pendingDesignation = s.id;
+          } else {
+            lastTapped = s.id;
+          }
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
+            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          if (!lastTapped)
+          const target = pendingDesignation ?? lastTapped;
+          if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
-          await dispatch.type(lastTapped, s.text);
+          pendingDesignation = null;
+          await dispatch.type(target, s.text);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
-            target: lastTapped,
+            target,
             ok: true,
             durationMs: Date.now() - startedAt
           });
@@ -81483,6 +81561,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   if (opts.signal?.aborted) {
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
+  }
+  if (pendingDesignation) {
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -81800,6 +81881,26 @@ function replayTreeData(envelope) {
     }
   });
 }
+function createReplayPressByTestId(interact) {
+  return async (id) => {
+    const result = await interact({
+      action: "press",
+      testID: id,
+      animated: false,
+      allowInputDesignation: true
+    });
+    const envelope = JSON.parse(result.content[0]?.text ?? "{}");
+    if (envelope.ok === false) {
+      throw new ReplayDispatchError(envelope.code ?? "INTERACTION_NOT_ACTUATED", `press "${id}" failed: ${envelope.error ?? "ok:false"}`, envelope.meta);
+    }
+    if (envelope.data?.action !== "designateTextInput")
+      return { kind: "press" };
+    if (envelope.data.focusOnly !== true) {
+      throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
+    }
+    return { kind: "designation", focusOnly: true };
+  };
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -81899,7 +82000,7 @@ function buildCdpDispatch(deps, signal) {
     async press(id) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.pressByTestId(id);
+      return deps.pressByTestId(id);
     },
     async type(id, text) {
       await assertExactInteractable(id);
@@ -82430,9 +82531,12 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
-              if (step.t === "tap" && step.target)
-                reactFocusId = step.target;
+              if (step.t === "tap" && step.target) {
+                reactFocusId = step.focusOnly ? void 0 : step.target;
+              }
             }
+            if (replay.finalFocusId === null)
+              reactFocusId = void 0;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;
@@ -82442,6 +82546,7 @@ function createMaestroRunHandler(deps = {}) {
                 index: sourceIndices[step.sourceIndex] ?? step.sourceIndex,
                 name: step.t,
                 verb: step.t,
+                ...step.focusOnly ? { focusOnly: true } : {},
                 status: step.ok ? "pass" : "fail",
                 durationMs: step.durationMs
               });
@@ -82517,6 +82622,7 @@ function createMaestroRunHandler(deps = {}) {
                 name: String(record2.t ?? "unknown"),
                 verb: String(record2.t ?? "unknown"),
                 ...record2.target !== void 0 ? { target: String(record2.target) } : {},
+                ...record2.focusOnly === true ? { focusOnly: true } : {},
                 status: record2.ok === false ? "fail" : "pass",
                 durationMs: Number(record2.durationMs ?? 0)
               });
@@ -82531,6 +82637,7 @@ function createMaestroRunHandler(deps = {}) {
               index: failure.sourceIndices[step.sourceIndex] ?? step.sourceIndex,
               name: step.t,
               verb: step.t,
+              ...step.focusOnly ? { focusOnly: true } : {},
               status: step.ok ? "pass" : "fail",
               durationMs: step.durationMs
             });
@@ -84781,6 +84888,8 @@ function createInteractHandler(getClient2) {
       opts.includeHidden = args.includeHidden;
     if (args.walkUp !== void 0)
       opts.walkUp = args.walkUp;
+    if (args.allowInputDesignation !== void 0)
+      opts.allowInputDesignation = args.allowInputDesignation;
     const result = await client2.evaluate(`__RN_AGENT.interact(${JSON.stringify(opts)})`);
     if (result.error) {
       return failResult(`Interact error: ${result.error}`);
@@ -97229,9 +97338,7 @@ var init_index = __esm({
       const interact = createInteractHandler(getClient);
       const tree = createComponentTreeHandler(getClient);
       return {
-        pressByTestId: async (id) => {
-          mustOk(await interact({ action: "press", testID: id, animated: false }), `press "${id}"`);
-        },
+        pressByTestId: createReplayPressByTestId(interact),
         typeByTestId: async (id, text) => {
           mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
         },

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -30509,7 +30509,7 @@ async function performExactFill(args, _client, tiers) {
     verification
   });
 }
-async function performReactTreeInput(testID, text, client2, signal) {
+async function performReactTreeInput(testID, text, client2, signal, options = {}) {
   const pathsTried = ["react-tree"];
   if (!client2) {
     return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" cannot be verified because the authoritative bundle is unavailable.`, { mutation: "none", pathsTried });
@@ -30533,28 +30533,47 @@ async function performReactTreeInput(testID, text, client2, signal) {
       return null;
     }
   };
-  const before = await readInput();
-  if (signal?.aborted) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
-      mutation: "none",
-      pathsTried
-    });
+  const designated = typeof options.designationToken === "string";
+  let requestedText = text;
+  if (!designated) {
+    const before = await readInput();
+    if (signal?.aborted) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
+        mutation: "none",
+        pathsTried
+      });
+    }
+    if (!before?.controlled) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
+    }
+    requestedText = `${before.value ?? ""}${text}`;
   }
-  if (!before?.controlled) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
-  }
-  const expected = `${before.value ?? ""}${text}`;
   let dispatch;
   try {
-    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({ action: "typeText", testID, text: expected, verify: true }) + ")");
+    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({
+      action: "typeText",
+      testID,
+      text: requestedText,
+      verify: true,
+      ...designated ? {
+        requireLiveInputDesignation: true,
+        designationToken: options.designationToken
+      } : {}
+    }) + ")");
     if (result.error || typeof result.value !== "string") {
       dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
     } else {
       const parsed = JSON.parse(result.value);
-      if (parsed.error)
-        dispatch = { error: parsed.error, mutation: "none" };
-      else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0) {
-        dispatch = { handler: parsed.handlerCalled };
+      if (parsed.error) {
+        const designationCode = parsed.code === "AMBIGUOUS_TESTID" || parsed.code === "ASSERTION_FAILED" || parsed.code === "INTERACTION_NOT_ACTUATED" ? parsed.code : void 0;
+        dispatch = {
+          error: parsed.error,
+          mutation: "none",
+          ...designationCode ? { code: designationCode } : {},
+          ...parsed.focusOnly === true ? { focusOnly: true } : {}
+        };
+      } else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0 && typeof parsed.text === "string") {
+        dispatch = { handler: parsed.handlerCalled, resultingText: parsed.text };
       } else {
         dispatch = { error: "dispatch result is inconclusive", mutation: "possible" };
       }
@@ -30563,6 +30582,14 @@ async function performReactTreeInput(testID, text, client2, signal) {
     dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
   }
   if ("error" in dispatch) {
+    if (dispatch.focusOnly) {
+      return failResult(`React-tree input "${testID}" refused: ${dispatch.error}`, dispatch.code ?? "TEXT_ENTRY_UNVERIFIED", {
+        mutation: dispatch.mutation,
+        pathsTried,
+        focusOnly: true,
+        hint: "No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying."
+      });
+    }
     return fillFailure("TEXT_ENTRY_UNVERIFIED", dispatch.mutation === "possible" ? `React-tree input "${testID}" may have mutated but its onChangeText result is unknown.` : `React-tree input "${testID}" has no verifiable controlled onChangeText path.`, { mutation: dispatch.mutation, pathsTried });
   }
   if (signal?.aborted) {
@@ -30571,6 +30598,7 @@ async function performReactTreeInput(testID, text, client2, signal) {
       pathsTried
     });
   }
+  const expected = dispatch.resultingText;
   let verification = "unreadable";
   let previous = null;
   let last = null;
@@ -51543,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 51;
+var HELPERS_VERSION = 56;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53732,7 +53760,261 @@ var INJECTED_HELPERS = `
     };
   }
 
+  function textInputDesignationDisabled(candidateProps) {
+    return candidateProps.disabled === true
+      || candidateProps.editable === false
+      || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+  }
+
+  function textInputDesignationInteractivity(input, selector) {
+    var current = input;
+    var seen = new WeakSet();
+    var depth = 0;
+    while (current && depth < 1000) {
+      if (seen.has(current)) {
+        return {
+          error: 'TextInput designation interactivity resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      seen.add(current);
+      if (isSubtreeInaccessible(current)) {
+        return {
+          error: 'TextInput designation target is hidden or occluded',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      var props = current.memoizedProps || {};
+      var pointerEvents = props.pointerEvents;
+      if (
+        current === input
+        && (pointerEvents === 'none' || pointerEvents === 'box-none')
+      ) {
+        return {
+          error: 'TextInput designation target is not user-interactable with pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      if (
+        current !== input
+        && (pointerEvents === 'none' || pointerEvents === 'box-only')
+      ) {
+        return {
+          error: 'TextInput designation target is blocked beneath pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      current = current.return;
+      depth++;
+    }
+    if (current) {
+      return {
+        error: 'TextInput designation interactivity resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    return null;
+  }
+
+  var activeTextInputDesignation = null;
+  var textInputDesignationSequence = 0;
+
+  function retainTextInputDesignation(input, selector) {
+    textInputDesignationSequence++;
+    var token = Date.now().toString(36) + '-' + textInputDesignationSequence.toString(36);
+    activeTextInputDesignation = {
+      token: token,
+      input: input,
+      selector: selector
+    };
+    return token;
+  }
+
+  function consumeTextInputDesignation(token, selector) {
+    var designation = activeTextInputDesignation;
+    if (
+      !designation
+      || designation.token !== token
+      || designation.selector !== selector
+    ) {
+      return null;
+    }
+    activeTextInputDesignation = null;
+    return designation;
+  }
+
+  function releaseInputDesignation(token) {
+    var released = !!activeTextInputDesignation
+      && activeTextInputDesignation.token === token;
+    if (released) activeTextInputDesignation = null;
+    return JSON.stringify({ released: released });
+  }
+
+  function isSameDesignatedInput(left, right) {
+    return !!left && !!right && (
+      left === right
+      || left.alternate === right
+      || right.alternate === left
+    );
+  }
+
+  function resolveTextInputDesignation(owner, selector) {
+    if (!owner) return null;
+    var designationStack = [owner];
+    var designationSeen = new WeakSet();
+    var designationMatches = [];
+    var designationInputs = [];
+    var designationWork = 0;
+    while (designationStack.length > 0 && designationWork < 2000) {
+      var designationFiber = designationStack.pop();
+      if (designationSeen.has(designationFiber)) continue;
+      designationSeen.add(designationFiber);
+      designationWork++;
+      var designationProps = designationFiber.memoizedProps || {};
+      var designationMatchesSelector = designationProps.testID === selector
+        || designationProps.nativeID === selector;
+      if (designationMatchesSelector) {
+        designationMatches.push(designationFiber);
+      }
+      if (
+        designationFiber.tag === 5
+        && typeof designationFiber.type === 'string'
+        && hostKind(designationFiber) === 'textinput'
+        && designationMatchesSelector
+      ) {
+        designationInputs.push(designationFiber);
+      }
+      var designationChild = designationFiber.child;
+      while (designationChild) {
+        designationStack.push(designationChild);
+        designationChild = designationChild.sibling;
+      }
+    }
+    if (designationStack.length > 0) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    if (designationInputs.length > 1) {
+      return {
+        error: 'Ambiguous TextInput designation target',
+        testID: selector,
+        count: designationInputs.length,
+        focusOnly: true
+      };
+    }
+    if (designationInputs.length !== 1) return null;
+    var designationInput = designationInputs[0];
+    var designationInputProps = designationInput.memoizedProps || {};
+    var designationLineage = new WeakSet();
+    var designationLineageFiber = designationInput;
+    var designationLineageDepth = 0;
+    while (designationLineageFiber && designationLineageDepth < 1000) {
+      if (designationLineage.has(designationLineageFiber)) {
+        return {
+          error: 'TextInput designation resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      designationLineage.add(designationLineageFiber);
+      if (designationLineageFiber === owner) break;
+      designationLineageFiber = designationLineageFiber.return;
+      designationLineageDepth++;
+    }
+    if (designationLineageFiber !== owner) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    for (var designationIndex = 0; designationIndex < designationMatches.length; designationIndex++) {
+      var designationMatch = designationMatches[designationIndex];
+      if (!designationLineage.has(designationMatch)) {
+        return {
+          error: 'Ambiguous TextInput designation target',
+          testID: selector,
+          count: designationMatches.length,
+          focusOnly: true
+        };
+      }
+      if (textInputDesignationDisabled(designationMatch.memoizedProps || {})) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          component: typeTextFiberName(designationInput),
+          testID: selector,
+          focusOnly: true
+        };
+      }
+    }
+    var designationInteractivity = textInputDesignationInteractivity(
+      designationInput,
+      selector
+    );
+    if (designationInteractivity) return designationInteractivity;
+    if (typeof designationInputProps.onPress === 'function') return null;
+    return {
+      success: true,
+      action: 'designateTextInput',
+      component: typeTextFiberName(designationInput),
+      testID: selector,
+      focusOnly: true,
+      inputFiber: designationInput
+    };
+  }
+
   function executeTypeTextTransaction(opts) {
+    var designationSelector = opts.testID;
+    var boundDesignation = null;
+    if (opts.requireLiveInputDesignation === true) {
+      boundDesignation = consumeTextInputDesignation(
+        opts.designationToken,
+        designationSelector
+      );
+      if (!boundDesignation) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveFrontmost;
+      try {
+        liveFrontmost = JSON.parse(isTestIdFrontmost(designationSelector));
+      } catch (_) {
+        liveFrontmost = null;
+      }
+      if (!liveFrontmost || liveFrontmost.visible !== true) {
+        return {
+          error: liveFrontmost && liveFrontmost.reason
+            ? liveFrontmost.reason
+            : 'TextInput designation frontmost state is unreadable',
+          code: liveFrontmost && liveFrontmost.code
+            ? liveFrontmost.code
+            : (liveFrontmost && liveFrontmost.matchCount > 1
+              ? 'AMBIGUOUS_TESTID'
+              : 'ASSERTION_FAILED'),
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var resolution = resolveTypeTextTarget(opts);
     if (resolution.error) return resolution;
     var binding = resolution.binding;
@@ -53747,7 +54029,107 @@ var INJECTED_HELPERS = `
         hint: 'Inspected every matching fiber and its bounded ownership graph \u2014 no typeable handler exists. Use cdp_component_tree to inspect the field, or pass the inner field testID directly.'
       };
     }
+    if (opts.requireLiveInputDesignation === true) {
+      var designationSourceProps = binding.sourceFiber.memoizedProps || {};
+      if (
+        typeof designationSelector !== 'string'
+        || !designationSelector
+        || hostKind(binding.sourceFiber) !== 'textinput'
+        || (
+          designationSourceProps.testID !== designationSelector
+          && designationSourceProps.nativeID !== designationSelector
+        )
+      ) {
+        return {
+          error: 'TextInput designation no longer resolves to the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationOwner = binding.sourceFiber;
+      var designationOwnerCursor = binding.sourceFiber.return;
+      var designationOwnerSeen = new WeakSet();
+      var designationOwnerDepth = 0;
+      while (designationOwnerCursor && designationOwnerDepth < 1000) {
+        if (designationOwnerSeen.has(designationOwnerCursor)) {
+          designationOwnerCursor = null;
+          designationOwnerDepth = 1000;
+          break;
+        }
+        designationOwnerSeen.add(designationOwnerCursor);
+        designationOwnerDepth++;
+        var designationOwnerProps = designationOwnerCursor.memoizedProps || {};
+        if (
+          designationOwnerProps.testID === designationSelector
+          || designationOwnerProps.nativeID === designationSelector
+        ) {
+          designationOwner = designationOwnerCursor;
+        }
+        designationOwnerCursor = designationOwnerCursor.return;
+      }
+      if (designationOwnerCursor || designationOwnerDepth >= 1000) {
+        return {
+          error: 'TextInput designation ownership resolution truncated',
+          code: 'ASSERTION_FAILED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveDesignation = resolveTextInputDesignation(designationOwner, designationSelector);
+      if (!liveDesignation || liveDesignation.success !== true) {
+        if (!liveDesignation) {
+          return {
+            error: 'TextInput designation no longer resolves to the exact host input',
+            code: 'INTERACTION_NOT_ACTUATED',
+            testID: designationSelector,
+            focusOnly: true,
+            handlerCalled: false
+          };
+        }
+        liveDesignation.code = liveDesignation.truncated === true
+          ? 'ASSERTION_FAILED'
+          : 'INTERACTION_NOT_ACTUATED';
+        liveDesignation.handlerCalled = false;
+        return liveDesignation;
+      }
+      if (
+        !isSameDesignatedInput(boundDesignation.input, binding.sourceFiber)
+        || !isSameDesignatedInput(boundDesignation.input, liveDesignation.inputFiber)
+      ) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationCandidateProps = binding.candidateFiber.memoizedProps || {};
+      if (textInputDesignationDisabled(designationCandidateProps)) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          component: binding.component,
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      if (binding.controlled !== true) {
+        return {
+          error: 'TextInput designation is uncontrolled or unreadable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var text = opts.text !== undefined ? opts.text : '';
+    if (boundDesignation) text = (binding.valueBefore || '') + text;
     try {
       if (binding.contract === 'onChangeText:string') binding.handler(text);
       else binding.handler({ nativeEvent: { text: text } });
@@ -54082,70 +54464,16 @@ var INJECTED_HELPERS = `
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
           if (opts.allowInputDesignation === true && opts.testID) {
-            var designationStack = [found];
-            var designationSeen = new WeakSet();
-            var designationInputs = [];
-            var designationWork = 0;
-            while (designationStack.length > 0 && designationWork < 2000) {
-              var designationFiber = designationStack.pop();
-              if (designationSeen.has(designationFiber)) continue;
-              designationSeen.add(designationFiber);
-              designationWork++;
-              var designationProps = designationFiber.memoizedProps || {};
-              if (
-                designationFiber.tag === 5
-                && typeof designationFiber.type === 'string'
-                && hostKind(designationFiber) === 'textinput'
-                && (designationProps.testID === selector || designationProps.nativeID === selector)
-              ) {
-                designationInputs.push(designationFiber);
+            var designation = resolveTextInputDesignation(found, selector);
+            if (designation) {
+              if (designation.success === true) {
+                designation.designationToken = retainTextInputDesignation(
+                  designation.inputFiber,
+                  selector
+                );
+                delete designation.inputFiber;
               }
-              var designationChild = designationFiber.child;
-              while (designationChild) {
-                designationStack.push(designationChild);
-                designationChild = designationChild.sibling;
-              }
-            }
-            if (designationStack.length > 0) {
-              return JSON.stringify({
-                error: 'TextInput designation resolution truncated',
-                testID: selector,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length > 1) {
-              return JSON.stringify({
-                error: 'Ambiguous TextInput designation target',
-                testID: selector,
-                count: designationInputs.length,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length === 1) {
-              var designationInput = designationInputs[0];
-              var designationInputProps = designationInput.memoizedProps || {};
-              var designationDisabled = function(candidateProps) {
-                return candidateProps.disabled === true
-                  || candidateProps.editable === false
-                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
-              };
-              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
-                return JSON.stringify({
-                  error: 'TextInput is disabled or non-editable',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
-              if (typeof designationInputProps.onPress !== 'function') {
-                return JSON.stringify({
-                  success: true,
-                  action: 'designateTextInput',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
+              return JSON.stringify(designation);
             }
           }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
@@ -55682,6 +56010,7 @@ var INJECTED_HELPERS = `
     getStoreState: getStoreState,
     getComponentState: getComponentState,
     readInputValue: readInputValue,
+    releaseInputDesignation: releaseInputDesignation,
     dispatchAction: dispatchAction,
     getErrors: getErrors,
     clearErrors: clearErrors,
@@ -79384,6 +79713,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
+  let staleDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -79398,12 +79728,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
       throw new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline");
     }
   };
+  const releaseDesignation = async (token2) => {
+    try {
+      await dispatch.releaseDesignation?.(token2);
+    } catch {
+    }
+  };
+  const releasePendingDesignation = async () => {
+    const designation = pendingDesignation;
+    pendingDesignation = null;
+    if (designation)
+      await releaseDesignation(designation.token);
+  };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
-    if (pendingDesignation && s.t !== "type")
+    let stepFocusOnly;
+    if (pendingDesignation && s.t !== "type") {
+      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      const staleToken = pendingDesignation.token;
       pendingDesignation = null;
+      await releaseDesignation(staleToken);
+    }
     try {
       requireNotAborted();
       switch (s.t) {
@@ -79419,28 +79766,38 @@ async function replayFlow(steps, dispatch, opts = {}) {
           break;
         case "tap":
           const pressResult = await dispatch.press(s.id);
-          requireNotAborted();
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = s.id;
+            pendingDesignation = { id: s.id, token: pressResult.token };
+            stepFocusOnly = true;
           } else {
             lastTapped = s.id;
           }
+          requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
-            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
+            ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          const target = pendingDesignation ?? lastTapped;
+          const designation = pendingDesignation;
+          const target = designation?.id ?? lastTapped;
           if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
-          await dispatch.type(target, s.text);
+          try {
+            await dispatch.type(target, s.text, designation ? {
+              focusOnlyDesignation: true,
+              designationToken: designation.token
+            } : void 0);
+          } finally {
+            if (designation)
+              await releaseDesignation(designation.token);
+          }
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -79529,10 +79886,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
       }
     } catch (e) {
       const waitedMs = Date.now() - startedAt;
+      await releasePendingDesignation();
       trace.push({
         sourceIndex: sourceIndex(i),
         t: evidenceType,
         target: "id" in s ? s.id : void 0,
+        ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
         ok: false,
         durationMs: waitedMs
       });
@@ -79541,10 +79900,15 @@ async function replayFlow(steps, dispatch, opts = {}) {
     }
   }
   if (opts.signal?.aborted) {
+    await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  if (pendingDesignation) {
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  if (unconsumedDesignation) {
+    if (pendingDesignation) {
+      await releasePendingDesignation();
+    }
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -79839,10 +80203,14 @@ function createReplayPressByTestId(interact) {
     }
     if (envelope.data?.action !== "designateTextInput")
       return { kind: "press" };
-    if (envelope.data.focusOnly !== true) {
+    if (envelope.data.focusOnly !== true || typeof envelope.data.designationToken !== "string" || envelope.data.designationToken.length === 0) {
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
     }
-    return { kind: "designation", focusOnly: true };
+    return {
+      kind: "designation",
+      focusOnly: true,
+      token: envelope.data.designationToken
+    };
   };
 }
 function nodeProps(treeJson, id) {
@@ -79946,10 +80314,13 @@ function buildCdpDispatch(deps, signal) {
       requireNotAborted();
       return deps.pressByTestId(id);
     },
-    async type(id, text) {
+    async type(id, text, context) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.typeByTestId(id, text);
+      await deps.typeByTestId(id, text, context);
+    },
+    async releaseDesignation(token2) {
+      await deps.releaseInputDesignation?.(token2);
     },
     async visibility(id) {
       await deps.treeFor(id);
@@ -94502,8 +94873,14 @@ var makeReplayDeps = (_args, signal) => {
   const tree = createComponentTreeHandler(getClient);
   return {
     pressByTestId: createReplayPressByTestId(interact),
-    typeByTestId: async (id, text) => {
-      mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
+    typeByTestId: async (id, text, context) => {
+      mustOk(await performReactTreeInput(id, text, getClient(), signal, context ? { designationToken: context.designationToken } : {}), `type "${id}"`);
+    },
+    releaseInputDesignation: async (token2) => {
+      try {
+        await getClient().evaluate(`__RN_AGENT.releaseInputDesignation(${JSON.stringify(token2)})`);
+      } catch {
+      }
     },
     treeFor: async (id) => {
       const fetchTree = async (interactiveOnly) => JSON.parse((await tree({

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51571,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 56;
+var HELPERS_VERSION = 57;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53763,6 +53763,7 @@ var INJECTED_HELPERS = `
   function textInputDesignationDisabled(candidateProps) {
     return candidateProps.disabled === true
       || candidateProps.editable === false
+      || candidateProps.readOnly === true
       || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
   }
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79747,7 +79747,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const startedAt = Date.now();
     let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      staleDesignation = staleDesignation ?? {
+        id: pendingDesignation.id,
+        index: pendingDesignation.index
+      };
       const staleToken = pendingDesignation.token;
       pendingDesignation = null;
       await releaseDesignation(staleToken);
@@ -79769,7 +79772,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const pressResult = await dispatch.press(s.id);
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = { id: s.id, token: pressResult.token };
+            pendingDesignation = { id: s.id, token: pressResult.token, index: i };
             stepFocusOnly = true;
           } else {
             lastTapped = s.id;
@@ -79904,12 +79907,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
     await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
   if (unconsumedDesignation) {
     if (pendingDesignation) {
       await releasePendingDesignation();
     }
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
+    return fail3(unconsumedDesignation.index, `TextInput designation for "${unconsumedDesignation.id}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation.id, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51543,7 +51543,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 50;
+var HELPERS_VERSION = 51;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -54081,6 +54081,73 @@ var INJECTED_HELPERS = `
 
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
+          if (opts.allowInputDesignation === true && opts.testID) {
+            var designationStack = [found];
+            var designationSeen = new WeakSet();
+            var designationInputs = [];
+            var designationWork = 0;
+            while (designationStack.length > 0 && designationWork < 2000) {
+              var designationFiber = designationStack.pop();
+              if (designationSeen.has(designationFiber)) continue;
+              designationSeen.add(designationFiber);
+              designationWork++;
+              var designationProps = designationFiber.memoizedProps || {};
+              if (
+                designationFiber.tag === 5
+                && typeof designationFiber.type === 'string'
+                && hostKind(designationFiber) === 'textinput'
+                && (designationProps.testID === selector || designationProps.nativeID === selector)
+              ) {
+                designationInputs.push(designationFiber);
+              }
+              var designationChild = designationFiber.child;
+              while (designationChild) {
+                designationStack.push(designationChild);
+                designationChild = designationChild.sibling;
+              }
+            }
+            if (designationStack.length > 0) {
+              return JSON.stringify({
+                error: 'TextInput designation resolution truncated',
+                testID: selector,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length > 1) {
+              return JSON.stringify({
+                error: 'Ambiguous TextInput designation target',
+                testID: selector,
+                count: designationInputs.length,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length === 1) {
+              var designationInput = designationInputs[0];
+              var designationInputProps = designationInput.memoizedProps || {};
+              var designationDisabled = function(candidateProps) {
+                return candidateProps.disabled === true
+                  || candidateProps.editable === false
+                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+              };
+              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
+                return JSON.stringify({
+                  error: 'TextInput is disabled or non-editable',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+              if (typeof designationInputProps.onPress !== 'function') {
+                return JSON.stringify({
+                  success: true,
+                  action: 'designateTextInput',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+            }
+          }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
         }
         if (opts.value !== undefined) {
@@ -79316,6 +79383,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
+  let pendingDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -79334,6 +79402,8 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    if (pendingDesignation && s.t !== "type")
+      pendingDesignation = null;
     try {
       requireNotAborted();
       switch (s.t) {
@@ -79348,26 +79418,34 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         case "tap":
-          await dispatch.press(s.id);
+          const pressResult = await dispatch.press(s.id);
           requireNotAborted();
-          lastTapped = s.id;
+          if (pressResult?.kind === "designation") {
+            lastTapped = null;
+            pendingDesignation = s.id;
+          } else {
+            lastTapped = s.id;
+          }
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
+            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          if (!lastTapped)
+          const target = pendingDesignation ?? lastTapped;
+          if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
-          await dispatch.type(lastTapped, s.text);
+          pendingDesignation = null;
+          await dispatch.type(target, s.text);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
-            target: lastTapped,
+            target,
             ok: true,
             durationMs: Date.now() - startedAt
           });
@@ -79464,6 +79542,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   if (opts.signal?.aborted) {
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
+  }
+  if (pendingDesignation) {
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -79744,6 +79825,26 @@ function replayTreeData(envelope) {
     }
   });
 }
+function createReplayPressByTestId(interact) {
+  return async (id) => {
+    const result = await interact({
+      action: "press",
+      testID: id,
+      animated: false,
+      allowInputDesignation: true
+    });
+    const envelope = JSON.parse(result.content[0]?.text ?? "{}");
+    if (envelope.ok === false) {
+      throw new ReplayDispatchError(envelope.code ?? "INTERACTION_NOT_ACTUATED", `press "${id}" failed: ${envelope.error ?? "ok:false"}`, envelope.meta);
+    }
+    if (envelope.data?.action !== "designateTextInput")
+      return { kind: "press" };
+    if (envelope.data.focusOnly !== true) {
+      throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
+    }
+    return { kind: "designation", focusOnly: true };
+  };
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -79843,7 +79944,7 @@ function buildCdpDispatch(deps, signal) {
     async press(id) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.pressByTestId(id);
+      return deps.pressByTestId(id);
     },
     async type(id, text) {
       await assertExactInteractable(id);
@@ -80388,9 +80489,12 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
-              if (step.t === "tap" && step.target)
-                reactFocusId = step.target;
+              if (step.t === "tap" && step.target) {
+                reactFocusId = step.focusOnly ? void 0 : step.target;
+              }
             }
+            if (replay.finalFocusId === null)
+              reactFocusId = void 0;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;
@@ -80400,6 +80504,7 @@ function createMaestroRunHandler(deps = {}) {
                 index: sourceIndices[step.sourceIndex] ?? step.sourceIndex,
                 name: step.t,
                 verb: step.t,
+                ...step.focusOnly ? { focusOnly: true } : {},
                 status: step.ok ? "pass" : "fail",
                 durationMs: step.durationMs
               });
@@ -80475,6 +80580,7 @@ function createMaestroRunHandler(deps = {}) {
                 name: String(record2.t ?? "unknown"),
                 verb: String(record2.t ?? "unknown"),
                 ...record2.target !== void 0 ? { target: String(record2.target) } : {},
+                ...record2.focusOnly === true ? { focusOnly: true } : {},
                 status: record2.ok === false ? "fail" : "pass",
                 durationMs: Number(record2.durationMs ?? 0)
               });
@@ -80489,6 +80595,7 @@ function createMaestroRunHandler(deps = {}) {
               index: failure.sourceIndices[step.sourceIndex] ?? step.sourceIndex,
               name: step.t,
               verb: step.t,
+              ...step.focusOnly ? { focusOnly: true } : {},
               status: step.ok ? "pass" : "fail",
               durationMs: step.durationMs
             });
@@ -82629,6 +82736,8 @@ function createInteractHandler(getClient2) {
       opts.includeHidden = args.includeHidden;
     if (args.walkUp !== void 0)
       opts.walkUp = args.walkUp;
+    if (args.allowInputDesignation !== void 0)
+      opts.allowInputDesignation = args.allowInputDesignation;
     const result = await client2.evaluate(`__RN_AGENT.interact(${JSON.stringify(opts)})`);
     if (result.error) {
       return failResult(`Interact error: ${result.error}`);
@@ -94392,9 +94501,7 @@ var makeReplayDeps = (_args, signal) => {
   const interact = createInteractHandler(getClient);
   const tree = createComponentTreeHandler(getClient);
   return {
-    pressByTestId: async (id) => {
-      mustOk(await interact({ action: "press", testID: id, animated: false }), `press "${id}"`);
-    },
+    pressByTestId: createReplayPressByTestId(interact),
     typeByTestId: async (id, text) => {
       mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
     },

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51571,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 58;
+var HELPERS_VERSION = 59;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53724,6 +53724,38 @@ var INJECTED_HELPERS = `
         });
       }
     }
+
+    function bindingDescendsFrom(descendant, ancestor) {
+      var cursor = descendant.candidateFiber.return;
+      var returnSeen = new WeakSet();
+      while (cursor) {
+        if (!consumeWork()) return false;
+        if (returnSeen.has(cursor)) {
+          state.truncated = true;
+          state.reason = 'cycle';
+          return false;
+        }
+        returnSeen.add(cursor);
+        if (sameTypeTextFiber(cursor, ancestor.candidateFiber)) return true;
+        cursor = cursor.return;
+      }
+      return false;
+    }
+
+    // RN TextInput renders one element as a composite fiber plus its host child sharing one handler; keep the deepest (press's match-deepest-only rule).
+    function collapseLineageBindings(all) {
+      return all.filter(function(binding) {
+        return !all.some(function(other) {
+          return !state.truncated
+            && other !== binding
+            && other.handler === binding.handler
+            && other.contract === binding.contract
+            && bindingDescendsFrom(other, binding);
+        });
+      });
+    }
+
+    if (!state.truncated && bindings.length > 1) bindings = collapseLineageBindings(bindings);
 
     if (state.truncated) return typeTextTruncation(state);
     if (bindings.length > 1) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51571,7 +51571,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 57;
+var HELPERS_VERSION = 58;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53775,6 +53775,7 @@ var INJECTED_HELPERS = `
       if (seen.has(current)) {
         return {
           error: 'TextInput designation interactivity resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -53816,6 +53817,7 @@ var INJECTED_HELPERS = `
     if (current) {
       return {
         error: 'TextInput designation interactivity resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -53901,6 +53903,7 @@ var INJECTED_HELPERS = `
     if (designationStack.length > 0) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -53924,6 +53927,7 @@ var INJECTED_HELPERS = `
       if (designationLineage.has(designationLineageFiber)) {
         return {
           error: 'TextInput designation resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -53937,6 +53941,7 @@ var INJECTED_HELPERS = `
     if (designationLineageFiber !== owner) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -83130,7 +83135,8 @@ function createInteractHandler(getClient2) {
       return failResult(`Interact returned non-JSON: ${result.value.slice(0, 200)}`);
     }
     if (parsed.error) {
-      return failResult(`Interact failed: ${parsed.error}`, pickDefined(parsed, REFUSAL_FIELDS));
+      const refusal = pickDefined(parsed, REFUSAL_FIELDS);
+      return parsed.code === "ASSERTION_FAILED" ? failResult(`Interact failed: ${parsed.error}`, "ASSERTION_FAILED", refusal) : failResult(`Interact failed: ${parsed.error}`, refusal);
     }
     if (parsed.action_executed && parsed.handler_error) {
       return failResult(`Action executed but handler threw: ${parsed.handler_error}`, {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79715,6 +79715,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
   let staleDesignation = null;
+  let consumedDesignationId = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -79791,8 +79792,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const designation = pendingDesignation;
           const target = designation?.id ?? lastTapped;
           if (!target)
-            return fail3(i, "inputText before any tapOn \u2014 no focus target");
+            return fail3(i, consumedDesignationId ? `the TextInput designation for "${consumedDesignationId}" was already consumed \u2014 tapOn the field again before typing` : "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
+          if (designation)
+            consumedDesignationId = designation.id;
           try {
             await dispatch.type(target, s.text, designation ? {
               focusOnlyDesignation: true,
@@ -80850,7 +80853,7 @@ function createMaestroRunHandler(deps = {}) {
             });
           }
           let stageCursor = 0;
-          let reactFocusId = retainedReactFocusId ?? segment.initialReactFocusId;
+          let reactFocusId = retainedReactFocusId === void 0 ? segment.initialReactFocusId : retainedReactFocusId;
           const stageResults = await executeMaestroAuthorityStages(segment.commands, async (commands) => {
             const sourceIndices = segment.sourceIndices.slice(stageCursor, stageCursor + commands.length);
             stageCursor += commands.length;
@@ -80858,18 +80861,18 @@ function createMaestroRunHandler(deps = {}) {
               ...replayDependencies,
               launchApp: async () => {
               }
-            }, { signal: controller.signal, initialFocusId: reactFocusId });
+            }, { signal: controller.signal, initialFocusId: reactFocusId ?? void 0 });
             if (!replay.passed)
               throw new ReactReplayFailure(replay, sourceIndices);
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
               if (step.t === "tap" && step.target) {
-                reactFocusId = step.focusOnly ? void 0 : step.target;
+                reactFocusId = step.focusOnly ? null : step.target;
               }
             }
             if (replay.finalFocusId === null)
-              reactFocusId = void 0;
+              reactFocusId = null;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15650,6 +15650,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
+  let staleDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -15668,8 +15669,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
-    if (pendingDesignation && s.t !== "type")
+    if (pendingDesignation && s.t !== "type") {
+      staleDesignation = staleDesignation ?? pendingDesignation;
       pendingDesignation = null;
+    }
     try {
       requireNotAborted();
       switch (s.t) {
@@ -15810,8 +15813,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   if (opts.signal?.aborted) {
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  if (pendingDesignation) {
-    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
+  if (unconsumedDesignation) {
+    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15665,13 +15665,28 @@ async function replayFlow(steps, dispatch, opts = {}) {
       throw new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline");
     }
   };
+  const releaseDesignation = async (token2) => {
+    try {
+      await dispatch.releaseDesignation?.(token2);
+    } catch {
+    }
+  };
+  const releasePendingDesignation = async () => {
+    const designation = pendingDesignation;
+    pendingDesignation = null;
+    if (designation)
+      await releaseDesignation(designation.token);
+  };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation;
+      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      const staleToken = pendingDesignation.token;
       pendingDesignation = null;
+      await releaseDesignation(staleToken);
     }
     try {
       requireNotAborted();
@@ -15688,29 +15703,38 @@ async function replayFlow(steps, dispatch, opts = {}) {
           break;
         case "tap":
           const pressResult = await dispatch.press(s.id);
-          requireNotAborted();
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = s.id;
+            pendingDesignation = { id: s.id, token: pressResult.token };
+            stepFocusOnly = true;
           } else {
             lastTapped = s.id;
           }
+          requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
-            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
+            ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          const target = pendingDesignation ?? lastTapped;
+          const designation = pendingDesignation;
+          const target = designation?.id ?? lastTapped;
           if (!target)
             return fail(i, "inputText before any tapOn \u2014 no focus target");
-          const focusOnlyDesignation = pendingDesignation !== null;
           pendingDesignation = null;
-          await dispatch.type(target, s.text, focusOnlyDesignation ? { focusOnlyDesignation: true } : void 0);
+          try {
+            await dispatch.type(target, s.text, designation ? {
+              focusOnlyDesignation: true,
+              designationToken: designation.token
+            } : void 0);
+          } finally {
+            if (designation)
+              await releaseDesignation(designation.token);
+          }
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -15799,10 +15823,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
       }
     } catch (e) {
       const waitedMs = Date.now() - startedAt;
+      await releasePendingDesignation();
       trace.push({
         sourceIndex: sourceIndex(i),
         t: evidenceType,
         target: "id" in s ? s.id : void 0,
+        ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
         ok: false,
         durationMs: waitedMs
       });
@@ -15811,10 +15837,14 @@ async function replayFlow(steps, dispatch, opts = {}) {
     }
   }
   if (opts.signal?.aborted) {
+    await releasePendingDesignation();
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
   if (unconsumedDesignation) {
+    if (pendingDesignation) {
+      await releasePendingDesignation();
+    }
     return fail(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
@@ -16167,6 +16197,9 @@ function buildCdpDispatch(deps, signal) {
       await assertExactInteractable(id);
       requireNotAborted();
       await deps.typeByTestId(id, text, context);
+    },
+    async releaseDesignation(token2) {
+      await deps.releaseInputDesignation?.(token2);
     },
     async visibility(id) {
       await deps.treeFor(id);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15705,8 +15705,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const target = pendingDesignation ?? lastTapped;
           if (!target)
             return fail(i, "inputText before any tapOn \u2014 no focus target");
+          const focusOnlyDesignation = pendingDesignation !== null;
           pendingDesignation = null;
-          await dispatch.type(target, s.text);
+          await dispatch.type(target, s.text, focusOnlyDesignation ? { focusOnlyDesignation: true } : void 0);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -16158,10 +16159,10 @@ function buildCdpDispatch(deps, signal) {
       requireNotAborted();
       return deps.pressByTestId(id);
     },
-    async type(id, text) {
+    async type(id, text, context) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.typeByTestId(id, text);
+      await deps.typeByTestId(id, text, context);
     },
     async visibility(id) {
       await deps.treeFor(id);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15649,6 +15649,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
+  let pendingDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -15667,6 +15668,8 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    if (pendingDesignation && s.t !== "type")
+      pendingDesignation = null;
     try {
       requireNotAborted();
       switch (s.t) {
@@ -15681,26 +15684,34 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         case "tap":
-          await dispatch.press(s.id);
+          const pressResult = await dispatch.press(s.id);
           requireNotAborted();
-          lastTapped = s.id;
+          if (pressResult?.kind === "designation") {
+            lastTapped = null;
+            pendingDesignation = s.id;
+          } else {
+            lastTapped = s.id;
+          }
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
+            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          if (!lastTapped)
+          const target = pendingDesignation ?? lastTapped;
+          if (!target)
             return fail(i, "inputText before any tapOn \u2014 no focus target");
-          await dispatch.type(lastTapped, s.text);
+          pendingDesignation = null;
+          await dispatch.type(target, s.text);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
-            target: lastTapped,
+            target,
             ok: true,
             durationMs: Date.now() - startedAt
           });
@@ -15797,6 +15808,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   if (opts.signal?.aborted) {
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
+  }
+  if (pendingDesignation) {
+    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -16142,7 +16156,7 @@ function buildCdpDispatch(deps, signal) {
     async press(id) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.pressByTestId(id);
+      return deps.pressByTestId(id);
     },
     async type(id, text) {
       await assertExactInteractable(id);
@@ -16687,9 +16701,12 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
-              if (step.t === "tap" && step.target)
-                reactFocusId = step.target;
+              if (step.t === "tap" && step.target) {
+                reactFocusId = step.focusOnly ? void 0 : step.target;
+              }
             }
+            if (replay.finalFocusId === null)
+              reactFocusId = void 0;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;
@@ -16699,6 +16716,7 @@ function createMaestroRunHandler(deps = {}) {
                 index: sourceIndices[step.sourceIndex] ?? step.sourceIndex,
                 name: step.t,
                 verb: step.t,
+                ...step.focusOnly ? { focusOnly: true } : {},
                 status: step.ok ? "pass" : "fail",
                 durationMs: step.durationMs
               });
@@ -16774,6 +16792,7 @@ function createMaestroRunHandler(deps = {}) {
                 name: String(record.t ?? "unknown"),
                 verb: String(record.t ?? "unknown"),
                 ...record.target !== void 0 ? { target: String(record.target) } : {},
+                ...record.focusOnly === true ? { focusOnly: true } : {},
                 status: record.ok === false ? "fail" : "pass",
                 durationMs: Number(record.durationMs ?? 0)
               });
@@ -16788,6 +16807,7 @@ function createMaestroRunHandler(deps = {}) {
               index: failure.sourceIndices[step.sourceIndex] ?? step.sourceIndex,
               name: step.t,
               verb: step.t,
+              ...step.focusOnly ? { focusOnly: true } : {},
               status: step.ok ? "pass" : "fail",
               durationMs: step.durationMs
             });

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15651,6 +15651,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
   let staleDesignation = null;
+  let consumedDesignationId = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -15727,8 +15728,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const designation = pendingDesignation;
           const target = designation?.id ?? lastTapped;
           if (!target)
-            return fail(i, "inputText before any tapOn \u2014 no focus target");
+            return fail(i, consumedDesignationId ? `the TextInput designation for "${consumedDesignationId}" was already consumed \u2014 tapOn the field again before typing` : "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
+          if (designation)
+            consumedDesignationId = designation.id;
           try {
             await dispatch.type(target, s.text, designation ? {
               focusOnlyDesignation: true,
@@ -16728,7 +16731,7 @@ function createMaestroRunHandler(deps = {}) {
             });
           }
           let stageCursor = 0;
-          let reactFocusId = retainedReactFocusId ?? segment.initialReactFocusId;
+          let reactFocusId = retainedReactFocusId === void 0 ? segment.initialReactFocusId : retainedReactFocusId;
           const stageResults = await executeMaestroAuthorityStages(segment.commands, async (commands) => {
             const sourceIndices = segment.sourceIndices.slice(stageCursor, stageCursor + commands.length);
             stageCursor += commands.length;
@@ -16736,18 +16739,18 @@ function createMaestroRunHandler(deps = {}) {
               ...replayDependencies,
               launchApp: async () => {
               }
-            }, { signal: controller.signal, initialFocusId: reactFocusId });
+            }, { signal: controller.signal, initialFocusId: reactFocusId ?? void 0 });
             if (!replay.passed)
               throw new ReactReplayFailure(replay, sourceIndices);
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
               if (step.t === "tap" && step.target) {
-                reactFocusId = step.focusOnly ? void 0 : step.target;
+                reactFocusId = step.focusOnly ? null : step.target;
               }
             }
             if (replay.finalFocusId === null)
-              reactFocusId = void 0;
+              reactFocusId = null;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -15683,7 +15683,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const startedAt = Date.now();
     let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      staleDesignation = staleDesignation ?? {
+        id: pendingDesignation.id,
+        index: pendingDesignation.index
+      };
       const staleToken = pendingDesignation.token;
       pendingDesignation = null;
       await releaseDesignation(staleToken);
@@ -15705,7 +15708,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const pressResult = await dispatch.press(s.id);
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = { id: s.id, token: pressResult.token };
+            pendingDesignation = { id: s.id, token: pressResult.token, index: i };
             stepFocusOnly = true;
           } else {
             lastTapped = s.id;
@@ -15840,12 +15843,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
     await releasePendingDesignation();
     return fail(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
   if (unconsumedDesignation) {
     if (pendingDesignation) {
       await releasePendingDesignation();
     }
-    return fail(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
+    return fail(unconsumedDesignation.index, `TextInput designation for "${unconsumedDesignation.id}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation.id, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63945,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 57;
+    HELPERS_VERSION = 58;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66149,6 +66149,7 @@ var init_injected_helpers = __esm({
       if (seen.has(current)) {
         return {
           error: 'TextInput designation interactivity resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -66190,6 +66191,7 @@ var init_injected_helpers = __esm({
     if (current) {
       return {
         error: 'TextInput designation interactivity resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -66275,6 +66277,7 @@ var init_injected_helpers = __esm({
     if (designationStack.length > 0) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -66298,6 +66301,7 @@ var init_injected_helpers = __esm({
       if (designationLineage.has(designationLineageFiber)) {
         return {
           error: 'TextInput designation resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -66311,6 +66315,7 @@ var init_injected_helpers = __esm({
     if (designationLineageFiber !== owner) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -85282,7 +85287,8 @@ function createInteractHandler(getClient2) {
       return failResult(`Interact returned non-JSON: ${result.value.slice(0, 200)}`);
     }
     if (parsed.error) {
-      return failResult(`Interact failed: ${parsed.error}`, pickDefined(parsed, REFUSAL_FIELDS));
+      const refusal = pickDefined(parsed, REFUSAL_FIELDS);
+      return parsed.code === "ASSERTION_FAILED" ? failResult(`Interact failed: ${parsed.error}`, "ASSERTION_FAILED", refusal) : failResult(`Interact failed: ${parsed.error}`, refusal);
     }
     if (parsed.action_executed && parsed.handler_error) {
       return failResult(`Action executed but handler threw: ${parsed.handler_error}`, {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63945,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 58;
+    HELPERS_VERSION = 59;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66098,6 +66098,38 @@ var init_injected_helpers = __esm({
         });
       }
     }
+
+    function bindingDescendsFrom(descendant, ancestor) {
+      var cursor = descendant.candidateFiber.return;
+      var returnSeen = new WeakSet();
+      while (cursor) {
+        if (!consumeWork()) return false;
+        if (returnSeen.has(cursor)) {
+          state.truncated = true;
+          state.reason = 'cycle';
+          return false;
+        }
+        returnSeen.add(cursor);
+        if (sameTypeTextFiber(cursor, ancestor.candidateFiber)) return true;
+        cursor = cursor.return;
+      }
+      return false;
+    }
+
+    // RN TextInput renders one element as a composite fiber plus its host child sharing one handler; keep the deepest (press's match-deepest-only rule).
+    function collapseLineageBindings(all) {
+      return all.filter(function(binding) {
+        return !all.some(function(other) {
+          return !state.truncated
+            && other !== binding
+            && other.handler === binding.handler
+            && other.contract === binding.contract
+            && bindingDescendsFrom(other, binding);
+        });
+      });
+    }
+
+    if (!state.truncated && bindings.length > 1) bindings = collapseLineageBindings(bindings);
 
     if (state.truncated) return typeTextTruncation(state);
     if (bindings.length > 1) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81766,7 +81766,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const startedAt = Date.now();
     let stepFocusOnly;
     if (pendingDesignation && s.t !== "type") {
-      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      staleDesignation = staleDesignation ?? {
+        id: pendingDesignation.id,
+        index: pendingDesignation.index
+      };
       const staleToken = pendingDesignation.token;
       pendingDesignation = null;
       await releaseDesignation(staleToken);
@@ -81788,7 +81791,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const pressResult = await dispatch.press(s.id);
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = { id: s.id, token: pressResult.token };
+            pendingDesignation = { id: s.id, token: pressResult.token, index: i };
             stepFocusOnly = true;
           } else {
             lastTapped = s.id;
@@ -81923,12 +81926,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
     await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
   if (unconsumedDesignation) {
     if (pendingDesignation) {
       await releasePendingDesignation();
     }
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
+    return fail3(unconsumedDesignation.index, `TextInput designation for "${unconsumedDesignation.id}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation.id, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63945,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 56;
+    HELPERS_VERSION = 57;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66137,6 +66137,7 @@ var init_injected_helpers = __esm({
   function textInputDesignationDisabled(candidateProps) {
     return candidateProps.disabled === true
       || candidateProps.editable === false
+      || candidateProps.readOnly === true
       || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
   }
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81734,6 +81734,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
   let staleDesignation = null;
+  let consumedDesignationId = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -81810,8 +81811,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
           const designation = pendingDesignation;
           const target = designation?.id ?? lastTapped;
           if (!target)
-            return fail3(i, "inputText before any tapOn \u2014 no focus target");
+            return fail3(i, consumedDesignationId ? `the TextInput designation for "${consumedDesignationId}" was already consumed \u2014 tapOn the field again before typing` : "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
+          if (designation)
+            consumedDesignationId = designation.id;
           try {
             await dispatch.type(target, s.text, designation ? {
               focusOnlyDesignation: true,
@@ -82892,7 +82895,7 @@ function createMaestroRunHandler(deps = {}) {
             });
           }
           let stageCursor = 0;
-          let reactFocusId = retainedReactFocusId ?? segment.initialReactFocusId;
+          let reactFocusId = retainedReactFocusId === void 0 ? segment.initialReactFocusId : retainedReactFocusId;
           const stageResults = await executeMaestroAuthorityStages(segment.commands, async (commands) => {
             const sourceIndices = segment.sourceIndices.slice(stageCursor, stageCursor + commands.length);
             stageCursor += commands.length;
@@ -82900,18 +82903,18 @@ function createMaestroRunHandler(deps = {}) {
               ...replayDependencies,
               launchApp: async () => {
               }
-            }, { signal: controller.signal, initialFocusId: reactFocusId });
+            }, { signal: controller.signal, initialFocusId: reactFocusId ?? void 0 });
             if (!replay.passed)
               throw new ReactReplayFailure(replay, sourceIndices);
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
               if (step.t === "tap" && step.target) {
-                reactFocusId = step.focusOnly ? void 0 : step.target;
+                reactFocusId = step.focusOnly ? null : step.target;
               }
             }
             if (replay.finalFocusId === null)
-              reactFocusId = void 0;
+              reactFocusId = null;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -31725,7 +31725,7 @@ async function performExactFill(args, _client, tiers) {
     verification
   });
 }
-async function performReactTreeInput(testID, text, client2, signal) {
+async function performReactTreeInput(testID, text, client2, signal, options = {}) {
   const pathsTried = ["react-tree"];
   if (!client2) {
     return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" cannot be verified because the authoritative bundle is unavailable.`, { mutation: "none", pathsTried });
@@ -31749,28 +31749,47 @@ async function performReactTreeInput(testID, text, client2, signal) {
       return null;
     }
   };
-  const before = await readInput();
-  if (signal?.aborted) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
-      mutation: "none",
-      pathsTried
-    });
+  const designated = typeof options.designationToken === "string";
+  let requestedText = text;
+  if (!designated) {
+    const before = await readInput();
+    if (signal?.aborted) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", "React-tree input was cancelled before mutation.", {
+        mutation: "none",
+        pathsTried
+      });
+    }
+    if (!before?.controlled) {
+      return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
+    }
+    requestedText = `${before.value ?? ""}${text}`;
   }
-  if (!before?.controlled) {
-    return fillFailure("TEXT_ENTRY_UNVERIFIED", `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`, { mutation: "none", pathsTried });
-  }
-  const expected = `${before.value ?? ""}${text}`;
   let dispatch;
   try {
-    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({ action: "typeText", testID, text: expected, verify: true }) + ")");
+    const result = await client2.evaluate("__RN_AGENT.interact(" + JSON.stringify({
+      action: "typeText",
+      testID,
+      text: requestedText,
+      verify: true,
+      ...designated ? {
+        requireLiveInputDesignation: true,
+        designationToken: options.designationToken
+      } : {}
+    }) + ")");
     if (result.error || typeof result.value !== "string") {
       dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
     } else {
       const parsed = JSON.parse(result.value);
-      if (parsed.error)
-        dispatch = { error: parsed.error, mutation: "none" };
-      else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0) {
-        dispatch = { handler: parsed.handlerCalled };
+      if (parsed.error) {
+        const designationCode = parsed.code === "AMBIGUOUS_TESTID" || parsed.code === "ASSERTION_FAILED" || parsed.code === "INTERACTION_NOT_ACTUATED" ? parsed.code : void 0;
+        dispatch = {
+          error: parsed.error,
+          mutation: "none",
+          ...designationCode ? { code: designationCode } : {},
+          ...parsed.focusOnly === true ? { focusOnly: true } : {}
+        };
+      } else if (typeof parsed.handlerCalled === "string" && parsed.controlled !== void 0 && typeof parsed.text === "string") {
+        dispatch = { handler: parsed.handlerCalled, resultingText: parsed.text };
       } else {
         dispatch = { error: "dispatch result is inconclusive", mutation: "possible" };
       }
@@ -31779,6 +31798,14 @@ async function performReactTreeInput(testID, text, client2, signal) {
     dispatch = { error: "dispatch result is unavailable", mutation: "possible" };
   }
   if ("error" in dispatch) {
+    if (dispatch.focusOnly) {
+      return failResult(`React-tree input "${testID}" refused: ${dispatch.error}`, dispatch.code ?? "TEXT_ENTRY_UNVERIFIED", {
+        mutation: dispatch.mutation,
+        pathsTried,
+        focusOnly: true,
+        hint: "No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying."
+      });
+    }
     return fillFailure("TEXT_ENTRY_UNVERIFIED", dispatch.mutation === "possible" ? `React-tree input "${testID}" may have mutated but its onChangeText result is unknown.` : `React-tree input "${testID}" has no verifiable controlled onChangeText path.`, { mutation: dispatch.mutation, pathsTried });
   }
   if (signal?.aborted) {
@@ -31787,6 +31814,7 @@ async function performReactTreeInput(testID, text, client2, signal) {
       pathsTried
     });
   }
+  const expected = dispatch.resultingText;
   let verification = "unreadable";
   let previous = null;
   let last = null;
@@ -63917,7 +63945,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 51;
+    HELPERS_VERSION = 56;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66106,7 +66134,261 @@ var init_injected_helpers = __esm({
     };
   }
 
+  function textInputDesignationDisabled(candidateProps) {
+    return candidateProps.disabled === true
+      || candidateProps.editable === false
+      || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+  }
+
+  function textInputDesignationInteractivity(input, selector) {
+    var current = input;
+    var seen = new WeakSet();
+    var depth = 0;
+    while (current && depth < 1000) {
+      if (seen.has(current)) {
+        return {
+          error: 'TextInput designation interactivity resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      seen.add(current);
+      if (isSubtreeInaccessible(current)) {
+        return {
+          error: 'TextInput designation target is hidden or occluded',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      var props = current.memoizedProps || {};
+      var pointerEvents = props.pointerEvents;
+      if (
+        current === input
+        && (pointerEvents === 'none' || pointerEvents === 'box-none')
+      ) {
+        return {
+          error: 'TextInput designation target is not user-interactable with pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      if (
+        current !== input
+        && (pointerEvents === 'none' || pointerEvents === 'box-only')
+      ) {
+        return {
+          error: 'TextInput designation target is blocked beneath pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      current = current.return;
+      depth++;
+    }
+    if (current) {
+      return {
+        error: 'TextInput designation interactivity resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    return null;
+  }
+
+  var activeTextInputDesignation = null;
+  var textInputDesignationSequence = 0;
+
+  function retainTextInputDesignation(input, selector) {
+    textInputDesignationSequence++;
+    var token = Date.now().toString(36) + '-' + textInputDesignationSequence.toString(36);
+    activeTextInputDesignation = {
+      token: token,
+      input: input,
+      selector: selector
+    };
+    return token;
+  }
+
+  function consumeTextInputDesignation(token, selector) {
+    var designation = activeTextInputDesignation;
+    if (
+      !designation
+      || designation.token !== token
+      || designation.selector !== selector
+    ) {
+      return null;
+    }
+    activeTextInputDesignation = null;
+    return designation;
+  }
+
+  function releaseInputDesignation(token) {
+    var released = !!activeTextInputDesignation
+      && activeTextInputDesignation.token === token;
+    if (released) activeTextInputDesignation = null;
+    return JSON.stringify({ released: released });
+  }
+
+  function isSameDesignatedInput(left, right) {
+    return !!left && !!right && (
+      left === right
+      || left.alternate === right
+      || right.alternate === left
+    );
+  }
+
+  function resolveTextInputDesignation(owner, selector) {
+    if (!owner) return null;
+    var designationStack = [owner];
+    var designationSeen = new WeakSet();
+    var designationMatches = [];
+    var designationInputs = [];
+    var designationWork = 0;
+    while (designationStack.length > 0 && designationWork < 2000) {
+      var designationFiber = designationStack.pop();
+      if (designationSeen.has(designationFiber)) continue;
+      designationSeen.add(designationFiber);
+      designationWork++;
+      var designationProps = designationFiber.memoizedProps || {};
+      var designationMatchesSelector = designationProps.testID === selector
+        || designationProps.nativeID === selector;
+      if (designationMatchesSelector) {
+        designationMatches.push(designationFiber);
+      }
+      if (
+        designationFiber.tag === 5
+        && typeof designationFiber.type === 'string'
+        && hostKind(designationFiber) === 'textinput'
+        && designationMatchesSelector
+      ) {
+        designationInputs.push(designationFiber);
+      }
+      var designationChild = designationFiber.child;
+      while (designationChild) {
+        designationStack.push(designationChild);
+        designationChild = designationChild.sibling;
+      }
+    }
+    if (designationStack.length > 0) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    if (designationInputs.length > 1) {
+      return {
+        error: 'Ambiguous TextInput designation target',
+        testID: selector,
+        count: designationInputs.length,
+        focusOnly: true
+      };
+    }
+    if (designationInputs.length !== 1) return null;
+    var designationInput = designationInputs[0];
+    var designationInputProps = designationInput.memoizedProps || {};
+    var designationLineage = new WeakSet();
+    var designationLineageFiber = designationInput;
+    var designationLineageDepth = 0;
+    while (designationLineageFiber && designationLineageDepth < 1000) {
+      if (designationLineage.has(designationLineageFiber)) {
+        return {
+          error: 'TextInput designation resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      designationLineage.add(designationLineageFiber);
+      if (designationLineageFiber === owner) break;
+      designationLineageFiber = designationLineageFiber.return;
+      designationLineageDepth++;
+    }
+    if (designationLineageFiber !== owner) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    for (var designationIndex = 0; designationIndex < designationMatches.length; designationIndex++) {
+      var designationMatch = designationMatches[designationIndex];
+      if (!designationLineage.has(designationMatch)) {
+        return {
+          error: 'Ambiguous TextInput designation target',
+          testID: selector,
+          count: designationMatches.length,
+          focusOnly: true
+        };
+      }
+      if (textInputDesignationDisabled(designationMatch.memoizedProps || {})) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          component: typeTextFiberName(designationInput),
+          testID: selector,
+          focusOnly: true
+        };
+      }
+    }
+    var designationInteractivity = textInputDesignationInteractivity(
+      designationInput,
+      selector
+    );
+    if (designationInteractivity) return designationInteractivity;
+    if (typeof designationInputProps.onPress === 'function') return null;
+    return {
+      success: true,
+      action: 'designateTextInput',
+      component: typeTextFiberName(designationInput),
+      testID: selector,
+      focusOnly: true,
+      inputFiber: designationInput
+    };
+  }
+
   function executeTypeTextTransaction(opts) {
+    var designationSelector = opts.testID;
+    var boundDesignation = null;
+    if (opts.requireLiveInputDesignation === true) {
+      boundDesignation = consumeTextInputDesignation(
+        opts.designationToken,
+        designationSelector
+      );
+      if (!boundDesignation) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveFrontmost;
+      try {
+        liveFrontmost = JSON.parse(isTestIdFrontmost(designationSelector));
+      } catch (_) {
+        liveFrontmost = null;
+      }
+      if (!liveFrontmost || liveFrontmost.visible !== true) {
+        return {
+          error: liveFrontmost && liveFrontmost.reason
+            ? liveFrontmost.reason
+            : 'TextInput designation frontmost state is unreadable',
+          code: liveFrontmost && liveFrontmost.code
+            ? liveFrontmost.code
+            : (liveFrontmost && liveFrontmost.matchCount > 1
+              ? 'AMBIGUOUS_TESTID'
+              : 'ASSERTION_FAILED'),
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var resolution = resolveTypeTextTarget(opts);
     if (resolution.error) return resolution;
     var binding = resolution.binding;
@@ -66121,7 +66403,107 @@ var init_injected_helpers = __esm({
         hint: 'Inspected every matching fiber and its bounded ownership graph \u2014 no typeable handler exists. Use cdp_component_tree to inspect the field, or pass the inner field testID directly.'
       };
     }
+    if (opts.requireLiveInputDesignation === true) {
+      var designationSourceProps = binding.sourceFiber.memoizedProps || {};
+      if (
+        typeof designationSelector !== 'string'
+        || !designationSelector
+        || hostKind(binding.sourceFiber) !== 'textinput'
+        || (
+          designationSourceProps.testID !== designationSelector
+          && designationSourceProps.nativeID !== designationSelector
+        )
+      ) {
+        return {
+          error: 'TextInput designation no longer resolves to the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationOwner = binding.sourceFiber;
+      var designationOwnerCursor = binding.sourceFiber.return;
+      var designationOwnerSeen = new WeakSet();
+      var designationOwnerDepth = 0;
+      while (designationOwnerCursor && designationOwnerDepth < 1000) {
+        if (designationOwnerSeen.has(designationOwnerCursor)) {
+          designationOwnerCursor = null;
+          designationOwnerDepth = 1000;
+          break;
+        }
+        designationOwnerSeen.add(designationOwnerCursor);
+        designationOwnerDepth++;
+        var designationOwnerProps = designationOwnerCursor.memoizedProps || {};
+        if (
+          designationOwnerProps.testID === designationSelector
+          || designationOwnerProps.nativeID === designationSelector
+        ) {
+          designationOwner = designationOwnerCursor;
+        }
+        designationOwnerCursor = designationOwnerCursor.return;
+      }
+      if (designationOwnerCursor || designationOwnerDepth >= 1000) {
+        return {
+          error: 'TextInput designation ownership resolution truncated',
+          code: 'ASSERTION_FAILED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveDesignation = resolveTextInputDesignation(designationOwner, designationSelector);
+      if (!liveDesignation || liveDesignation.success !== true) {
+        if (!liveDesignation) {
+          return {
+            error: 'TextInput designation no longer resolves to the exact host input',
+            code: 'INTERACTION_NOT_ACTUATED',
+            testID: designationSelector,
+            focusOnly: true,
+            handlerCalled: false
+          };
+        }
+        liveDesignation.code = liveDesignation.truncated === true
+          ? 'ASSERTION_FAILED'
+          : 'INTERACTION_NOT_ACTUATED';
+        liveDesignation.handlerCalled = false;
+        return liveDesignation;
+      }
+      if (
+        !isSameDesignatedInput(boundDesignation.input, binding.sourceFiber)
+        || !isSameDesignatedInput(boundDesignation.input, liveDesignation.inputFiber)
+      ) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationCandidateProps = binding.candidateFiber.memoizedProps || {};
+      if (textInputDesignationDisabled(designationCandidateProps)) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          component: binding.component,
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      if (binding.controlled !== true) {
+        return {
+          error: 'TextInput designation is uncontrolled or unreadable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var text = opts.text !== undefined ? opts.text : '';
+    if (boundDesignation) text = (binding.valueBefore || '') + text;
     try {
       if (binding.contract === 'onChangeText:string') binding.handler(text);
       else binding.handler({ nativeEvent: { text: text } });
@@ -66456,70 +66838,16 @@ var init_injected_helpers = __esm({
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
           if (opts.allowInputDesignation === true && opts.testID) {
-            var designationStack = [found];
-            var designationSeen = new WeakSet();
-            var designationInputs = [];
-            var designationWork = 0;
-            while (designationStack.length > 0 && designationWork < 2000) {
-              var designationFiber = designationStack.pop();
-              if (designationSeen.has(designationFiber)) continue;
-              designationSeen.add(designationFiber);
-              designationWork++;
-              var designationProps = designationFiber.memoizedProps || {};
-              if (
-                designationFiber.tag === 5
-                && typeof designationFiber.type === 'string'
-                && hostKind(designationFiber) === 'textinput'
-                && (designationProps.testID === selector || designationProps.nativeID === selector)
-              ) {
-                designationInputs.push(designationFiber);
+            var designation = resolveTextInputDesignation(found, selector);
+            if (designation) {
+              if (designation.success === true) {
+                designation.designationToken = retainTextInputDesignation(
+                  designation.inputFiber,
+                  selector
+                );
+                delete designation.inputFiber;
               }
-              var designationChild = designationFiber.child;
-              while (designationChild) {
-                designationStack.push(designationChild);
-                designationChild = designationChild.sibling;
-              }
-            }
-            if (designationStack.length > 0) {
-              return JSON.stringify({
-                error: 'TextInput designation resolution truncated',
-                testID: selector,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length > 1) {
-              return JSON.stringify({
-                error: 'Ambiguous TextInput designation target',
-                testID: selector,
-                count: designationInputs.length,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length === 1) {
-              var designationInput = designationInputs[0];
-              var designationInputProps = designationInput.memoizedProps || {};
-              var designationDisabled = function(candidateProps) {
-                return candidateProps.disabled === true
-                  || candidateProps.editable === false
-                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
-              };
-              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
-                return JSON.stringify({
-                  error: 'TextInput is disabled or non-editable',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
-              if (typeof designationInputProps.onPress !== 'function') {
-                return JSON.stringify({
-                  success: true,
-                  action: 'designateTextInput',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
+              return JSON.stringify(designation);
             }
           }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
@@ -68056,6 +68384,7 @@ var init_injected_helpers = __esm({
     getStoreState: getStoreState,
     getComponentState: getComponentState,
     readInputValue: readInputValue,
+    releaseInputDesignation: releaseInputDesignation,
     dispatchAction: dispatchAction,
     getErrors: getErrors,
     clearErrors: clearErrors,
@@ -81403,6 +81732,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
   let pendingDesignation = null;
+  let staleDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -81417,12 +81747,29 @@ async function replayFlow(steps, dispatch, opts = {}) {
       throw new ReplayDispatchError("RUNNER_TIMEOUT", "React-tree replay exceeded its execution deadline");
     }
   };
+  const releaseDesignation = async (token2) => {
+    try {
+      await dispatch.releaseDesignation?.(token2);
+    } catch {
+    }
+  };
+  const releasePendingDesignation = async () => {
+    const designation = pendingDesignation;
+    pendingDesignation = null;
+    if (designation)
+      await releaseDesignation(designation.token);
+  };
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
-    if (pendingDesignation && s.t !== "type")
+    let stepFocusOnly;
+    if (pendingDesignation && s.t !== "type") {
+      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      const staleToken = pendingDesignation.token;
       pendingDesignation = null;
+      await releaseDesignation(staleToken);
+    }
     try {
       requireNotAborted();
       switch (s.t) {
@@ -81438,28 +81785,38 @@ async function replayFlow(steps, dispatch, opts = {}) {
           break;
         case "tap":
           const pressResult = await dispatch.press(s.id);
-          requireNotAborted();
           if (pressResult?.kind === "designation") {
             lastTapped = null;
-            pendingDesignation = s.id;
+            pendingDesignation = { id: s.id, token: pressResult.token };
+            stepFocusOnly = true;
           } else {
             lastTapped = s.id;
           }
+          requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
-            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
+            ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          const target = pendingDesignation ?? lastTapped;
+          const designation = pendingDesignation;
+          const target = designation?.id ?? lastTapped;
           if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           pendingDesignation = null;
-          await dispatch.type(target, s.text);
+          try {
+            await dispatch.type(target, s.text, designation ? {
+              focusOnlyDesignation: true,
+              designationToken: designation.token
+            } : void 0);
+          } finally {
+            if (designation)
+              await releaseDesignation(designation.token);
+          }
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -81548,10 +81905,12 @@ async function replayFlow(steps, dispatch, opts = {}) {
       }
     } catch (e) {
       const waitedMs = Date.now() - startedAt;
+      await releasePendingDesignation();
       trace.push({
         sourceIndex: sourceIndex(i),
         t: evidenceType,
         target: "id" in s ? s.id : void 0,
+        ...stepFocusOnly ? { focusOnly: stepFocusOnly } : {},
         ok: false,
         durationMs: waitedMs
       });
@@ -81560,10 +81919,15 @@ async function replayFlow(steps, dispatch, opts = {}) {
     }
   }
   if (opts.signal?.aborted) {
+    await releasePendingDesignation();
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
   }
-  if (pendingDesignation) {
-    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  if (unconsumedDesignation) {
+    if (pendingDesignation) {
+      await releasePendingDesignation();
+    }
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: unconsumedDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -81895,10 +82259,14 @@ function createReplayPressByTestId(interact) {
     }
     if (envelope.data?.action !== "designateTextInput")
       return { kind: "press" };
-    if (envelope.data.focusOnly !== true) {
+    if (envelope.data.focusOnly !== true || typeof envelope.data.designationToken !== "string" || envelope.data.designationToken.length === 0) {
       throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
     }
-    return { kind: "designation", focusOnly: true };
+    return {
+      kind: "designation",
+      focusOnly: true,
+      token: envelope.data.designationToken
+    };
   };
 }
 function nodeProps(treeJson, id) {
@@ -82002,10 +82370,13 @@ function buildCdpDispatch(deps, signal) {
       requireNotAborted();
       return deps.pressByTestId(id);
     },
-    async type(id, text) {
+    async type(id, text, context) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.typeByTestId(id, text);
+      await deps.typeByTestId(id, text, context);
+    },
+    async releaseDesignation(token2) {
+      await deps.releaseInputDesignation?.(token2);
     },
     async visibility(id) {
       await deps.treeFor(id);
@@ -97339,8 +97710,14 @@ var init_index = __esm({
       const tree = createComponentTreeHandler(getClient);
       return {
         pressByTestId: createReplayPressByTestId(interact),
-        typeByTestId: async (id, text) => {
-          mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
+        typeByTestId: async (id, text, context) => {
+          mustOk(await performReactTreeInput(id, text, getClient(), signal, context ? { designationToken: context.designationToken } : {}), `type "${id}"`);
+        },
+        releaseInputDesignation: async (token2) => {
+          try {
+            await getClient().evaluate(`__RN_AGENT.releaseInputDesignation(${JSON.stringify(token2)})`);
+          } catch {
+          }
         },
         treeFor: async (id) => {
           const fetchTree = async (interactiveOnly) => JSON.parse((await tree({

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -63917,7 +63917,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 50;
+    HELPERS_VERSION = 51;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -66455,6 +66455,73 @@ var init_injected_helpers = __esm({
 
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
+          if (opts.allowInputDesignation === true && opts.testID) {
+            var designationStack = [found];
+            var designationSeen = new WeakSet();
+            var designationInputs = [];
+            var designationWork = 0;
+            while (designationStack.length > 0 && designationWork < 2000) {
+              var designationFiber = designationStack.pop();
+              if (designationSeen.has(designationFiber)) continue;
+              designationSeen.add(designationFiber);
+              designationWork++;
+              var designationProps = designationFiber.memoizedProps || {};
+              if (
+                designationFiber.tag === 5
+                && typeof designationFiber.type === 'string'
+                && hostKind(designationFiber) === 'textinput'
+                && (designationProps.testID === selector || designationProps.nativeID === selector)
+              ) {
+                designationInputs.push(designationFiber);
+              }
+              var designationChild = designationFiber.child;
+              while (designationChild) {
+                designationStack.push(designationChild);
+                designationChild = designationChild.sibling;
+              }
+            }
+            if (designationStack.length > 0) {
+              return JSON.stringify({
+                error: 'TextInput designation resolution truncated',
+                testID: selector,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length > 1) {
+              return JSON.stringify({
+                error: 'Ambiguous TextInput designation target',
+                testID: selector,
+                count: designationInputs.length,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length === 1) {
+              var designationInput = designationInputs[0];
+              var designationInputProps = designationInput.memoizedProps || {};
+              var designationDisabled = function(candidateProps) {
+                return candidateProps.disabled === true
+                  || candidateProps.editable === false
+                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+              };
+              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
+                return JSON.stringify({
+                  error: 'TextInput is disabled or non-editable',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+              if (typeof designationInputProps.onPress !== 'function') {
+                return JSON.stringify({
+                  success: true,
+                  action: 'designateTextInput',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+            }
+          }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
         }
         if (opts.value !== undefined) {
@@ -81335,6 +81402,7 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = opts.initialFocusId ?? null;
+  let pendingDesignation = null;
   const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason, failureCode, failureMeta) => ({
     passed: false,
@@ -81353,6 +81421,8 @@ async function replayFlow(steps, dispatch, opts = {}) {
     const s = steps[i];
     const evidenceType = s.t === "waitVisible" ? s.evidenceType ?? s.t : s.t;
     const startedAt = Date.now();
+    if (pendingDesignation && s.t !== "type")
+      pendingDesignation = null;
     try {
       requireNotAborted();
       switch (s.t) {
@@ -81367,26 +81437,34 @@ async function replayFlow(steps, dispatch, opts = {}) {
           });
           break;
         case "tap":
-          await dispatch.press(s.id);
+          const pressResult = await dispatch.press(s.id);
           requireNotAborted();
-          lastTapped = s.id;
+          if (pressResult?.kind === "designation") {
+            lastTapped = null;
+            pendingDesignation = s.id;
+          } else {
+            lastTapped = s.id;
+          }
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
+            ...pressResult?.kind === "designation" ? { focusOnly: true } : {},
             ok: true,
             durationMs: Date.now() - startedAt
           });
           break;
         case "type": {
-          if (!lastTapped)
+          const target = pendingDesignation ?? lastTapped;
+          if (!target)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
-          await dispatch.type(lastTapped, s.text);
+          pendingDesignation = null;
+          await dispatch.type(target, s.text);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
-            target: lastTapped,
+            target,
             ok: true,
             durationMs: Date.now() - startedAt
           });
@@ -81483,6 +81561,9 @@ async function replayFlow(steps, dispatch, opts = {}) {
   }
   if (opts.signal?.aborted) {
     return fail3(Math.max(0, steps.length - 1), "React-tree replay exceeded its execution deadline", "RUNNER_TIMEOUT");
+  }
+  if (pendingDesignation) {
+    return fail3(Math.max(0, steps.length - 1), `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`, "INTERACTION_NOT_ACTUATED", { failedSelector: pendingDesignation, focusOnly: true });
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };
 }
@@ -81800,6 +81881,26 @@ function replayTreeData(envelope) {
     }
   });
 }
+function createReplayPressByTestId(interact) {
+  return async (id) => {
+    const result = await interact({
+      action: "press",
+      testID: id,
+      animated: false,
+      allowInputDesignation: true
+    });
+    const envelope = JSON.parse(result.content[0]?.text ?? "{}");
+    if (envelope.ok === false) {
+      throw new ReplayDispatchError(envelope.code ?? "INTERACTION_NOT_ACTUATED", `press "${id}" failed: ${envelope.error ?? "ok:false"}`, envelope.meta);
+    }
+    if (envelope.data?.action !== "designateTextInput")
+      return { kind: "press" };
+    if (envelope.data.focusOnly !== true) {
+      throw new ReplayDispatchError("INTERACTION_NOT_ACTUATED", `press "${id}" returned an invalid TextInput designation`);
+    }
+    return { kind: "designation", focusOnly: true };
+  };
+}
 function nodeProps(treeJson, id) {
   const stack = [treeJson];
   while (stack.length) {
@@ -81899,7 +82000,7 @@ function buildCdpDispatch(deps, signal) {
     async press(id) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.pressByTestId(id);
+      return deps.pressByTestId(id);
     },
     async type(id, text) {
       await assertExactInteractable(id);
@@ -82430,9 +82531,12 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of replay.steps) {
               if (step.t === "launch")
                 reactFocusId = void 0;
-              if (step.t === "tap" && step.target)
-                reactFocusId = step.target;
+              if (step.t === "tap" && step.target) {
+                reactFocusId = step.focusOnly ? void 0 : step.target;
+              }
             }
+            if (replay.finalFocusId === null)
+              reactFocusId = void 0;
             return { replay, sourceIndices };
           }, claimOrigin, completeOrigin, relaunchManagedApp, reproveManagedOrigin, { signal: controller.signal });
           retainedReactFocusId = reactFocusId;
@@ -82442,6 +82546,7 @@ function createMaestroRunHandler(deps = {}) {
                 index: sourceIndices[step.sourceIndex] ?? step.sourceIndex,
                 name: step.t,
                 verb: step.t,
+                ...step.focusOnly ? { focusOnly: true } : {},
                 status: step.ok ? "pass" : "fail",
                 durationMs: step.durationMs
               });
@@ -82517,6 +82622,7 @@ function createMaestroRunHandler(deps = {}) {
                 name: String(record2.t ?? "unknown"),
                 verb: String(record2.t ?? "unknown"),
                 ...record2.target !== void 0 ? { target: String(record2.target) } : {},
+                ...record2.focusOnly === true ? { focusOnly: true } : {},
                 status: record2.ok === false ? "fail" : "pass",
                 durationMs: Number(record2.durationMs ?? 0)
               });
@@ -82531,6 +82637,7 @@ function createMaestroRunHandler(deps = {}) {
               index: failure.sourceIndices[step.sourceIndex] ?? step.sourceIndex,
               name: step.t,
               verb: step.t,
+              ...step.focusOnly ? { focusOnly: true } : {},
               status: step.ok ? "pass" : "fail",
               durationMs: step.durationMs
             });
@@ -84781,6 +84888,8 @@ function createInteractHandler(getClient2) {
       opts.includeHidden = args.includeHidden;
     if (args.walkUp !== void 0)
       opts.walkUp = args.walkUp;
+    if (args.allowInputDesignation !== void 0)
+      opts.allowInputDesignation = args.allowInputDesignation;
     const result = await client2.evaluate(`__RN_AGENT.interact(${JSON.stringify(opts)})`);
     if (result.error) {
       return failResult(`Interact error: ${result.error}`);
@@ -97229,9 +97338,7 @@ var init_index = __esm({
       const interact = createInteractHandler(getClient);
       const tree = createComponentTreeHandler(getClient);
       return {
-        pressByTestId: async (id) => {
-          mustOk(await interact({ action: "press", testID: id, animated: false }), `press "${id}"`);
-        },
+        pressByTestId: createReplayPressByTestId(interact),
         typeByTestId: async (id, text) => {
           mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
         },

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -274,6 +274,7 @@ export async function replayFlow(
   const trace: ReplayResult['steps'] = [];
   let lastTapped: string | null = opts.initialFocusId ?? null;
   let pendingDesignation: string | null = null;
+  let staleDesignation: string | null = null;
   const sourceIndex = (i: number): number => opts.sourceIndex ?? i + offset;
 
   const fail = (
@@ -303,7 +304,10 @@ export async function replayFlow(
     const s = steps[i];
     const evidenceType = s.t === 'waitVisible' ? (s.evidenceType ?? s.t) : s.t;
     const startedAt = Date.now();
-    if (pendingDesignation && s.t !== 'type') pendingDesignation = null;
+    if (pendingDesignation && s.t !== 'type') {
+      staleDesignation = staleDesignation ?? pendingDesignation;
+      pendingDesignation = null;
+    }
     try {
       requireNotAborted();
       switch (s.t) {
@@ -476,12 +480,13 @@ export async function replayFlow(
       'RUNNER_TIMEOUT',
     );
   }
-  if (pendingDesignation) {
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
+  if (unconsumedDesignation) {
     return fail(
       Math.max(0, steps.length - 1),
-      `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`,
+      `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`,
       'INTERACTION_NOT_ACTUATED',
-      { failedSelector: pendingDesignation, focusOnly: true },
+      { failedSelector: unconsumedDesignation, focusOnly: true },
     );
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -16,15 +16,19 @@ export class UnsupportedStepError extends Error {
 export interface ReplayDispatch {
   press(id: string): Promise<ReplayPressResult | void>;
   type(id: string, text: string, context?: ReplayTypeContext): Promise<void>;
+  releaseDesignation?(token: string): Promise<void>;
   visibility(id: string): Promise<ReplayVisibility>;
   launch(stopApp: boolean): Promise<void>;
   settle(timeoutMs: number): Promise<void>;
 }
 
-export type ReplayPressResult = { kind: 'press' } | { kind: 'designation'; focusOnly: true };
+export type ReplayPressResult =
+  | { kind: 'press' }
+  | { kind: 'designation'; focusOnly: true; token: string };
 
 export interface ReplayTypeContext {
   focusOnlyDesignation: true;
+  designationToken: string;
 }
 
 export interface ReplayVisibility {
@@ -273,7 +277,7 @@ export async function replayFlow(
   const offset = opts.indexOffset ?? 0;
   const trace: ReplayResult['steps'] = [];
   let lastTapped: string | null = opts.initialFocusId ?? null;
-  let pendingDesignation: string | null = null;
+  let pendingDesignation: { id: string; token: string } | null = null;
   let staleDesignation: string | null = null;
   const sourceIndex = (i: number): number => opts.sourceIndex ?? i + offset;
 
@@ -299,14 +303,26 @@ export async function replayFlow(
       );
     }
   };
+  const releaseDesignation = async (token: string): Promise<void> => {
+    try {
+      await dispatch.releaseDesignation?.(token);
+    } catch {}
+  };
+  const releasePendingDesignation = async (): Promise<void> => {
+    const designation = pendingDesignation;
+    pendingDesignation = null;
+    if (designation) await releaseDesignation(designation.token);
+  };
 
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     const evidenceType = s.t === 'waitVisible' ? (s.evidenceType ?? s.t) : s.t;
     const startedAt = Date.now();
     if (pendingDesignation && s.t !== 'type') {
-      staleDesignation = staleDesignation ?? pendingDesignation;
+      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      const staleToken = pendingDesignation.token;
       pendingDesignation = null;
+      await releaseDesignation(staleToken);
     }
     try {
       requireNotAborted();
@@ -323,13 +339,13 @@ export async function replayFlow(
           break;
         case 'tap':
           const pressResult = await dispatch.press(s.id);
-          requireNotAborted();
           if (pressResult?.kind === 'designation') {
             lastTapped = null;
-            pendingDesignation = s.id;
+            pendingDesignation = { id: s.id, token: pressResult.token };
           } else {
             lastTapped = s.id;
           }
+          requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
@@ -340,15 +356,24 @@ export async function replayFlow(
           });
           break;
         case 'type': {
-          const target = pendingDesignation ?? lastTapped;
+          const designation = pendingDesignation;
+          const target = designation?.id ?? lastTapped;
           if (!target) return fail(i, 'inputText before any tapOn — no focus target');
-          const focusOnlyDesignation = pendingDesignation !== null;
           pendingDesignation = null;
-          await dispatch.type(
-            target,
-            s.text,
-            focusOnlyDesignation ? { focusOnlyDesignation: true } : undefined,
-          );
+          try {
+            await dispatch.type(
+              target,
+              s.text,
+              designation
+                ? {
+                    focusOnlyDesignation: true,
+                    designationToken: designation.token,
+                  }
+                : undefined,
+            );
+          } finally {
+            if (designation) await releaseDesignation(designation.token);
+          }
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
@@ -456,6 +481,7 @@ export async function replayFlow(
       }
     } catch (e) {
       const waitedMs = Date.now() - startedAt;
+      await releasePendingDesignation();
       trace.push({
         sourceIndex: sourceIndex(i),
         t: evidenceType,
@@ -474,14 +500,18 @@ export async function replayFlow(
   }
 
   if (opts.signal?.aborted) {
+    await releasePendingDesignation();
     return fail(
       Math.max(0, steps.length - 1),
       'React-tree replay exceeded its execution deadline',
       'RUNNER_TIMEOUT',
     );
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
   if (unconsumedDesignation) {
+    if (pendingDesignation) {
+      await releasePendingDesignation();
+    }
     return fail(
       Math.max(0, steps.length - 1),
       `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`,

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -15,13 +15,17 @@ export class UnsupportedStepError extends Error {
 
 export interface ReplayDispatch {
   press(id: string): Promise<ReplayPressResult | void>;
-  type(id: string, text: string): Promise<void>;
+  type(id: string, text: string, context?: ReplayTypeContext): Promise<void>;
   visibility(id: string): Promise<ReplayVisibility>;
   launch(stopApp: boolean): Promise<void>;
   settle(timeoutMs: number): Promise<void>;
 }
 
 export type ReplayPressResult = { kind: 'press' } | { kind: 'designation'; focusOnly: true };
+
+export interface ReplayTypeContext {
+  focusOnlyDesignation: true;
+}
 
 export interface ReplayVisibility {
   visible: boolean;
@@ -334,8 +338,13 @@ export async function replayFlow(
         case 'type': {
           const target = pendingDesignation ?? lastTapped;
           if (!target) return fail(i, 'inputText before any tapOn — no focus target');
+          const focusOnlyDesignation = pendingDesignation !== null;
           pendingDesignation = null;
-          await dispatch.type(target, s.text);
+          await dispatch.type(
+            target,
+            s.text,
+            focusOnlyDesignation ? { focusOnlyDesignation: true } : undefined,
+          );
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -277,8 +277,8 @@ export async function replayFlow(
   const offset = opts.indexOffset ?? 0;
   const trace: ReplayResult['steps'] = [];
   let lastTapped: string | null = opts.initialFocusId ?? null;
-  let pendingDesignation: { id: string; token: string } | null = null;
-  let staleDesignation: string | null = null;
+  let pendingDesignation: { id: string; token: string; index: number } | null = null;
+  let staleDesignation: { id: string; index: number } | null = null;
   const sourceIndex = (i: number): number => opts.sourceIndex ?? i + offset;
 
   const fail = (
@@ -320,7 +320,10 @@ export async function replayFlow(
     const startedAt = Date.now();
     let stepFocusOnly: true | undefined;
     if (pendingDesignation && s.t !== 'type') {
-      staleDesignation = staleDesignation ?? pendingDesignation.id;
+      staleDesignation = staleDesignation ?? {
+        id: pendingDesignation.id,
+        index: pendingDesignation.index,
+      };
       const staleToken = pendingDesignation.token;
       pendingDesignation = null;
       await releaseDesignation(staleToken);
@@ -342,7 +345,7 @@ export async function replayFlow(
           const pressResult = await dispatch.press(s.id);
           if (pressResult?.kind === 'designation') {
             lastTapped = null;
-            pendingDesignation = { id: s.id, token: pressResult.token };
+            pendingDesignation = { id: s.id, token: pressResult.token, index: i };
             stepFocusOnly = true;
           } else {
             lastTapped = s.id;
@@ -510,16 +513,16 @@ export async function replayFlow(
       'RUNNER_TIMEOUT',
     );
   }
-  const unconsumedDesignation = staleDesignation ?? pendingDesignation?.id;
+  const unconsumedDesignation = staleDesignation ?? pendingDesignation;
   if (unconsumedDesignation) {
     if (pendingDesignation) {
       await releasePendingDesignation();
     }
     return fail(
-      Math.max(0, steps.length - 1),
-      `TextInput designation for "${unconsumedDesignation}" must be followed immediately by inputText`,
+      unconsumedDesignation.index,
+      `TextInput designation for "${unconsumedDesignation.id}" must be followed immediately by inputText`,
       'INTERACTION_NOT_ACTUATED',
-      { failedSelector: unconsumedDesignation, focusOnly: true },
+      { failedSelector: unconsumedDesignation.id, focusOnly: true },
     );
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -14,12 +14,14 @@ export class UnsupportedStepError extends Error {
 }
 
 export interface ReplayDispatch {
-  press(id: string): Promise<void>;
+  press(id: string): Promise<ReplayPressResult | void>;
   type(id: string, text: string): Promise<void>;
   visibility(id: string): Promise<ReplayVisibility>;
   launch(stopApp: boolean): Promise<void>;
   settle(timeoutMs: number): Promise<void>;
 }
+
+export type ReplayPressResult = { kind: 'press' } | { kind: 'designation'; focusOnly: true };
 
 export interface ReplayVisibility {
   visible: boolean;
@@ -46,7 +48,14 @@ export interface ReplayResult {
   failureCode?: string;
   failureMeta?: Record<string, unknown>;
   reason?: string;
-  steps: { sourceIndex: number; t: string; target?: string; ok: boolean; durationMs: number }[];
+  steps: {
+    sourceIndex: number;
+    t: string;
+    target?: string;
+    focusOnly?: true;
+    ok: boolean;
+    durationMs: number;
+  }[];
 }
 
 const interp = (s: string, p: Record<string, string>): string =>
@@ -260,6 +269,7 @@ export async function replayFlow(
   const offset = opts.indexOffset ?? 0;
   const trace: ReplayResult['steps'] = [];
   let lastTapped: string | null = opts.initialFocusId ?? null;
+  let pendingDesignation: string | null = null;
   const sourceIndex = (i: number): number => opts.sourceIndex ?? i + offset;
 
   const fail = (
@@ -289,6 +299,7 @@ export async function replayFlow(
     const s = steps[i];
     const evidenceType = s.t === 'waitVisible' ? (s.evidenceType ?? s.t) : s.t;
     const startedAt = Date.now();
+    if (pendingDesignation && s.t !== 'type') pendingDesignation = null;
     try {
       requireNotAborted();
       switch (s.t) {
@@ -303,25 +314,33 @@ export async function replayFlow(
           });
           break;
         case 'tap':
-          await dispatch.press(s.id);
+          const pressResult = await dispatch.press(s.id);
           requireNotAborted();
-          lastTapped = s.id;
+          if (pressResult?.kind === 'designation') {
+            lastTapped = null;
+            pendingDesignation = s.id;
+          } else {
+            lastTapped = s.id;
+          }
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
+            ...(pressResult?.kind === 'designation' ? { focusOnly: true as const } : {}),
             ok: true,
             durationMs: Date.now() - startedAt,
           });
           break;
         case 'type': {
-          if (!lastTapped) return fail(i, 'inputText before any tapOn — no focus target');
-          await dispatch.type(lastTapped, s.text);
+          const target = pendingDesignation ?? lastTapped;
+          if (!target) return fail(i, 'inputText before any tapOn — no focus target');
+          pendingDesignation = null;
+          await dispatch.type(target, s.text);
           requireNotAborted();
           trace.push({
             sourceIndex: sourceIndex(i),
             t: s.t,
-            target: lastTapped,
+            target,
             ok: true,
             durationMs: Date.now() - startedAt,
           });
@@ -446,6 +465,14 @@ export async function replayFlow(
       Math.max(0, steps.length - 1),
       'React-tree replay exceeded its execution deadline',
       'RUNNER_TIMEOUT',
+    );
+  }
+  if (pendingDesignation) {
+    return fail(
+      Math.max(0, steps.length - 1),
+      `TextInput designation for "${pendingDesignation}" must be followed immediately by inputText`,
+      'INTERACTION_NOT_ACTUATED',
+      { failedSelector: pendingDesignation, focusOnly: true },
     );
   }
   return { passed: true, finalFocusId: lastTapped, steps: trace };

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -318,6 +318,7 @@ export async function replayFlow(
     const s = steps[i];
     const evidenceType = s.t === 'waitVisible' ? (s.evidenceType ?? s.t) : s.t;
     const startedAt = Date.now();
+    let stepFocusOnly: true | undefined;
     if (pendingDesignation && s.t !== 'type') {
       staleDesignation = staleDesignation ?? pendingDesignation.id;
       const staleToken = pendingDesignation.token;
@@ -342,6 +343,7 @@ export async function replayFlow(
           if (pressResult?.kind === 'designation') {
             lastTapped = null;
             pendingDesignation = { id: s.id, token: pressResult.token };
+            stepFocusOnly = true;
           } else {
             lastTapped = s.id;
           }
@@ -350,7 +352,7 @@ export async function replayFlow(
             sourceIndex: sourceIndex(i),
             t: s.t,
             target: s.id,
-            ...(pressResult?.kind === 'designation' ? { focusOnly: true as const } : {}),
+            ...(stepFocusOnly ? { focusOnly: stepFocusOnly } : {}),
             ok: true,
             durationMs: Date.now() - startedAt,
           });
@@ -486,6 +488,7 @@ export async function replayFlow(
         sourceIndex: sourceIndex(i),
         t: evidenceType,
         target: 'id' in s ? s.id : undefined,
+        ...(stepFocusOnly ? { focusOnly: stepFocusOnly } : {}),
         ok: false,
         durationMs: waitedMs,
       });

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -279,6 +279,7 @@ export async function replayFlow(
   let lastTapped: string | null = opts.initialFocusId ?? null;
   let pendingDesignation: { id: string; token: string; index: number } | null = null;
   let staleDesignation: { id: string; index: number } | null = null;
+  let consumedDesignationId: string | null = null;
   const sourceIndex = (i: number): number => opts.sourceIndex ?? i + offset;
 
   const fail = (
@@ -363,8 +364,15 @@ export async function replayFlow(
         case 'type': {
           const designation = pendingDesignation;
           const target = designation?.id ?? lastTapped;
-          if (!target) return fail(i, 'inputText before any tapOn — no focus target');
+          if (!target)
+            return fail(
+              i,
+              consumedDesignationId
+                ? `the TextInput designation for "${consumedDesignationId}" was already consumed — tapOn the field again before typing`
+                : 'inputText before any tapOn — no focus target',
+            );
           pendingDesignation = null;
+          if (designation) consumedDesignationId = designation.id;
           try {
             await dispatch.type(
               target,

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -375,11 +375,20 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
     pressByTestId: createReplayPressByTestId(interact),
     typeByTestId: async (id: string, text: string, context) => {
       mustOk(
-        await performReactTreeInput(id, text, getClient(), signal, {
-          requireLiveInputDesignation: context?.focusOnlyDesignation === true,
-        }),
+        await performReactTreeInput(
+          id,
+          text,
+          getClient(),
+          signal,
+          context ? { designationToken: context.designationToken } : {},
+        ),
         `type "${id}"`,
       );
+    },
+    releaseInputDesignation: async (token: string) => {
+      try {
+        await getClient().evaluate(`__RN_AGENT.releaseInputDesignation(${JSON.stringify(token)})`);
+      } catch {}
     },
     treeFor: async (id: string) => {
       const fetchTree = async (interactiveOnly: boolean) =>

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -373,8 +373,13 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
   const tree = createComponentTreeHandler(getClient);
   return {
     pressByTestId: createReplayPressByTestId(interact),
-    typeByTestId: async (id: string, text: string) => {
-      mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
+    typeByTestId: async (id: string, text: string, context) => {
+      mustOk(
+        await performReactTreeInput(id, text, getClient(), signal, {
+          requireLiveInputDesignation: context?.focusOnlyDesignation === true,
+        }),
+        `type "${id}"`,
+      );
     },
     treeFor: async (id: string) => {
       const fetchTree = async (interactiveOnly: boolean) =>

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -43,7 +43,11 @@ import { createRepairActionHandler } from './tools/repair-action.js';
 import { createSaveAsActionHandler } from './tools/save-as-action.js';
 import { createRunActionHandler } from './tools/run-action.js';
 import { createLoginPrologueHandler } from './tools/login-prologue.js';
-import { replayTreeData, unwrapTree } from './tools/cdp-replay-dispatch.js';
+import {
+  createReplayPressByTestId,
+  replayTreeData,
+  unwrapTree,
+} from './tools/cdp-replay-dispatch.js';
 import type { CdpReplayDeps } from './tools/cdp-replay-dispatch.js';
 import { ReplayDispatchError } from './domain/cdp-flow-replay.js';
 import { createDispatchHandler } from './tools/dispatch.js';
@@ -368,9 +372,7 @@ const makeReplayDeps = (_args?: unknown, signal?: AbortSignal): CdpReplayDeps | 
   const interact = createInteractHandler(getClient);
   const tree = createComponentTreeHandler(getClient);
   return {
-    pressByTestId: async (id: string) => {
-      mustOk(await interact({ action: 'press', testID: id, animated: false }), `press "${id}"`);
-    },
+    pressByTestId: createReplayPressByTestId(interact),
     typeByTestId: async (id: string, text: string) => {
       mustOk(await performReactTreeInput(id, text, getClient(), signal), `type "${id}"`);
     },

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 58;
+export const HELPERS_VERSION = 59;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2156,6 +2156,38 @@ export const INJECTED_HELPERS = `
         });
       }
     }
+
+    function bindingDescendsFrom(descendant, ancestor) {
+      var cursor = descendant.candidateFiber.return;
+      var returnSeen = new WeakSet();
+      while (cursor) {
+        if (!consumeWork()) return false;
+        if (returnSeen.has(cursor)) {
+          state.truncated = true;
+          state.reason = 'cycle';
+          return false;
+        }
+        returnSeen.add(cursor);
+        if (sameTypeTextFiber(cursor, ancestor.candidateFiber)) return true;
+        cursor = cursor.return;
+      }
+      return false;
+    }
+
+    // RN TextInput renders one element as a composite fiber plus its host child sharing one handler; keep the deepest (press's match-deepest-only rule).
+    function collapseLineageBindings(all) {
+      return all.filter(function(binding) {
+        return !all.some(function(other) {
+          return !state.truncated
+            && other !== binding
+            && other.handler === binding.handler
+            && other.contract === binding.contract
+            && bindingDescendsFrom(other, binding);
+        });
+      });
+    }
+
+    if (!state.truncated && bindings.length > 1) bindings = collapseLineageBindings(bindings);
 
     if (state.truncated) return typeTextTruncation(state);
     if (bindings.length > 1) {

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 51;
+export const HELPERS_VERSION = 52;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2193,6 +2193,30 @@ export const INJECTED_HELPERS = `
   }
 
   function executeTypeTextTransaction(opts) {
+    var designationSelector = opts.testID;
+    if (opts.requireLiveInputDesignation === true) {
+      var liveFrontmost;
+      try {
+        liveFrontmost = JSON.parse(isTestIdFrontmost(designationSelector));
+      } catch (_) {
+        liveFrontmost = null;
+      }
+      if (!liveFrontmost || liveFrontmost.visible !== true) {
+        return {
+          error: liveFrontmost && liveFrontmost.reason
+            ? liveFrontmost.reason
+            : 'TextInput designation frontmost state is unreadable',
+          code: liveFrontmost && liveFrontmost.code
+            ? liveFrontmost.code
+            : (liveFrontmost && liveFrontmost.matchCount > 1
+              ? 'AMBIGUOUS_TESTID'
+              : 'ASSERTION_FAILED'),
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+    }
     var resolution = resolveTypeTextTarget(opts);
     if (resolution.error) return resolution;
     var binding = resolution.binding;
@@ -2206,6 +2230,45 @@ export const INJECTED_HELPERS = `
         visitedFibers: resolution.state.visitedFibers,
         hint: 'Inspected every matching fiber and its bounded ownership graph — no typeable handler exists. Use cdp_component_tree to inspect the field, or pass the inner field testID directly.'
       };
+    }
+    if (opts.requireLiveInputDesignation === true) {
+      var designationSourceProps = binding.sourceFiber.memoizedProps || {};
+      if (
+        typeof designationSelector !== 'string'
+        || !designationSelector
+        || hostKind(binding.sourceFiber) !== 'textinput'
+        || (
+          designationSourceProps.testID !== designationSelector
+          && designationSourceProps.nativeID !== designationSelector
+        )
+      ) {
+        return {
+          error: 'TextInput designation no longer resolves to the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var designationCandidateProps = binding.candidateFiber.memoizedProps || {};
+      var designationIsDisabled = function(candidateProps) {
+        return candidateProps.disabled === true
+          || candidateProps.editable === false
+          || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+      };
+      if (
+        designationIsDisabled(designationSourceProps)
+        || designationIsDisabled(designationCandidateProps)
+      ) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          component: binding.component,
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
     }
     var text = opts.text !== undefined ? opts.text : '';
     try {

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 52;
+export const HELPERS_VERSION = 53;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2192,6 +2192,78 @@ export const INJECTED_HELPERS = `
     };
   }
 
+  function textInputDesignationDisabled(candidateProps) {
+    return candidateProps.disabled === true
+      || candidateProps.editable === false
+      || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+  }
+
+  function resolveTextInputDesignation(owner, selector) {
+    if (!owner) return null;
+    var designationStack = [owner];
+    var designationSeen = new WeakSet();
+    var designationInputs = [];
+    var designationWork = 0;
+    while (designationStack.length > 0 && designationWork < 2000) {
+      var designationFiber = designationStack.pop();
+      if (designationSeen.has(designationFiber)) continue;
+      designationSeen.add(designationFiber);
+      designationWork++;
+      var designationProps = designationFiber.memoizedProps || {};
+      if (
+        designationFiber.tag === 5
+        && typeof designationFiber.type === 'string'
+        && hostKind(designationFiber) === 'textinput'
+        && (designationProps.testID === selector || designationProps.nativeID === selector)
+      ) {
+        designationInputs.push(designationFiber);
+      }
+      var designationChild = designationFiber.child;
+      while (designationChild) {
+        designationStack.push(designationChild);
+        designationChild = designationChild.sibling;
+      }
+    }
+    if (designationStack.length > 0) {
+      return {
+        error: 'TextInput designation resolution truncated',
+        testID: selector,
+        focusOnly: true
+      };
+    }
+    if (designationInputs.length > 1) {
+      return {
+        error: 'Ambiguous TextInput designation target',
+        testID: selector,
+        count: designationInputs.length,
+        focusOnly: true
+      };
+    }
+    if (designationInputs.length !== 1) return null;
+    var designationInput = designationInputs[0];
+    var designationOwnerProps = owner.memoizedProps || {};
+    var designationInputProps = designationInput.memoizedProps || {};
+    if (
+      textInputDesignationDisabled(designationOwnerProps)
+      || textInputDesignationDisabled(designationInputProps)
+    ) {
+      return {
+        error: 'TextInput is disabled or non-editable',
+        component: typeTextFiberName(designationInput),
+        testID: selector,
+        focusOnly: true
+      };
+    }
+    if (typeof designationInputProps.onPress === 'function') return null;
+    return {
+      success: true,
+      action: 'designateTextInput',
+      component: typeTextFiberName(designationInput),
+      testID: selector,
+      focusOnly: true
+    };
+  }
+
   function executeTypeTextTransaction(opts) {
     var designationSelector = opts.testID;
     if (opts.requireLiveInputDesignation === true) {
@@ -2250,16 +2322,55 @@ export const INJECTED_HELPERS = `
           handlerCalled: false
         };
       }
+      var designationOwner = binding.sourceFiber;
+      var designationOwnerCursor = binding.sourceFiber.return;
+      var designationOwnerSeen = new WeakSet();
+      var designationOwnerDepth = 0;
+      while (designationOwnerCursor && designationOwnerDepth < 1000) {
+        if (designationOwnerSeen.has(designationOwnerCursor)) {
+          designationOwnerCursor = null;
+          designationOwnerDepth = 1000;
+          break;
+        }
+        designationOwnerSeen.add(designationOwnerCursor);
+        designationOwnerDepth++;
+        var designationOwnerProps = designationOwnerCursor.memoizedProps || {};
+        if (
+          designationOwnerProps.testID === designationSelector
+          || designationOwnerProps.nativeID === designationSelector
+        ) {
+          designationOwner = designationOwnerCursor;
+        }
+        designationOwnerCursor = designationOwnerCursor.return;
+      }
+      if (designationOwnerCursor || designationOwnerDepth >= 1000) {
+        return {
+          error: 'TextInput designation ownership resolution truncated',
+          code: 'ASSERTION_FAILED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
+      var liveDesignation = resolveTextInputDesignation(designationOwner, designationSelector);
+      if (!liveDesignation || liveDesignation.success !== true) {
+        if (!liveDesignation) {
+          return {
+            error: 'TextInput designation no longer resolves to the exact host input',
+            code: 'INTERACTION_NOT_ACTUATED',
+            testID: designationSelector,
+            focusOnly: true,
+            handlerCalled: false
+          };
+        }
+        liveDesignation.code = liveDesignation.error === 'TextInput designation resolution truncated'
+          ? 'ASSERTION_FAILED'
+          : 'INTERACTION_NOT_ACTUATED';
+        liveDesignation.handlerCalled = false;
+        return liveDesignation;
+      }
       var designationCandidateProps = binding.candidateFiber.memoizedProps || {};
-      var designationIsDisabled = function(candidateProps) {
-        return candidateProps.disabled === true
-          || candidateProps.editable === false
-          || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
-      };
-      if (
-        designationIsDisabled(designationSourceProps)
-        || designationIsDisabled(designationCandidateProps)
-      ) {
+      if (textInputDesignationDisabled(designationCandidateProps)) {
         return {
           error: 'TextInput is disabled or non-editable',
           code: 'INTERACTION_NOT_ACTUATED',
@@ -2605,71 +2716,8 @@ export const INJECTED_HELPERS = `
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
           if (opts.allowInputDesignation === true && opts.testID) {
-            var designationStack = [found];
-            var designationSeen = new WeakSet();
-            var designationInputs = [];
-            var designationWork = 0;
-            while (designationStack.length > 0 && designationWork < 2000) {
-              var designationFiber = designationStack.pop();
-              if (designationSeen.has(designationFiber)) continue;
-              designationSeen.add(designationFiber);
-              designationWork++;
-              var designationProps = designationFiber.memoizedProps || {};
-              if (
-                designationFiber.tag === 5
-                && typeof designationFiber.type === 'string'
-                && hostKind(designationFiber) === 'textinput'
-                && (designationProps.testID === selector || designationProps.nativeID === selector)
-              ) {
-                designationInputs.push(designationFiber);
-              }
-              var designationChild = designationFiber.child;
-              while (designationChild) {
-                designationStack.push(designationChild);
-                designationChild = designationChild.sibling;
-              }
-            }
-            if (designationStack.length > 0) {
-              return JSON.stringify({
-                error: 'TextInput designation resolution truncated',
-                testID: selector,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length > 1) {
-              return JSON.stringify({
-                error: 'Ambiguous TextInput designation target',
-                testID: selector,
-                count: designationInputs.length,
-                focusOnly: true
-              });
-            }
-            if (designationInputs.length === 1) {
-              var designationInput = designationInputs[0];
-              var designationInputProps = designationInput.memoizedProps || {};
-              var designationDisabled = function(candidateProps) {
-                return candidateProps.disabled === true
-                  || candidateProps.editable === false
-                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
-              };
-              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
-                return JSON.stringify({
-                  error: 'TextInput is disabled or non-editable',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
-              if (typeof designationInputProps.onPress !== 'function') {
-                return JSON.stringify({
-                  success: true,
-                  action: 'designateTextInput',
-                  component: typeTextFiberName(designationInput),
-                  testID: selector,
-                  focusOnly: true
-                });
-              }
-            }
+            var designation = resolveTextInputDesignation(found, selector);
+            if (designation) return JSON.stringify(designation);
           }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
         }

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 53;
+export const HELPERS_VERSION = 54;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2198,6 +2198,63 @@ export const INJECTED_HELPERS = `
       || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
   }
 
+  function textInputDesignationInteractivity(input, selector) {
+    var current = input;
+    var seen = new WeakSet();
+    var depth = 0;
+    while (current && depth < 1000) {
+      if (seen.has(current)) {
+        return {
+          error: 'TextInput designation interactivity resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      seen.add(current);
+      if (isSubtreeInaccessible(current)) {
+        return {
+          error: 'TextInput designation target is hidden or occluded',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      var props = current.memoizedProps || {};
+      var pointerEvents = props.pointerEvents;
+      if (
+        current === input
+        && (pointerEvents === 'none' || pointerEvents === 'box-none')
+      ) {
+        return {
+          error: 'TextInput designation target is not user-interactable with pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      if (
+        current !== input
+        && (pointerEvents === 'none' || pointerEvents === 'box-only')
+      ) {
+        return {
+          error: 'TextInput designation target is blocked beneath pointerEvents="' + pointerEvents + '"',
+          testID: selector,
+          focusOnly: true
+        };
+      }
+      current = current.return;
+      depth++;
+    }
+    if (current) {
+      return {
+        error: 'TextInput designation interactivity resolution truncated',
+        testID: selector,
+        focusOnly: true,
+        truncated: true
+      };
+    }
+    return null;
+  }
+
   function resolveTextInputDesignation(owner, selector) {
     if (!owner) return null;
     var designationStack = [owner];
@@ -2228,7 +2285,8 @@ export const INJECTED_HELPERS = `
       return {
         error: 'TextInput designation resolution truncated',
         testID: selector,
-        focusOnly: true
+        focusOnly: true,
+        truncated: true
       };
     }
     if (designationInputs.length > 1) {
@@ -2254,6 +2312,11 @@ export const INJECTED_HELPERS = `
         focusOnly: true
       };
     }
+    var designationInteractivity = textInputDesignationInteractivity(
+      designationInput,
+      selector
+    );
+    if (designationInteractivity) return designationInteractivity;
     if (typeof designationInputProps.onPress === 'function') return null;
     return {
       success: true,
@@ -2363,7 +2426,7 @@ export const INJECTED_HELPERS = `
             handlerCalled: false
           };
         }
-        liveDesignation.code = liveDesignation.error === 'TextInput designation resolution truncated'
+        liveDesignation.code = liveDesignation.truncated === true
           ? 'ASSERTION_FAILED'
           : 'INTERACTION_NOT_ACTUATED';
         liveDesignation.handlerCalled = false;

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 54;
+export const HELPERS_VERSION = 55;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2259,6 +2259,7 @@ export const INJECTED_HELPERS = `
     if (!owner) return null;
     var designationStack = [owner];
     var designationSeen = new WeakSet();
+    var designationMatches = [];
     var designationInputs = [];
     var designationWork = 0;
     while (designationStack.length > 0 && designationWork < 2000) {
@@ -2267,11 +2268,16 @@ export const INJECTED_HELPERS = `
       designationSeen.add(designationFiber);
       designationWork++;
       var designationProps = designationFiber.memoizedProps || {};
+      var designationMatchesSelector = designationProps.testID === selector
+        || designationProps.nativeID === selector;
+      if (designationMatchesSelector) {
+        designationMatches.push(designationFiber);
+      }
       if (
         designationFiber.tag === 5
         && typeof designationFiber.type === 'string'
         && hostKind(designationFiber) === 'textinput'
-        && (designationProps.testID === selector || designationProps.nativeID === selector)
+        && designationMatchesSelector
       ) {
         designationInputs.push(designationFiber);
       }
@@ -2299,18 +2305,50 @@ export const INJECTED_HELPERS = `
     }
     if (designationInputs.length !== 1) return null;
     var designationInput = designationInputs[0];
-    var designationOwnerProps = owner.memoizedProps || {};
     var designationInputProps = designationInput.memoizedProps || {};
-    if (
-      textInputDesignationDisabled(designationOwnerProps)
-      || textInputDesignationDisabled(designationInputProps)
-    ) {
+    var designationLineage = new WeakSet();
+    var designationLineageFiber = designationInput;
+    var designationLineageDepth = 0;
+    while (designationLineageFiber && designationLineageDepth < 1000) {
+      if (designationLineage.has(designationLineageFiber)) {
+        return {
+          error: 'TextInput designation resolution truncated',
+          testID: selector,
+          focusOnly: true,
+          truncated: true
+        };
+      }
+      designationLineage.add(designationLineageFiber);
+      if (designationLineageFiber === owner) break;
+      designationLineageFiber = designationLineageFiber.return;
+      designationLineageDepth++;
+    }
+    if (designationLineageFiber !== owner) {
       return {
-        error: 'TextInput is disabled or non-editable',
-        component: typeTextFiberName(designationInput),
+        error: 'TextInput designation resolution truncated',
         testID: selector,
-        focusOnly: true
+        focusOnly: true,
+        truncated: true
       };
+    }
+    for (var designationIndex = 0; designationIndex < designationMatches.length; designationIndex++) {
+      var designationMatch = designationMatches[designationIndex];
+      if (!designationLineage.has(designationMatch)) {
+        return {
+          error: 'Ambiguous TextInput designation target',
+          testID: selector,
+          count: designationMatches.length,
+          focusOnly: true
+        };
+      }
+      if (textInputDesignationDisabled(designationMatch.memoizedProps || {})) {
+        return {
+          error: 'TextInput is disabled or non-editable',
+          component: typeTextFiberName(designationInput),
+          testID: selector,
+          focusOnly: true
+        };
+      }
     }
     var designationInteractivity = textInputDesignationInteractivity(
       designationInput,

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 55;
+export const HELPERS_VERSION = 56;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2255,6 +2255,48 @@ export const INJECTED_HELPERS = `
     return null;
   }
 
+  var activeTextInputDesignation = null;
+  var textInputDesignationSequence = 0;
+
+  function retainTextInputDesignation(input, selector) {
+    textInputDesignationSequence++;
+    var token = Date.now().toString(36) + '-' + textInputDesignationSequence.toString(36);
+    activeTextInputDesignation = {
+      token: token,
+      input: input,
+      selector: selector
+    };
+    return token;
+  }
+
+  function consumeTextInputDesignation(token, selector) {
+    var designation = activeTextInputDesignation;
+    if (
+      !designation
+      || designation.token !== token
+      || designation.selector !== selector
+    ) {
+      return null;
+    }
+    activeTextInputDesignation = null;
+    return designation;
+  }
+
+  function releaseInputDesignation(token) {
+    var released = !!activeTextInputDesignation
+      && activeTextInputDesignation.token === token;
+    if (released) activeTextInputDesignation = null;
+    return JSON.stringify({ released: released });
+  }
+
+  function isSameDesignatedInput(left, right) {
+    return !!left && !!right && (
+      left === right
+      || left.alternate === right
+      || right.alternate === left
+    );
+  }
+
   function resolveTextInputDesignation(owner, selector) {
     if (!owner) return null;
     var designationStack = [owner];
@@ -2361,13 +2403,28 @@ export const INJECTED_HELPERS = `
       action: 'designateTextInput',
       component: typeTextFiberName(designationInput),
       testID: selector,
-      focusOnly: true
+      focusOnly: true,
+      inputFiber: designationInput
     };
   }
 
   function executeTypeTextTransaction(opts) {
     var designationSelector = opts.testID;
+    var boundDesignation = null;
     if (opts.requireLiveInputDesignation === true) {
+      boundDesignation = consumeTextInputDesignation(
+        opts.designationToken,
+        designationSelector
+      );
+      if (!boundDesignation) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
       var liveFrontmost;
       try {
         liveFrontmost = JSON.parse(isTestIdFrontmost(designationSelector));
@@ -2470,6 +2527,18 @@ export const INJECTED_HELPERS = `
         liveDesignation.handlerCalled = false;
         return liveDesignation;
       }
+      if (
+        !isSameDesignatedInput(boundDesignation.input, binding.sourceFiber)
+        || !isSameDesignatedInput(boundDesignation.input, liveDesignation.inputFiber)
+      ) {
+        return {
+          error: 'TextInput designation no longer owns the exact host input',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
       var designationCandidateProps = binding.candidateFiber.memoizedProps || {};
       if (textInputDesignationDisabled(designationCandidateProps)) {
         return {
@@ -2481,8 +2550,18 @@ export const INJECTED_HELPERS = `
           handlerCalled: false
         };
       }
+      if (binding.controlled !== true) {
+        return {
+          error: 'TextInput designation is uncontrolled or unreadable',
+          code: 'INTERACTION_NOT_ACTUATED',
+          testID: designationSelector,
+          focusOnly: true,
+          handlerCalled: false
+        };
+      }
     }
     var text = opts.text !== undefined ? opts.text : '';
+    if (boundDesignation) text = (binding.valueBefore || '') + text;
     try {
       if (binding.contract === 'onChangeText:string') binding.handler(text);
       else binding.handler({ nativeEvent: { text: text } });
@@ -2818,7 +2897,16 @@ export const INJECTED_HELPERS = `
         if (typeof props.onPress !== 'function') {
           if (opts.allowInputDesignation === true && opts.testID) {
             var designation = resolveTextInputDesignation(found, selector);
-            if (designation) return JSON.stringify(designation);
+            if (designation) {
+              if (designation.success === true) {
+                designation.designationToken = retainTextInputDesignation(
+                  designation.inputFiber,
+                  selector
+                );
+                delete designation.inputFiber;
+              }
+              return JSON.stringify(designation);
+            }
           }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
         }
@@ -4354,6 +4442,7 @@ export const INJECTED_HELPERS = `
     getStoreState: getStoreState,
     getComponentState: getComponentState,
     readInputValue: readInputValue,
+    releaseInputDesignation: releaseInputDesignation,
     dispatchAction: dispatchAction,
     getErrors: getErrors,
     clearErrors: clearErrors,

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 56;
+export const HELPERS_VERSION = 57;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2195,6 +2195,7 @@ export const INJECTED_HELPERS = `
   function textInputDesignationDisabled(candidateProps) {
     return candidateProps.disabled === true
       || candidateProps.editable === false
+      || candidateProps.readOnly === true
       || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
   }
 

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 57;
+export const HELPERS_VERSION = 58;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2207,6 +2207,7 @@ export const INJECTED_HELPERS = `
       if (seen.has(current)) {
         return {
           error: 'TextInput designation interactivity resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -2248,6 +2249,7 @@ export const INJECTED_HELPERS = `
     if (current) {
       return {
         error: 'TextInput designation interactivity resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -2333,6 +2335,7 @@ export const INJECTED_HELPERS = `
     if (designationStack.length > 0) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true
@@ -2356,6 +2359,7 @@ export const INJECTED_HELPERS = `
       if (designationLineage.has(designationLineageFiber)) {
         return {
           error: 'TextInput designation resolution truncated',
+          code: 'ASSERTION_FAILED',
           testID: selector,
           focusOnly: true,
           truncated: true
@@ -2369,6 +2373,7 @@ export const INJECTED_HELPERS = `
     if (designationLineageFiber !== owner) {
       return {
         error: 'TextInput designation resolution truncated',
+        code: 'ASSERTION_FAILED',
         testID: selector,
         focusOnly: true,
         truncated: true

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 50;
+export const HELPERS_VERSION = 51;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -2541,6 +2541,73 @@ export const INJECTED_HELPERS = `
 
       if (action === 'press') {
         if (typeof props.onPress !== 'function') {
+          if (opts.allowInputDesignation === true && opts.testID) {
+            var designationStack = [found];
+            var designationSeen = new WeakSet();
+            var designationInputs = [];
+            var designationWork = 0;
+            while (designationStack.length > 0 && designationWork < 2000) {
+              var designationFiber = designationStack.pop();
+              if (designationSeen.has(designationFiber)) continue;
+              designationSeen.add(designationFiber);
+              designationWork++;
+              var designationProps = designationFiber.memoizedProps || {};
+              if (
+                designationFiber.tag === 5
+                && typeof designationFiber.type === 'string'
+                && hostKind(designationFiber) === 'textinput'
+                && (designationProps.testID === selector || designationProps.nativeID === selector)
+              ) {
+                designationInputs.push(designationFiber);
+              }
+              var designationChild = designationFiber.child;
+              while (designationChild) {
+                designationStack.push(designationChild);
+                designationChild = designationChild.sibling;
+              }
+            }
+            if (designationStack.length > 0) {
+              return JSON.stringify({
+                error: 'TextInput designation resolution truncated',
+                testID: selector,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length > 1) {
+              return JSON.stringify({
+                error: 'Ambiguous TextInput designation target',
+                testID: selector,
+                count: designationInputs.length,
+                focusOnly: true
+              });
+            }
+            if (designationInputs.length === 1) {
+              var designationInput = designationInputs[0];
+              var designationInputProps = designationInput.memoizedProps || {};
+              var designationDisabled = function(candidateProps) {
+                return candidateProps.disabled === true
+                  || candidateProps.editable === false
+                  || (candidateProps.accessibilityState && candidateProps.accessibilityState.disabled === true);
+              };
+              if (designationDisabled(props) || designationDisabled(designationInputProps)) {
+                return JSON.stringify({
+                  error: 'TextInput is disabled or non-editable',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+              if (typeof designationInputProps.onPress !== 'function') {
+                return JSON.stringify({
+                  success: true,
+                  action: 'designateTextInput',
+                  component: typeTextFiberName(designationInput),
+                  testID: selector,
+                  focusOnly: true
+                });
+              }
+            }
+          }
           return JSON.stringify({ error: 'Component has no onPress handler', component: typeName, testID: selector });
         }
         if (opts.value !== undefined) {

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -73,6 +73,7 @@ export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
 export interface CdpReplayDeps {
   pressByTestId(id: string): Promise<ReplayPressResult | void>;
   typeByTestId(id: string, text: string, context?: ReplayTypeContext): Promise<void>;
+  releaseInputDesignation?(token: string): Promise<void>;
   // Returns parsed readable getTree data filtered to `id`.
   treeFor(id: string): Promise<unknown>;
   // Exact-ID oracle; matchCount 0 proves absence, while refusals omit it.
@@ -101,7 +102,7 @@ export function createReplayPressByTestId(
       ok?: boolean;
       code?: string;
       error?: string;
-      data?: { action?: string; focusOnly?: boolean };
+      data?: { action?: string; focusOnly?: boolean; designationToken?: string };
       meta?: Record<string, unknown>;
     };
     if (envelope.ok === false) {
@@ -112,13 +113,21 @@ export function createReplayPressByTestId(
       );
     }
     if (envelope.data?.action !== 'designateTextInput') return { kind: 'press' };
-    if (envelope.data.focusOnly !== true) {
+    if (
+      envelope.data.focusOnly !== true ||
+      typeof envelope.data.designationToken !== 'string' ||
+      envelope.data.designationToken.length === 0
+    ) {
       throw new ReplayDispatchError(
         'INTERACTION_NOT_ACTUATED',
         `press "${id}" returned an invalid TextInput designation`,
       );
     }
-    return { kind: 'designation', focusOnly: true };
+    return {
+      kind: 'designation',
+      focusOnly: true,
+      token: envelope.data.designationToken,
+    };
   };
 }
 
@@ -251,6 +260,9 @@ export function buildCdpDispatch(deps: CdpReplayDeps, signal?: AbortSignal): Rep
       await assertExactInteractable(id);
       requireNotAborted();
       await deps.typeByTestId(id, text, context);
+    },
+    async releaseDesignation(token) {
+      await deps.releaseInputDesignation?.(token);
     },
     async visibility(id) {
       await deps.treeFor(id);

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -3,8 +3,10 @@ import {
   replayFlow,
   ReplayDispatchError,
   type ReplayResult,
+  type ReplayPressResult,
 } from '../domain/cdp-flow-replay.js';
 import type { ReplayDispatch } from '../domain/cdp-flow-replay.js';
+import type { createInteractHandler } from './interact.js';
 
 // Unwrap getTree's `{ tree: <node>|{matches} }` envelope to the node(s) the
 // dispatch helpers walk. Returns the bare node for a single match, the
@@ -68,7 +70,7 @@ export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
 }
 
 export interface CdpReplayDeps {
-  pressByTestId(id: string): Promise<void>;
+  pressByTestId(id: string): Promise<ReplayPressResult | void>;
   typeByTestId(id: string, text: string): Promise<void>;
   // Returns parsed readable getTree data filtered to `id`.
   treeFor(id: string): Promise<unknown>;
@@ -82,6 +84,41 @@ export interface CdpReplayDeps {
   }>;
   launchApp(stopApp: boolean): Promise<void>;
   settle(timeoutMs: number): Promise<void>;
+}
+
+export function createReplayPressByTestId(
+  interact: ReturnType<typeof createInteractHandler>,
+): CdpReplayDeps['pressByTestId'] {
+  return async (id) => {
+    const result = await interact({
+      action: 'press',
+      testID: id,
+      animated: false,
+      allowInputDesignation: true,
+    });
+    const envelope = JSON.parse(result.content[0]?.text ?? '{}') as {
+      ok?: boolean;
+      code?: string;
+      error?: string;
+      data?: { action?: string; focusOnly?: boolean };
+      meta?: Record<string, unknown>;
+    };
+    if (envelope.ok === false) {
+      throw new ReplayDispatchError(
+        envelope.code ?? 'INTERACTION_NOT_ACTUATED',
+        `press "${id}" failed: ${envelope.error ?? 'ok:false'}`,
+        envelope.meta,
+      );
+    }
+    if (envelope.data?.action !== 'designateTextInput') return { kind: 'press' };
+    if (envelope.data.focusOnly !== true) {
+      throw new ReplayDispatchError(
+        'INTERACTION_NOT_ACTUATED',
+        `press "${id}" returned an invalid TextInput designation`,
+      );
+    }
+    return { kind: 'designation', focusOnly: true };
+  };
 }
 
 function nodeProps(treeJson: unknown, id: string): Record<string, unknown> | null {
@@ -207,7 +244,7 @@ export function buildCdpDispatch(deps: CdpReplayDeps, signal?: AbortSignal): Rep
     async press(id) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.pressByTestId(id);
+      return deps.pressByTestId(id);
     },
     async type(id, text) {
       await assertExactInteractable(id);

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -4,6 +4,7 @@ import {
   ReplayDispatchError,
   type ReplayResult,
   type ReplayPressResult,
+  type ReplayTypeContext,
 } from '../domain/cdp-flow-replay.js';
 import type { ReplayDispatch } from '../domain/cdp-flow-replay.js';
 import type { createInteractHandler } from './interact.js';
@@ -71,7 +72,7 @@ export function replayTreeData(envelope: ReplayTreeEnvelope): unknown {
 
 export interface CdpReplayDeps {
   pressByTestId(id: string): Promise<ReplayPressResult | void>;
-  typeByTestId(id: string, text: string): Promise<void>;
+  typeByTestId(id: string, text: string, context?: ReplayTypeContext): Promise<void>;
   // Returns parsed readable getTree data filtered to `id`.
   treeFor(id: string): Promise<unknown>;
   // Exact-ID oracle; matchCount 0 proves absence, while refusals omit it.
@@ -246,10 +247,10 @@ export function buildCdpDispatch(deps: CdpReplayDeps, signal?: AbortSignal): Rep
       requireNotAborted();
       return deps.pressByTestId(id);
     },
-    async type(id, text) {
+    async type(id, text, context) {
       await assertExactInteractable(id);
       requireNotAborted();
-      await deps.typeByTestId(id, text);
+      await deps.typeByTestId(id, text, context);
     },
     async visibility(id) {
       await deps.treeFor(id);

--- a/packages/rn-dev-agent-core/src/tools/device-interact.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-interact.ts
@@ -1282,7 +1282,7 @@ export async function performReactTreeInput(
   text: string,
   client: CDPClient | null,
   signal?: AbortSignal,
-  options: { requireLiveInputDesignation?: boolean } = {},
+  options: { designationToken?: string } = {},
 ): Promise<ToolResult> {
   const pathsTried = ['react-tree'];
   if (!client) {
@@ -1315,23 +1315,31 @@ export async function performReactTreeInput(
       return null;
     }
   };
-  const before = await readInput();
-  if (signal?.aborted) {
-    return fillFailure('TEXT_ENTRY_UNVERIFIED', 'React-tree input was cancelled before mutation.', {
-      mutation: 'none',
-      pathsTried,
-    });
+  const designated = typeof options.designationToken === 'string';
+  let requestedText = text;
+  if (!designated) {
+    const before = await readInput();
+    if (signal?.aborted) {
+      return fillFailure(
+        'TEXT_ENTRY_UNVERIFIED',
+        'React-tree input was cancelled before mutation.',
+        {
+          mutation: 'none',
+          pathsTried,
+        },
+      );
+    }
+    if (!before?.controlled) {
+      return fillFailure(
+        'TEXT_ENTRY_UNVERIFIED',
+        `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`,
+        { mutation: 'none', pathsTried },
+      );
+    }
+    requestedText = `${before.value ?? ''}${text}`;
   }
-  if (!before?.controlled) {
-    return fillFailure(
-      'TEXT_ENTRY_UNVERIFIED',
-      `React-tree input "${testID}" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.`,
-      { mutation: 'none', pathsTried },
-    );
-  }
-  const expected = `${before.value ?? ''}${text}`;
   let dispatch:
-    | { handler: string }
+    | { handler: string; resultingText: string }
     | {
         error: string;
         mutation: 'none' | 'possible';
@@ -1344,9 +1352,14 @@ export async function performReactTreeInput(
         JSON.stringify({
           action: 'typeText',
           testID,
-          text: expected,
+          text: requestedText,
           verify: true,
-          ...(options.requireLiveInputDesignation ? { requireLiveInputDesignation: true } : {}),
+          ...(designated
+            ? {
+                requireLiveInputDesignation: true,
+                designationToken: options.designationToken,
+              }
+            : {}),
         }) +
         ')',
     );
@@ -1359,6 +1372,7 @@ export async function performReactTreeInput(
         focusOnly?: boolean;
         handlerCalled?: string | false;
         controlled?: boolean;
+        text?: string;
       } = JSON.parse(result.value);
       if (parsed.error) {
         const designationCode =
@@ -1373,8 +1387,12 @@ export async function performReactTreeInput(
           ...(designationCode ? { code: designationCode } : {}),
           ...(parsed.focusOnly === true ? { focusOnly: true } : {}),
         };
-      } else if (typeof parsed.handlerCalled === 'string' && parsed.controlled !== undefined) {
-        dispatch = { handler: parsed.handlerCalled };
+      } else if (
+        typeof parsed.handlerCalled === 'string' &&
+        parsed.controlled !== undefined &&
+        typeof parsed.text === 'string'
+      ) {
+        dispatch = { handler: parsed.handlerCalled, resultingText: parsed.text };
       } else {
         dispatch = { error: 'dispatch result is inconclusive', mutation: 'possible' };
       }
@@ -1409,6 +1427,7 @@ export async function performReactTreeInput(
       pathsTried,
     });
   }
+  const expected = dispatch.resultingText;
   let verification: 'exact' | 'mismatch' | 'unreadable' = 'unreadable';
   let previous: { value: string | null; controlled: boolean } | null = null;
   let last: { value: string | null; controlled: boolean } | null = null;

--- a/packages/rn-dev-agent-core/src/tools/device-interact.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-interact.ts
@@ -1282,6 +1282,7 @@ export async function performReactTreeInput(
   text: string,
   client: CDPClient | null,
   signal?: AbortSignal,
+  options: { requireLiveInputDesignation?: boolean } = {},
 ): Promise<ToolResult> {
   const pathsTried = ['react-tree'];
   if (!client) {
@@ -1329,11 +1330,24 @@ export async function performReactTreeInput(
     );
   }
   const expected = `${before.value ?? ''}${text}`;
-  let dispatch: { handler: string } | { error: string; mutation: 'none' | 'possible' };
+  let dispatch:
+    | { handler: string }
+    | {
+        error: string;
+        mutation: 'none' | 'possible';
+        code?: 'AMBIGUOUS_TESTID' | 'ASSERTION_FAILED' | 'INTERACTION_NOT_ACTUATED';
+        focusOnly?: true;
+      };
   try {
     const result = await client.evaluate(
       '__RN_AGENT.interact(' +
-        JSON.stringify({ action: 'typeText', testID, text: expected, verify: true }) +
+        JSON.stringify({
+          action: 'typeText',
+          testID,
+          text: expected,
+          verify: true,
+          ...(options.requireLiveInputDesignation ? { requireLiveInputDesignation: true } : {}),
+        }) +
         ')',
     );
     if (result.error || typeof result.value !== 'string') {
@@ -1341,11 +1355,25 @@ export async function performReactTreeInput(
     } else {
       const parsed: {
         error?: string;
+        code?: unknown;
+        focusOnly?: boolean;
         handlerCalled?: string | false;
         controlled?: boolean;
       } = JSON.parse(result.value);
-      if (parsed.error) dispatch = { error: parsed.error, mutation: 'none' };
-      else if (typeof parsed.handlerCalled === 'string' && parsed.controlled !== undefined) {
+      if (parsed.error) {
+        const designationCode =
+          parsed.code === 'AMBIGUOUS_TESTID' ||
+          parsed.code === 'ASSERTION_FAILED' ||
+          parsed.code === 'INTERACTION_NOT_ACTUATED'
+            ? parsed.code
+            : undefined;
+        dispatch = {
+          error: parsed.error,
+          mutation: 'none',
+          ...(designationCode ? { code: designationCode } : {}),
+          ...(parsed.focusOnly === true ? { focusOnly: true } : {}),
+        };
+      } else if (typeof parsed.handlerCalled === 'string' && parsed.controlled !== undefined) {
         dispatch = { handler: parsed.handlerCalled };
       } else {
         dispatch = { error: 'dispatch result is inconclusive', mutation: 'possible' };
@@ -1355,6 +1383,18 @@ export async function performReactTreeInput(
     dispatch = { error: 'dispatch result is unavailable', mutation: 'possible' };
   }
   if ('error' in dispatch) {
+    if (dispatch.focusOnly) {
+      return failResult(
+        `React-tree input "${testID}" refused: ${dispatch.error}`,
+        dispatch.code ?? 'TEXT_ENTRY_UNVERIFIED',
+        {
+          mutation: dispatch.mutation,
+          pathsTried,
+          focusOnly: true,
+          hint: 'No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying.',
+        },
+      );
+    }
     return fillFailure(
       'TEXT_ENTRY_UNVERIFIED',
       dispatch.mutation === 'possible'

--- a/packages/rn-dev-agent-core/src/tools/interact.ts
+++ b/packages/rn-dev-agent-core/src/tools/interact.ts
@@ -19,7 +19,7 @@ const REFUSAL_FIELDS = [
 
 type InteractAction = 'press' | 'longPress' | 'typeText' | 'scroll' | 'setFieldValue';
 
-interface InteractArgs {
+export interface InteractArgs {
   action: InteractAction;
   testID?: string;
   accessibilityLabel?: string;
@@ -39,6 +39,7 @@ interface InteractArgs {
   includeHidden?: boolean;
   // GH #525 — press-only opt-in pressable-ancestor discovery.
   walkUp?: boolean;
+  allowInputDesignation?: boolean;
 }
 
 export function createInteractHandler(getClient: () => CDPClient) {
@@ -82,6 +83,8 @@ export function createInteractHandler(getClient: () => CDPClient) {
     if (args.exact !== undefined) opts.exact = args.exact;
     if (args.includeHidden !== undefined) opts.includeHidden = args.includeHidden;
     if (args.walkUp !== undefined) opts.walkUp = args.walkUp;
+    if (args.allowInputDesignation !== undefined)
+      opts.allowInputDesignation = args.allowInputDesignation;
 
     const result = await client.evaluate(`__RN_AGENT.interact(${JSON.stringify(opts)})`);
 

--- a/packages/rn-dev-agent-core/src/tools/interact.ts
+++ b/packages/rn-dev-agent-core/src/tools/interact.ts
@@ -104,7 +104,10 @@ export function createInteractHandler(getClient: () => CDPClient) {
     }
 
     if (parsed.error) {
-      return failResult(`Interact failed: ${parsed.error}`, pickDefined(parsed, REFUSAL_FIELDS));
+      const refusal = pickDefined(parsed, REFUSAL_FIELDS);
+      return parsed.code === 'ASSERTION_FAILED'
+        ? failResult(`Interact failed: ${parsed.error}`, 'ASSERTION_FAILED', refusal)
+        : failResult(`Interact failed: ${parsed.error}`, refusal);
     }
 
     // GH#250: a handler throw is an app-side failure, not a warning — the action

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -866,7 +866,7 @@ export function createMaestroRunHandler(
       const proofDomains: Array<'react-tree' | 'xctest-native'> = [];
       let nativeTransportVersion: unknown = null;
       let nativeOutput = '';
-      let retainedReactFocusId: string | undefined;
+      let retainedReactFocusId: string | null | undefined;
       try {
         for (const segment of iosProofPlan.segments) {
           if (controller.signal.aborted || deadline - now() <= 0) {
@@ -972,7 +972,8 @@ export function createMaestroRunHandler(
             );
           }
           let stageCursor = 0;
-          let reactFocusId = retainedReactFocusId ?? segment.initialReactFocusId;
+          let reactFocusId: string | null | undefined =
+            retainedReactFocusId === undefined ? segment.initialReactFocusId : retainedReactFocusId;
           const stageResults = await executeMaestroAuthorityStages(
             segment.commands,
             async (commands) => {
@@ -988,16 +989,16 @@ export function createMaestroRunHandler(
                   ...replayDependencies,
                   launchApp: async () => {},
                 },
-                { signal: controller.signal, initialFocusId: reactFocusId },
+                { signal: controller.signal, initialFocusId: reactFocusId ?? undefined },
               );
               if (!replay.passed) throw new ReactReplayFailure(replay, sourceIndices);
               for (const step of replay.steps) {
                 if (step.t === 'launch') reactFocusId = undefined;
                 if (step.t === 'tap' && step.target) {
-                  reactFocusId = step.focusOnly ? undefined : step.target;
+                  reactFocusId = step.focusOnly ? null : step.target;
                 }
               }
-              if (replay.finalFocusId === null) reactFocusId = undefined;
+              if (replay.finalFocusId === null) reactFocusId = null;
               return { replay, sourceIndices };
             },
             claimOrigin,

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -454,6 +454,7 @@ interface PartitionedReplayStep {
   index: number;
   name: string;
   verb: string;
+  focusOnly?: true;
   status: 'pass' | 'fail';
   durationMs: number;
 }
@@ -992,8 +993,11 @@ export function createMaestroRunHandler(
               if (!replay.passed) throw new ReactReplayFailure(replay, sourceIndices);
               for (const step of replay.steps) {
                 if (step.t === 'launch') reactFocusId = undefined;
-                if (step.t === 'tap' && step.target) reactFocusId = step.target;
+                if (step.t === 'tap' && step.target) {
+                  reactFocusId = step.focusOnly ? undefined : step.target;
+                }
               }
+              if (replay.finalFocusId === null) reactFocusId = undefined;
               return { replay, sourceIndices };
             },
             claimOrigin,
@@ -1009,6 +1013,7 @@ export function createMaestroRunHandler(
                 index: sourceIndices[step.sourceIndex] ?? step.sourceIndex,
                 name: step.t,
                 verb: step.t,
+                ...(step.focusOnly ? { focusOnly: true as const } : {}),
                 status: step.ok ? 'pass' : 'fail',
                 durationMs: step.durationMs,
               });
@@ -1094,6 +1099,7 @@ export function createMaestroRunHandler(
                 sourceIndex?: number;
                 t?: unknown;
                 target?: unknown;
+                focusOnly?: unknown;
                 ok?: boolean;
                 durationMs?: number;
               };
@@ -1105,6 +1111,7 @@ export function createMaestroRunHandler(
                 name: String(record.t ?? 'unknown'),
                 verb: String(record.t ?? 'unknown'),
                 ...(record.target !== undefined ? { target: String(record.target) } : {}),
+                ...(record.focusOnly === true ? { focusOnly: true as const } : {}),
                 status: record.ok === false ? 'fail' : 'pass',
                 durationMs: Number(record.durationMs ?? 0),
               });
@@ -1122,6 +1129,7 @@ export function createMaestroRunHandler(
               index: failure.sourceIndices[step.sourceIndex] ?? step.sourceIndex,
               name: step.t,
               verb: step.t,
+              ...(step.focusOnly ? { focusOnly: true as const } : {}),
               status: step.ok ? 'pass' : 'fail',
               durationMs: step.durationMs,
             });

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -806,6 +806,7 @@ test('controlled input appends and succeeds only after exact fiber read-back', a
           value: JSON.stringify({
             controlled: true,
             handlerCalled: 'onChangeText',
+            text: value,
             valueBefore: before,
           }),
         };

--- a/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/ios-proof-domain-routing.test.ts
@@ -689,6 +689,55 @@ test('partitioned replay carries nested React focus across a native segment', as
   assert.deepEqual(calls, ['press:outer-field', 'press:inner-field', 'type:inner-field']);
 });
 
+test('a designation-only tap cannot be revived as static React focus after a native segment', async () => {
+  const calls: string[] = [];
+  const handler = createMaestroRunHandler({
+    getActiveSession: () => ({
+      name: 'designation-across-native',
+      platform: 'ios',
+      deviceId: IOS_UDID,
+      appId: 'com.example.app',
+      openedAt: new Date(0).toISOString(),
+    }),
+    replayDeps: () => ({
+      pressByTestId: async (id) => {
+        calls.push(`press:${id}`);
+        return { kind: 'designation', focusOnly: true, token: `designation-${id}` };
+      },
+      typeByTestId: async (id, text) => calls.push(`type:${id}:${text}`),
+      treeFor: async (id) => ({ testID: id }),
+      frontmostFor: async () => ({ visible: true }),
+      releaseInputDesignation: async () => {},
+      launchApp: async () => {},
+      settle: async () => {},
+    }),
+    chooseDispatch: () => nativeDispatch(),
+    parkFlow: async (run) => run(),
+    resolveEngineStatus: async () =>
+      buildReplayEngineStatus('pinned-ok', MAESTRO_RUNNER_PIN.version, false),
+    execFile: async () => ({ stdout: nativeRunnerOutput(), stderr: '' }),
+  });
+  const env = envelope(
+    await handler({
+      platform: 'ios',
+      deviceId: IOS_UDID,
+      inlineYaml: `appId: com.example.app
+---
+- tapOn:
+    id: email
+- inputText: first
+- assertVisible: Native status
+- inputText: second
+`,
+      ...callbacks,
+    }),
+  );
+
+  assert.equal(env.ok, false);
+  assert.match(env.error ?? '', /no focus target/);
+  assert.deepEqual(calls, ['press:email', 'type:email:first']);
+});
+
 test('inputText follows a nested native tap instead of reviving stale React focus', () => {
   const plan = planIosProofDomains(
     [

--- a/packages/rn-dev-agent-core/test/unit/issue-840-type-text-resolution.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/issue-840-type-text-resolution.test.ts
@@ -144,6 +144,57 @@ test('typeText keeps the proven shallow wrapped-field path typeable', () => {
   assert.equal(leaf.memoizedProps.value, '');
 });
 
+test('typeText collapses a stock TextInput composite and host that share one onChangeText', () => {
+  const calls: string[] = [];
+  const onChangeText = (value: string) => {
+    calls.push(value);
+  };
+  const root = makeFiber('Root');
+  const userProps = { testID: 'login_email', value: 'a', editable: true, onChangeText };
+  const composite = appendChild(root, makeFiber({ displayName: 'TextInput' }, { ...userProps }));
+  composite.tag = 11;
+  const host = appendChild(
+    composite,
+    makeFiber('RCTSinglelineTextInputView', { ...userProps, onChange() {}, text: 'a' }),
+  );
+
+  const result = runInteract(root, { action: 'typeText', testID: 'login_email', text: 'b' });
+
+  assert.equal(result.success, true, JSON.stringify(result));
+  assert.equal(result.handlerCalled, 'onChangeText');
+  assert.equal(result.controlled, true);
+  assert.equal(result.valueBefore, 'a');
+  assert.match(String(result.resolvedFrom), /^RCTSinglelineTextInputView/);
+  assert.deepEqual(calls, ['b']);
+  assert.equal(host.memoizedProps.value, 'a');
+});
+
+test('typeText keeps a stock-shaped composite and host ambiguous when they own distinct onChangeText functions', () => {
+  const calls: string[] = [];
+  const outer = (value: string) => {
+    calls.push(`outer:${value}`);
+  };
+  const inner = (value: string) => {
+    calls.push(`inner:${value}`);
+  };
+  const root = makeFiber('Root');
+  const composite = appendChild(
+    root,
+    makeFiber({ displayName: 'TextInput' }, { testID: 'login_email', onChangeText: outer }),
+  );
+  composite.tag = 11;
+  appendChild(
+    composite,
+    makeFiber('RCTSinglelineTextInputView', { testID: 'login_email', onChangeText: inner }),
+  );
+
+  const result = runInteract(root, { action: 'typeText', testID: 'login_email', text: 'unsafe' });
+
+  assert.equal(result.error, 'Ambiguous typeText resolution');
+  assert.equal(result.count, 2);
+  assert.deepEqual(calls, []);
+});
+
 test('typeText searches every same-testID match and selects the sole typeable target', () => {
   const calls: string[] = [];
   const root = makeFiber('Root');

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  replayFlow,
+  type ReplayDispatch,
+  type ReplayPressResult,
+} from '../../dist/domain/cdp-flow-replay.js';
+
+function dispatchFor(options: { designations?: string[]; nonInputs?: string[] } = {}): {
+  dispatch: ReplayDispatch;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  return {
+    calls,
+    dispatch: {
+      async press(id): Promise<ReplayPressResult> {
+        calls.push(['press', id]);
+        return options.designations?.includes(id)
+          ? { kind: 'designation', focusOnly: true }
+          : { kind: 'press' };
+      },
+      async type(id, text) {
+        calls.push(['type', id, text]);
+        if (options.nonInputs?.includes(id)) throw new Error('not a text input');
+      },
+      async visibility(id) {
+        calls.push(['visibility', id]);
+        return { visible: true };
+      },
+      async launch() {},
+      async settle() {},
+    },
+  };
+}
+
+test('a TextInput designation is consumed only by the adjacent type step', async () => {
+  const { dispatch, calls } = dispatchFor({ designations: ['email'] });
+  const result = await replayFlow(
+    [
+      { t: 'tap', id: 'email' },
+      { t: 'type', text: 'person@example.test' },
+      { t: 'type', text: '.invalid' },
+    ],
+    dispatch,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 2);
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.deepEqual(calls, [
+    ['press', 'email'],
+    ['type', 'email', 'person@example.test'],
+  ]);
+});
+
+test('a non-input tap invalidates an earlier TextInput designation', async () => {
+  const { dispatch, calls } = dispatchFor({
+    designations: ['email'],
+    nonInputs: ['continue'],
+  });
+  const result = await replayFlow(
+    [
+      { t: 'tap', id: 'email' },
+      { t: 'tap', id: 'continue' },
+      { t: 'type', text: 'must-not-reach-email' },
+    ],
+    dispatch,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 2);
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.equal(result.steps[1].focusOnly, undefined);
+  assert.deepEqual(calls, [
+    ['press', 'email'],
+    ['press', 'continue'],
+    ['type', 'continue', 'must-not-reach-email'],
+  ]);
+});
+
+test('an unconsumed designation refuses instead of masquerading as a successful tap', async () => {
+  const { dispatch, calls } = dispatchFor({ designations: ['email'] });
+  const result = await replayFlow([{ t: 'tap', id: 'email' }], dispatch);
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /must be followed immediately by inputText/);
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.deepEqual(calls, [['press', 'email']]);
+});

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
@@ -58,6 +58,30 @@ test('a TextInput designation is consumed only by the adjacent type step', async
   ]);
 });
 
+test('an aborted designation remains focusOnly in the failed tap trace', async () => {
+  const controller = new AbortController();
+  const { dispatch, calls } = dispatchFor({ designations: ['email'] });
+  const press = dispatch.press;
+  dispatch.press = async (id) => {
+    const result = await press(id);
+    controller.abort();
+    return result;
+  };
+  const result = await replayFlow([{ t: 'tap', id: 'email' }], dispatch, {
+    signal: controller.signal,
+  });
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'RUNNER_TIMEOUT');
+  assert.equal(result.steps[0].ok, false);
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.deepEqual(calls, [
+    ['press', 'email'],
+    ['release', 'designation-email'],
+  ]);
+});
+
 test('a non-input tap invalidates an earlier TextInput designation', async () => {
   const { dispatch, calls } = dispatchFor({
     designations: ['email'],

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
@@ -128,16 +128,17 @@ test('an assertion cannot clear an unconsumed TextInput designation', async () =
   const result = await replayFlow(
     [
       { t: 'tap', id: 'email' },
-      { t: 'assert', id: 'continue' },
+      { t: 'waitVisible', id: 'continue', timeoutMs: 0, evidenceType: 'assert' },
     ],
     dispatch,
   );
 
   assert.equal(result.passed, false);
-  assert.equal(result.failedStepIndex, 1);
+  assert.equal(result.failedStepIndex, 0);
   assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
   assert.match(result.reason ?? '', /must be followed immediately by inputText/);
   assert.equal(result.steps[0].focusOnly, true);
+  assert.equal(result.steps[1].ok, true);
   assert.deepEqual(calls, [
     ['press', 'email'],
     ['release', 'designation-email'],

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
@@ -50,6 +50,7 @@ test('a TextInput designation is consumed only by the adjacent type step', async
 
   assert.equal(result.passed, false);
   assert.equal(result.failedStepIndex, 2);
+  assert.match(result.reason ?? '', /designation for "email" was already consumed/);
   assert.equal(result.steps[0].focusOnly, true);
   assert.deepEqual(calls, [
     ['press', 'email'],
@@ -128,7 +129,7 @@ test('an assertion cannot clear an unconsumed TextInput designation', async () =
   const result = await replayFlow(
     [
       { t: 'tap', id: 'email' },
-      { t: 'waitVisible', id: 'continue', timeoutMs: 0, evidenceType: 'assert' },
+      { t: 'waitVisible', id: 'continue', timeoutMs: 1_000, evidenceType: 'assert' },
     ],
     dispatch,
   );

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
@@ -17,12 +17,15 @@ function dispatchFor(options: { designations?: string[]; nonInputs?: string[] } 
       async press(id): Promise<ReplayPressResult> {
         calls.push(['press', id]);
         return options.designations?.includes(id)
-          ? { kind: 'designation', focusOnly: true }
+          ? { kind: 'designation', focusOnly: true, token: `designation-${id}` }
           : { kind: 'press' };
       },
-      async type(id, text) {
-        calls.push(['type', id, text]);
+      async type(id, text, context) {
+        calls.push(['type', id, text, context?.designationToken ?? '']);
         if (options.nonInputs?.includes(id)) throw new Error('not a text input');
+      },
+      async releaseDesignation(token) {
+        calls.push(['release', token]);
       },
       async visibility(id) {
         calls.push(['visibility', id]);
@@ -50,7 +53,8 @@ test('a TextInput designation is consumed only by the adjacent type step', async
   assert.equal(result.steps[0].focusOnly, true);
   assert.deepEqual(calls, [
     ['press', 'email'],
-    ['type', 'email', 'person@example.test'],
+    ['type', 'email', 'person@example.test', 'designation-email'],
+    ['release', 'designation-email'],
   ]);
 });
 
@@ -74,8 +78,9 @@ test('a non-input tap invalidates an earlier TextInput designation', async () =>
   assert.equal(result.steps[1].focusOnly, undefined);
   assert.deepEqual(calls, [
     ['press', 'email'],
+    ['release', 'designation-email'],
     ['press', 'continue'],
-    ['type', 'continue', 'must-not-reach-email'],
+    ['type', 'continue', 'must-not-reach-email', ''],
   ]);
 });
 
@@ -88,7 +93,10 @@ test('an unconsumed designation refuses instead of masquerading as a successful 
   assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
   assert.match(result.reason ?? '', /must be followed immediately by inputText/);
   assert.equal(result.steps[0].focusOnly, true);
-  assert.deepEqual(calls, [['press', 'email']]);
+  assert.deepEqual(calls, [
+    ['press', 'email'],
+    ['release', 'designation-email'],
+  ]);
 });
 
 test('an assertion cannot clear an unconsumed TextInput designation', async () => {
@@ -108,6 +116,7 @@ test('an assertion cannot clear an unconsumed TextInput designation', async () =
   assert.equal(result.steps[0].focusOnly, true);
   assert.deepEqual(calls, [
     ['press', 'email'],
+    ['release', 'designation-email'],
     ['visibility', 'continue'],
   ]);
 });

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-domain.test.ts
@@ -90,3 +90,24 @@ test('an unconsumed designation refuses instead of masquerading as a successful 
   assert.equal(result.steps[0].focusOnly, true);
   assert.deepEqual(calls, [['press', 'email']]);
 });
+
+test('an assertion cannot clear an unconsumed TextInput designation', async () => {
+  const { dispatch, calls } = dispatchFor({ designations: ['email'] });
+  const result = await replayFlow(
+    [
+      { t: 'tap', id: 'email' },
+      { t: 'assert', id: 'continue' },
+    ],
+    dispatch,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 1);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /must be followed immediately by inputText/);
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.deepEqual(calls, [
+    ['press', 'email'],
+    ['visibility', 'continue'],
+  ]);
+});

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -50,6 +50,7 @@ function replayFixture(
   options: {
     editable?: boolean;
     wrapped?: boolean;
+    inputHidden?: boolean;
     beforeDesignatedTypeDispatch?: (fixture: {
       root: Fiber;
       input: Fiber;
@@ -65,6 +66,7 @@ function replayFixture(
     fiber('RCTSinglelineTextInputView', {
       testID: 'email',
       editable: options.editable ?? true,
+      ...(options.inputHidden ? { style: { display: 'none' } } : {}),
       value: '',
       onFocus: () => {
         calls.focus += 1;
@@ -136,7 +138,7 @@ function replayFixture(
         return { error };
       }
     },
-    probeHelperFreshness: async () => ({ fresh: true, version: 50, probed: true }),
+    probeHelperFreshness: async () => ({ fresh: true, version: 51, probed: true }),
   });
   const interact = createInteractHandler(() => client);
   const deps: CdpReplayDeps = {
@@ -247,6 +249,22 @@ test('a non-editable bare TextInput refuses designation without callbacks', asyn
   assert.equal(fixture.input.memoizedProps.value, '');
 });
 
+test('a hidden host TextInput beneath a visible wrapper refuses designation', async () => {
+  const fixture = replayFixture({ wrapped: true, inputHidden: true });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /hidden or occluded/);
+  assert.deepEqual(fixture.calls.typed, []);
+  assert.equal(fixture.input.memoizedProps.value, '');
+});
+
 test('designation preserves the frontmost and duplicate-target refusals', async (t) => {
   await t.test('occluded input', async () => {
     const fixture = replayFixture();
@@ -287,6 +305,27 @@ test('designation preserves the frontmost and duplicate-target refusals', async 
 });
 
 test('designation rechecks live eligibility at the injected mutation boundary', async (t) => {
+  await t.test('host input stops accepting pointer events', async () => {
+    const fixture = replayFixture({
+      wrapped: true,
+      beforeDesignatedTypeDispatch: ({ input }) => {
+        input.memoizedProps.pointerEvents = 'none';
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.match(result.reason ?? '', /pointerEvents="none"/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
   await t.test('matched wrapper becomes disabled', async () => {
     const fixture = replayFixture({
       wrapped: true,

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -58,6 +58,7 @@ function replayFixture(
     branchedDuplicate?: boolean;
     inputHidden?: boolean;
     inputValue?: string;
+    oversizedDesignationSubtree?: boolean;
     beforeDesignatedTypeDispatch?: (fixture: {
       root: Fiber;
       input: Fiber;
@@ -97,6 +98,11 @@ function replayFixture(
   );
   if (options.branchedDuplicate) {
     append(wrapper ?? root, fiber('RCTView', { testID: 'email' }));
+  }
+  if (options.oversizedDesignationSubtree) {
+    for (let filler = 0; filler < 2_100; filler++) {
+      append(wrapper ?? root, fiber('RCTView', { testID: `filler-${filler}` }));
+    }
   }
   append(
     root,
@@ -222,6 +228,22 @@ test('replay designates a bare TextInput and types without press or focus dispat
   assert.equal(fixture.calls.press, 0);
   assert.deepEqual(fixture.calls.typed, ['person@example.test']);
   assert.equal(fixture.input.memoizedProps.value, 'person@example.test');
+});
+
+test('a truncated designation scan refuses the press as an unproven assertion', async () => {
+  const fixture = replayFixture({ wrapped: true, oversizedDesignationSubtree: true });
+
+  const error = await fixture.deps.pressByTestId('email').then(
+    () => null,
+    (thrown: unknown) => thrown,
+  );
+
+  assert.ok(error instanceof ReplayDispatchError, `expected a refusal, got ${String(error)}`);
+  assert.equal(error.code, 'ASSERTION_FAILED');
+  assert.match(error.message, /TextInput designation resolution truncated/);
+  assert.equal(fixture.calls.focus, 0);
+  assert.equal(fixture.calls.press, 0);
+  assert.deepEqual(fixture.calls.typed, []);
 });
 
 test('designation refuses a replacement input with the same selector and value shape', async () => {

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -1,0 +1,306 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import vm from 'node:vm';
+import { ReplayDispatchError } from '../../dist/domain/cdp-flow-replay.js';
+import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+import {
+  createReplayPressByTestId,
+  runCdpReplayCommands,
+  unwrapTree,
+  type CdpReplayDeps,
+} from '../../dist/tools/cdp-replay-dispatch.js';
+import { performReactTreeInput } from '../../dist/tools/device-interact.js';
+import { createInteractHandler } from '../../dist/tools/interact.js';
+import { createMaestroRunHandler } from '../../dist/tools/maestro-run.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+
+type Fiber = {
+  tag: number;
+  type: string | { displayName: string };
+  memoizedProps: Record<string, unknown>;
+  child: Fiber | null;
+  sibling: Fiber | null;
+  return: Fiber | null;
+};
+
+function fiber(type: Fiber['type'], memoizedProps: Record<string, unknown> = {}): Fiber {
+  return {
+    tag: typeof type === 'string' ? 5 : 0,
+    type,
+    memoizedProps,
+    child: null,
+    sibling: null,
+    return: null,
+  };
+}
+
+function append(parent: Fiber, child: Fiber): Fiber {
+  child.return = parent;
+  if (!parent.child) {
+    parent.child = child;
+    return child;
+  }
+  let tail = parent.child;
+  while (tail.sibling) tail = tail.sibling;
+  tail.sibling = child;
+  return child;
+}
+
+function replayFixture(options: { editable?: boolean } = {}) {
+  const calls = { focus: 0, press: 0, typed: [] as string[] };
+  const root = fiber({ displayName: 'Root' });
+  const input = append(
+    root,
+    fiber('RCTSinglelineTextInputView', {
+      testID: 'email',
+      editable: options.editable ?? true,
+      value: '',
+      onFocus: () => {
+        calls.focus += 1;
+      },
+      onChangeText: (value: string) => {
+        calls.typed.push(value);
+        input.memoizedProps.value = value;
+      },
+    }),
+  );
+  append(
+    root,
+    fiber('RCTView', {
+      testID: 'continue',
+      onPress: () => {
+        calls.press += 1;
+      },
+    }),
+  );
+
+  const sandbox: Record<string, unknown> = {
+    Array,
+    Object,
+    JSON,
+    Map,
+    WeakSet,
+    Set,
+    Error,
+    Date,
+    RegExp,
+    Symbol,
+    parseInt,
+    parseFloat,
+    String,
+    Number,
+    Boolean,
+    Promise,
+    setTimeout,
+    clearTimeout,
+    console: { log() {}, error() {}, warn() {}, info() {}, debug() {} },
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+    renderers: new Map([[1, {}]]),
+    getFiberRoots: (rendererId: number) =>
+      rendererId === 1 ? new Set([{ current: root }]) : new Set(),
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(INJECTED_HELPERS, sandbox);
+
+  const client = createMockClient({
+    evaluate: async (expression: string) => {
+      try {
+        return { value: vm.runInContext(expression, sandbox) };
+      } catch (error) {
+        return { error };
+      }
+    },
+    probeHelperFreshness: async () => ({ fresh: true, version: 48, probed: true }),
+  });
+  const interact = createInteractHandler(() => client);
+  const deps: CdpReplayDeps = {
+    pressByTestId: createReplayPressByTestId(interact),
+    typeByTestId: async (id, text) => {
+      const result = await performReactTreeInput(id, text, client);
+      const envelope = JSON.parse(result.content[0]?.text ?? '{}') as {
+        ok?: boolean;
+        code?: string;
+        error?: string;
+        meta?: Record<string, unknown>;
+      };
+      if (envelope.ok === false) {
+        throw new ReplayDispatchError(
+          envelope.code ?? 'TEXT_ENTRY_UNVERIFIED',
+          envelope.error ?? `type "${id}" failed`,
+          envelope.meta,
+        );
+      }
+    },
+    treeFor: async (id) => {
+      const result = await client.evaluate(
+        `__RN_AGENT.getTree(${JSON.stringify({ filter: id, depth: 12 })})`,
+      );
+      assert.equal(result.error, undefined);
+      assert.equal(typeof result.value, 'string');
+      return unwrapTree(JSON.parse(result.value as string));
+    },
+    frontmostFor: async () => ({ visible: true, matchCount: 1 }),
+    async launchApp() {},
+    async settle() {},
+  };
+
+  return { calls, input, deps };
+}
+
+test('replay designates a bare TextInput and types without press or focus dispatch', async () => {
+  const fixture = replayFixture();
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'person@example.test' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, true, JSON.stringify(result));
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.equal(result.steps[1].target, 'email');
+  assert.equal(result.finalFocusId, null);
+  assert.equal(fixture.calls.focus, 0);
+  assert.equal(fixture.calls.press, 0);
+  assert.deepEqual(fixture.calls.typed, ['person@example.test']);
+  assert.equal(fixture.input.memoizedProps.value, 'person@example.test');
+});
+
+test('an intervening non-input tap makes later text entry refuse without reaching the input', async () => {
+  const fixture = replayFixture();
+  const result = await runCdpReplayCommands(
+    [
+      { tapOn: { id: 'email' } },
+      { tapOn: { id: 'continue' } },
+      { inputText: 'must-not-reach-email' },
+    ],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 2);
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.equal(result.steps[1].focusOnly, undefined);
+  assert.equal(fixture.calls.press, 1);
+  assert.equal(fixture.calls.focus, 0);
+  assert.deepEqual(fixture.calls.typed, []);
+  assert.equal(fixture.input.memoizedProps.value, '');
+});
+
+test('a designation without typing is explicit and refuses the replay', async () => {
+  const fixture = replayFixture();
+  const result = await runCdpReplayCommands([{ tapOn: { id: 'email' } }], {}, fixture.deps);
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /must be followed immediately by inputText/);
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.equal(fixture.calls.focus, 0);
+  assert.equal(fixture.calls.press, 0);
+  assert.deepEqual(fixture.calls.typed, []);
+});
+
+test('a non-editable bare TextInput refuses designation without callbacks', async () => {
+  const fixture = replayFixture({ editable: false });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /disabled or non-editable/);
+  assert.equal(fixture.calls.focus, 0);
+  assert.equal(fixture.calls.press, 0);
+  assert.deepEqual(fixture.calls.typed, []);
+  assert.equal(fixture.input.memoizedProps.value, '');
+});
+
+test('designation preserves the frontmost and duplicate-target refusals', async (t) => {
+  await t.test('occluded input', async () => {
+    const fixture = replayFixture();
+    fixture.deps.frontmostFor = async () => ({
+      visible: false,
+      reason: 'target is covered by a modal',
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 0);
+    assert.match(result.reason ?? '', /covered by a modal/);
+    assert.equal(fixture.calls.focus, 0);
+    assert.equal(fixture.calls.press, 0);
+    assert.deepEqual(fixture.calls.typed, []);
+  });
+
+  await t.test('duplicate exact input', async () => {
+    const fixture = replayFixture();
+    fixture.deps.frontmostFor = async () => ({ visible: true, matchCount: 2 });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 0);
+    assert.equal(result.failureCode, 'AMBIGUOUS_TESTID');
+    assert.equal(fixture.calls.focus, 0);
+    assert.equal(fixture.calls.press, 0);
+    assert.deepEqual(fixture.calls.typed, []);
+  });
+});
+
+test('maestro_run exposes designation in its public step trace', async () => {
+  const calls: string[][] = [];
+  const handler = createMaestroRunHandler({
+    replayDeps: () => ({
+      pressByTestId: async (id) => {
+        calls.push(['press', id]);
+        return { kind: 'designation', focusOnly: true };
+      },
+      typeByTestId: async (id, text) => {
+        calls.push(['type', id, text]);
+      },
+      treeFor: async (id) => ({ testID: id }),
+      frontmostFor: async () => ({ visible: true }),
+      async launchApp() {},
+      async settle() {},
+    }),
+  });
+  const result = await handler({
+    platform: 'ios',
+    inlineYaml: 'appId: com.example.app\n---\n- tapOn:\n    id: email\n- inputText: value\n',
+    claimNativeOrigin: async () => {},
+    completeNativeOrigin: async () => {},
+    relaunchManagedApp: async () => {},
+    reproveManagedOrigin: async () => {},
+    completeRunnerPark: async () => {},
+  });
+  const envelope = JSON.parse(result.content[0]?.text ?? '{}') as {
+    ok?: boolean;
+    data?: { steps?: Array<{ verb?: string; focusOnly?: boolean }> };
+  };
+
+  assert.equal(envelope.ok, true);
+  assert.deepEqual(calls, [
+    ['press', 'email'],
+    ['type', 'email', 'value'],
+  ]);
+  assert.deepEqual(
+    envelope.data?.steps?.map(({ verb, focusOnly }) => ({ verb, focusOnly })),
+    [
+      { verb: 'tap', focusOnly: true },
+      { verb: 'type', focusOnly: undefined },
+    ],
+  );
+});

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -59,6 +59,7 @@ function replayFixture(
     inputHidden?: boolean;
     inputValue?: string;
     oversizedDesignationSubtree?: boolean;
+    stockTextInput?: boolean;
     beforeDesignatedTypeDispatch?: (fixture: {
       root: Fiber;
       input: Fiber;
@@ -79,21 +80,29 @@ function replayFixture(
         }),
       )
     : null;
+  const userProps = {
+    testID: 'email',
+    editable: options.editable ?? true,
+    ...(options.readOnly ? { readOnly: true } : {}),
+    ...(options.inputHidden ? { style: { display: 'none' } } : {}),
+    value: options.inputValue ?? '',
+    onFocus: () => {
+      calls.focus += 1;
+    },
+    onChangeText: (value: string) => {
+      calls.typed.push(value);
+      input.memoizedProps.value = value;
+    },
+  };
+  const composite = options.stockTextInput
+    ? append(exactMiddle ?? wrapper ?? root, fiber({ displayName: 'TextInput' }, { ...userProps }))
+    : null;
+  if (composite) composite.tag = 11;
   const input = append(
-    exactMiddle ?? wrapper ?? root,
+    composite ?? exactMiddle ?? wrapper ?? root,
     fiber('RCTSinglelineTextInputView', {
-      testID: 'email',
-      editable: options.editable ?? true,
-      ...(options.readOnly ? { readOnly: true } : {}),
-      ...(options.inputHidden ? { style: { display: 'none' } } : {}),
-      value: options.inputValue ?? '',
-      onFocus: () => {
-        calls.focus += 1;
-      },
-      onChangeText: (value: string) => {
-        calls.typed.push(value);
-        input.memoizedProps.value = value;
-      },
+      ...userProps,
+      ...(composite ? { onChange: () => {}, text: userProps.value } : {}),
     }),
   );
   if (options.branchedDuplicate) {
@@ -228,6 +237,24 @@ test('replay designates a bare TextInput and types without press or focus dispat
   assert.equal(fixture.calls.press, 0);
   assert.deepEqual(fixture.calls.typed, ['person@example.test']);
   assert.equal(fixture.input.memoizedProps.value, 'person@example.test');
+});
+
+test('replay designates and types into a stock TextInput rendered as composite plus host', async () => {
+  const fixture = replayFixture({ stockTextInput: true, inputValue: 'a' });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'b' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, true, JSON.stringify(result));
+  assert.equal(result.steps[0].focusOnly, true);
+  assert.equal(result.steps[1].ok, true);
+  assert.equal(result.finalFocusId, null);
+  assert.equal(fixture.calls.focus, 0);
+  assert.equal(fixture.calls.press, 0);
+  assert.deepEqual(fixture.calls.typed, ['ab']);
+  assert.equal(fixture.input.memoizedProps.value, 'ab');
 });
 
 test('a truncated designation scan refuses the press as an unproven assertion', async () => {

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -50,19 +50,32 @@ function replayFixture(
   options: {
     editable?: boolean;
     wrapped?: boolean;
+    exactMiddle?: boolean;
+    exactMiddleDisabled?: boolean;
+    branchedDuplicate?: boolean;
     inputHidden?: boolean;
     beforeDesignatedTypeDispatch?: (fixture: {
       root: Fiber;
       input: Fiber;
       designationOwner: Fiber;
+      exactMiddle: Fiber | null;
     }) => void;
   } = {},
 ) {
   const calls = { focus: 0, press: 0, typed: [] as string[] };
   const root = fiber({ displayName: 'Root' });
   const wrapper = options.wrapped ? append(root, fiber('RCTView', { testID: 'email' })) : null;
+  const exactMiddle = options.exactMiddle
+    ? append(
+        wrapper ?? root,
+        fiber('RCTView', {
+          testID: 'email',
+          ...(options.exactMiddleDisabled ? { accessibilityState: { disabled: true } } : {}),
+        }),
+      )
+    : null;
   const input = append(
-    wrapper ?? root,
+    exactMiddle ?? wrapper ?? root,
     fiber('RCTSinglelineTextInputView', {
       testID: 'email',
       editable: options.editable ?? true,
@@ -77,6 +90,9 @@ function replayFixture(
       },
     }),
   );
+  if (options.branchedDuplicate) {
+    append(wrapper ?? root, fiber('RCTView', { testID: 'email' }));
+  }
   append(
     root,
     fiber('RCTView', {
@@ -131,6 +147,7 @@ function replayFixture(
             root,
             input,
             designationOwner: wrapper ?? input,
+            exactMiddle,
           });
         }
         return { value: vm.runInContext(expression, sandbox) };
@@ -138,7 +155,7 @@ function replayFixture(
         return { error };
       }
     },
-    probeHelperFreshness: async () => ({ fresh: true, version: 51, probed: true }),
+    probeHelperFreshness: async () => ({ fresh: true, version: 52, probed: true }),
   });
   const interact = createInteractHandler(() => client);
   const deps: CdpReplayDeps = {
@@ -265,6 +282,42 @@ test('a hidden host TextInput beneath a visible wrapper refuses designation', as
   assert.equal(fixture.input.memoizedProps.value, '');
 });
 
+test('a disabled intermediate exact target refuses designation', async () => {
+  const fixture = replayFixture({
+    wrapped: true,
+    exactMiddle: true,
+    exactMiddleDisabled: true,
+  });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /disabled or non-editable/);
+  assert.deepEqual(fixture.calls.typed, []);
+  assert.equal(fixture.input.memoizedProps.value, '');
+});
+
+test('a branched duplicate exact target refuses designation', async () => {
+  const fixture = replayFixture({ wrapped: true, branchedDuplicate: true });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /Ambiguous TextInput designation target/);
+  assert.deepEqual(fixture.calls.typed, []);
+  assert.equal(fixture.input.memoizedProps.value, '');
+});
+
 test('designation preserves the frontmost and duplicate-target refusals', async (t) => {
   await t.test('occluded input', async () => {
     const fixture = replayFixture();
@@ -343,6 +396,49 @@ test('designation rechecks live eligibility at the injected mutation boundary', 
     assert.equal(result.failedStepIndex, 1);
     assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
     assert.match(result.reason ?? '', /disabled or non-editable/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
+  await t.test('intermediate exact target becomes disabled', async () => {
+    const fixture = replayFixture({
+      wrapped: true,
+      exactMiddle: true,
+      beforeDesignatedTypeDispatch: ({ exactMiddle }) => {
+        exactMiddle!.memoizedProps.accessibilityState = { disabled: true };
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.match(result.reason ?? '', /disabled or non-editable/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
+  await t.test('branched duplicate exact target mounts', async () => {
+    const fixture = replayFixture({
+      wrapped: true,
+      beforeDesignatedTypeDispatch: ({ designationOwner }) => {
+        append(designationOwner, fiber('RCTView', { testID: 'email' }));
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.match(result.reason ?? '', /Ambiguous TextInput designation target/);
     assert.deepEqual(fixture.calls.typed, []);
     assert.equal(fixture.input.memoizedProps.value, '');
   });

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -46,7 +46,12 @@ function append(parent: Fiber, child: Fiber): Fiber {
   return child;
 }
 
-function replayFixture(options: { editable?: boolean } = {}) {
+function replayFixture(
+  options: {
+    editable?: boolean;
+    beforeDesignatedTypeDispatch?: (fixture: { root: Fiber; input: Fiber }) => void;
+  } = {},
+) {
   const calls = { focus: 0, press: 0, typed: [] as string[] };
   const root = fiber({ displayName: 'Root' });
   const input = append(
@@ -96,6 +101,7 @@ function replayFixture(options: { editable?: boolean } = {}) {
     console: { log() {}, error() {}, warn() {}, info() {}, debug() {} },
   };
   sandbox.globalThis = sandbox;
+  sandbox.__expo_router_state__ = { routeName: 'ReplayFixture' };
   sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
     renderers: new Map([[1, {}]]),
     getFiberRoots: (rendererId: number) =>
@@ -107,18 +113,28 @@ function replayFixture(options: { editable?: boolean } = {}) {
   const client = createMockClient({
     evaluate: async (expression: string) => {
       try {
+        if (
+          options.beforeDesignatedTypeDispatch &&
+          expression.startsWith('__RN_AGENT.interact(') &&
+          JSON.parse(expression.slice(expression.indexOf('(') + 1, -1))
+            .requireLiveInputDesignation === true
+        ) {
+          options.beforeDesignatedTypeDispatch({ root, input });
+        }
         return { value: vm.runInContext(expression, sandbox) };
       } catch (error) {
         return { error };
       }
     },
-    probeHelperFreshness: async () => ({ fresh: true, version: 48, probed: true }),
+    probeHelperFreshness: async () => ({ fresh: true, version: 49, probed: true }),
   });
   const interact = createInteractHandler(() => client);
   const deps: CdpReplayDeps = {
     pressByTestId: createReplayPressByTestId(interact),
-    typeByTestId: async (id, text) => {
-      const result = await performReactTreeInput(id, text, client);
+    typeByTestId: async (id, text, context) => {
+      const result = await performReactTreeInput(id, text, client, undefined, {
+        requireLiveInputDesignation: context?.focusOnlyDesignation === true,
+      });
       const envelope = JSON.parse(result.content[0]?.text ?? '{}') as {
         ok?: boolean;
         code?: string;
@@ -257,6 +273,94 @@ test('designation preserves the frontmost and duplicate-target refusals', async 
     assert.equal(fixture.calls.focus, 0);
     assert.equal(fixture.calls.press, 0);
     assert.deepEqual(fixture.calls.typed, []);
+  });
+});
+
+test('designation rechecks live eligibility at the injected mutation boundary', async (t) => {
+  await t.test('input becomes non-editable', async () => {
+    const fixture = replayFixture({
+      beforeDesignatedTypeDispatch: ({ input }) => {
+        input.memoizedProps.editable = false;
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.match(result.reason ?? '', /disabled or non-editable/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
+  await t.test('exact target ceases to be a host TextInput', async () => {
+    const fixture = replayFixture({
+      beforeDesignatedTypeDispatch: ({ input }) => {
+        input.type = 'RCTView';
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.match(result.reason ?? '', /exact host input/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
+  await t.test('duplicate exact input mounts', async () => {
+    const fixture = replayFixture({
+      beforeDesignatedTypeDispatch: ({ root }) => {
+        append(
+          root,
+          fiber('RCTSinglelineTextInputView', {
+            testID: 'email',
+            editable: true,
+            value: '',
+            onChangeText() {},
+          }),
+        );
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'AMBIGUOUS_TESTID');
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
+  await t.test('modal covers the input', async () => {
+    const fixture = replayFixture({
+      beforeDesignatedTypeDispatch: ({ root }) => {
+        append(root, fiber('RCTModalHostView', { accessibilityViewIsModal: true }));
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.match(result.reason ?? '', /hidden subtree|behind the active modal/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
   });
 });
 

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -49,13 +49,19 @@ function append(parent: Fiber, child: Fiber): Fiber {
 function replayFixture(
   options: {
     editable?: boolean;
-    beforeDesignatedTypeDispatch?: (fixture: { root: Fiber; input: Fiber }) => void;
+    wrapped?: boolean;
+    beforeDesignatedTypeDispatch?: (fixture: {
+      root: Fiber;
+      input: Fiber;
+      designationOwner: Fiber;
+    }) => void;
   } = {},
 ) {
   const calls = { focus: 0, press: 0, typed: [] as string[] };
   const root = fiber({ displayName: 'Root' });
+  const wrapper = options.wrapped ? append(root, fiber('RCTView', { testID: 'email' })) : null;
   const input = append(
-    root,
+    wrapper ?? root,
     fiber('RCTSinglelineTextInputView', {
       testID: 'email',
       editable: options.editable ?? true,
@@ -119,14 +125,18 @@ function replayFixture(
           JSON.parse(expression.slice(expression.indexOf('(') + 1, -1))
             .requireLiveInputDesignation === true
         ) {
-          options.beforeDesignatedTypeDispatch({ root, input });
+          options.beforeDesignatedTypeDispatch({
+            root,
+            input,
+            designationOwner: wrapper ?? input,
+          });
         }
         return { value: vm.runInContext(expression, sandbox) };
       } catch (error) {
         return { error };
       }
     },
-    probeHelperFreshness: async () => ({ fresh: true, version: 49, probed: true }),
+    probeHelperFreshness: async () => ({ fresh: true, version: 50, probed: true }),
   });
   const interact = createInteractHandler(() => client);
   const deps: CdpReplayDeps = {
@@ -277,6 +287,27 @@ test('designation preserves the frontmost and duplicate-target refusals', async 
 });
 
 test('designation rechecks live eligibility at the injected mutation boundary', async (t) => {
+  await t.test('matched wrapper becomes disabled', async () => {
+    const fixture = replayFixture({
+      wrapped: true,
+      beforeDesignatedTypeDispatch: ({ designationOwner }) => {
+        designationOwner.memoizedProps.disabled = true;
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.match(result.reason ?? '', /disabled or non-editable/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
   await t.test('input becomes non-editable', async () => {
     const fixture = replayFixture({
       beforeDesignatedTypeDispatch: ({ input }) => {

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -51,6 +51,7 @@ function append(parent: Fiber, child: Fiber): Fiber {
 function replayFixture(
   options: {
     editable?: boolean;
+    readOnly?: boolean;
     wrapped?: boolean;
     exactMiddle?: boolean;
     exactMiddleDisabled?: boolean;
@@ -82,6 +83,7 @@ function replayFixture(
     fiber('RCTSinglelineTextInputView', {
       testID: 'email',
       editable: options.editable ?? true,
+      ...(options.readOnly ? { readOnly: true } : {}),
       ...(options.inputHidden ? { style: { display: 'none' } } : {}),
       value: options.inputValue ?? '',
       onFocus: () => {
@@ -158,7 +160,7 @@ function replayFixture(
         return { error };
       }
     },
-    probeHelperFreshness: async () => ({ fresh: true, version: 53, probed: true }),
+    probeHelperFreshness: async () => ({ fresh: true, version: 57, probed: true }),
   });
   const interact = createInteractHandler(() => client);
   const deps: CdpReplayDeps = {
@@ -328,6 +330,24 @@ test('a designation without typing is explicit and refuses the replay', async ()
 
 test('a non-editable bare TextInput refuses designation without callbacks', async () => {
   const fixture = replayFixture({ editable: false });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /disabled or non-editable/);
+  assert.equal(fixture.calls.focus, 0);
+  assert.equal(fixture.calls.press, 0);
+  assert.deepEqual(fixture.calls.typed, []);
+  assert.equal(fixture.input.memoizedProps.value, '');
+});
+
+test('a read-only bare TextInput refuses designation without callbacks', async () => {
+  const fixture = replayFixture({ readOnly: true });
   const result = await runCdpReplayCommands(
     [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
     {},
@@ -525,6 +545,26 @@ test('designation rechecks live eligibility at the injected mutation boundary', 
     const fixture = replayFixture({
       beforeDesignatedTypeDispatch: ({ input }) => {
         input.memoizedProps.editable = false;
+      },
+    });
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'email' } }, { inputText: 'blocked' }],
+      {},
+      fixture.deps,
+    );
+
+    assert.equal(result.passed, false);
+    assert.equal(result.failedStepIndex, 1);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.match(result.reason ?? '', /disabled or non-editable/);
+    assert.deepEqual(fixture.calls.typed, []);
+    assert.equal(fixture.input.memoizedProps.value, '');
+  });
+
+  await t.test('input becomes read-only', async () => {
+    const fixture = replayFixture({
+      beforeDesignatedTypeDispatch: ({ input }) => {
+        input.memoizedProps.readOnly = true;
       },
     });
     const result = await runCdpReplayCommands(

--- a/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/textinput-designation-replay.test.ts
@@ -21,6 +21,7 @@ type Fiber = {
   child: Fiber | null;
   sibling: Fiber | null;
   return: Fiber | null;
+  alternate: Fiber | null;
 };
 
 function fiber(type: Fiber['type'], memoizedProps: Record<string, unknown> = {}): Fiber {
@@ -31,6 +32,7 @@ function fiber(type: Fiber['type'], memoizedProps: Record<string, unknown> = {})
     child: null,
     sibling: null,
     return: null,
+    alternate: null,
   };
 }
 
@@ -54,6 +56,7 @@ function replayFixture(
     exactMiddleDisabled?: boolean;
     branchedDuplicate?: boolean;
     inputHidden?: boolean;
+    inputValue?: string;
     beforeDesignatedTypeDispatch?: (fixture: {
       root: Fiber;
       input: Fiber;
@@ -80,7 +83,7 @@ function replayFixture(
       testID: 'email',
       editable: options.editable ?? true,
       ...(options.inputHidden ? { style: { display: 'none' } } : {}),
-      value: '',
+      value: options.inputValue ?? '',
       onFocus: () => {
         calls.focus += 1;
       },
@@ -155,15 +158,19 @@ function replayFixture(
         return { error };
       }
     },
-    probeHelperFreshness: async () => ({ fresh: true, version: 52, probed: true }),
+    probeHelperFreshness: async () => ({ fresh: true, version: 53, probed: true }),
   });
   const interact = createInteractHandler(() => client);
   const deps: CdpReplayDeps = {
     pressByTestId: createReplayPressByTestId(interact),
     typeByTestId: async (id, text, context) => {
-      const result = await performReactTreeInput(id, text, client, undefined, {
-        requireLiveInputDesignation: context?.focusOnlyDesignation === true,
-      });
+      const result = await performReactTreeInput(
+        id,
+        text,
+        client,
+        undefined,
+        context ? { designationToken: context.designationToken } : {},
+      );
       const envelope = JSON.parse(result.content[0]?.text ?? '{}') as {
         ok?: boolean;
         code?: string;
@@ -177,6 +184,9 @@ function replayFixture(
           envelope.meta,
         );
       }
+    },
+    releaseInputDesignation: async (token) => {
+      await client.evaluate(`__RN_AGENT.releaseInputDesignation(${JSON.stringify(token)})`);
     },
     treeFor: async (id) => {
       const result = await client.evaluate(
@@ -210,6 +220,74 @@ test('replay designates a bare TextInput and types without press or focus dispat
   assert.equal(fixture.calls.press, 0);
   assert.deepEqual(fixture.calls.typed, ['person@example.test']);
   assert.equal(fixture.input.memoizedProps.value, 'person@example.test');
+});
+
+test('designation refuses a replacement input with the same selector and value shape', async () => {
+  let replacement: Fiber | null = null;
+  let replacementCalls = 0;
+  const fixture = replayFixture({
+    inputValue: 'a',
+    beforeDesignatedTypeDispatch: ({ input }) => {
+      const parent = input.return!;
+      replacement = fiber('RCTSinglelineTextInputView', {
+        testID: 'email',
+        editable: true,
+        value: 'b',
+        onChangeText: () => {
+          replacementCalls++;
+        },
+      });
+      replacement.return = parent;
+      replacement.sibling = input.sibling;
+      parent.child = replacement;
+      input.return = null;
+      input.sibling = null;
+    },
+  });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'x' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 1);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.match(result.reason ?? '', /no longer owns the exact host input/);
+  assert.deepEqual(fixture.calls.typed, []);
+  assert.equal(replacementCalls, 0);
+  assert.equal(replacement?.memoizedProps.value, 'b');
+});
+
+test('designation follows the original input across its React alternate', async () => {
+  const alternateTyped: string[] = [];
+  const fixture = replayFixture({
+    inputValue: 'a',
+    beforeDesignatedTypeDispatch: ({ input }) => {
+      const parent = input.return!;
+      const alternate = fiber('RCTSinglelineTextInputView', {
+        ...input.memoizedProps,
+        value: 'b',
+        onChangeText: (value: string) => {
+          alternateTyped.push(value);
+          alternate.memoizedProps.value = value;
+        },
+      });
+      input.alternate = alternate;
+      alternate.alternate = input;
+      alternate.return = parent;
+      alternate.sibling = input.sibling;
+      parent.child = alternate;
+    },
+  });
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'email' } }, { inputText: 'x' }],
+    {},
+    fixture.deps,
+  );
+
+  assert.equal(result.passed, true, JSON.stringify(result));
+  assert.deepEqual(alternateTyped, ['bx']);
 });
 
 test('an intervening non-input tap makes later text entry refuse without reaching the input', async () => {
@@ -536,13 +614,14 @@ test('maestro_run exposes designation in its public step trace', async () => {
     replayDeps: () => ({
       pressByTestId: async (id) => {
         calls.push(['press', id]);
-        return { kind: 'designation', focusOnly: true };
+        return { kind: 'designation', focusOnly: true, token: `designation-${id}` };
       },
       typeByTestId: async (id, text) => {
         calls.push(['type', id, text]);
       },
       treeFor: async (id) => ({ testID: id }),
       frontmostFor: async () => ({ visible: true }),
+      releaseInputDesignation: async () => {},
       async launchApp() {},
       async settle() {},
     }),


### PR DESCRIPTION
## Intent

Implement the captain-approved repair at the PR 885 interaction seam for the reproduced defect where React-tree tapOn refuses a bare React Native TextInput without onPress and therefore blocks inputText and credential entry. Separate target designation from event dispatch: an enabled exact host TextInput without onPress may accept a designation-only replay tap; the designation is single-use and valid only for the immediately adjacent inputText step; dispatch no synthetic press and do not invoke onFocus during designation; trace it explicitly as focusOnly so it can never be represented as a real press. Preserve disabled, occluded, duplicate-target, ownership, authority, and exact-target checks. Required negative controls: designation becomes stale after an intervening non-input tap and later typing refuses without reaching the original input; designation without a following type step refuses and leaves no dangling designation; a non-editable bare input (editable=false and readOnly) refuses. Stay strictly inside action-restoration scope; do not implement the PR 883 foreground-surface repair, refactor surrounding architecture, generalize targeting, add configuration, or weaken existing tests. Functional structuring by default but keep every safety refusal explicit if functionalization would make it harder to audit.

ALREADY ACCEPTED ON THIS BRANCH (prior pipeline rounds, do not re-open): readOnly refused at both designation boundaries; unconsumed-designation refusal blames the designation tap index; cross-segment focus revocation is authoritative (retainedReactFocusId is string|null|undefined with null = revoked and an explicit === undefined test, never ??) with a regression proving refusal; press-time designation-scan truncation reports ASSERTION_FAILED matching the mutation boundary. ACCEPTED TRADEOFFS, recorded, do not fix: an unconsumed designation is refused at flow end rather than at the step that stales it; the consumed-designation diagnostic message does not survive a proof-domain segment boundary and a designation staled by a non-tap step within one segment reports the older "inputText before any tapOn" wording (refusal correct, text never reaches the input, message only). Deliberate test changes already justified: an inert `{ t: assert }` control (not a ReplayStep member, already failing on HEAD) was replaced with a real waitVisible step and its expected failedStepIndex corrected 1->0; its timeoutMs was raised 0->1000 to remove a 1-in-5 race. Both strengthen.

CAPTAIN DECISION OPTION A (data/decisions/pr896-composite-host-typetext-a.md), an explicitly authorized product-contract expansion, already reviewed with 0 findings in run 01M1F78S77C585SWMDQRH6S1KY whose test step failed only on provider capacity: a stock React Native TextInput renders as a composite ForwardRef fiber plus its host child, and RN spreads the user props onto the host, so both carry the same testID, value and onChangeText. The SHARED typeText target resolver (resolveTypeTextTarget in injected-helpers.ts) counted them as two typeable candidates and refused every stock TextInput as "Ambiguous typeText resolution count=2"; the designated inputText re-derives its target through that same resolver, so designation succeeded and the adjacent typing refused (probed at 004b20bf). AUTHORIZED CHANGE: in that shared owner - not only on the designated path - collapse two bindings into one when they share an identical handler function, identical contract, and one ancestor/descendant lineage, keeping the deepest fiber (the host), mirroring the match-deepest-only rule press already applies. Previously-refused ambiguous typeText cases matching that rule MUST now act, for both designated inputText on the real composite+host shape and plain typeText on stock TextInput including test-app login_email. Distinct handler functions, distinct contracts, and same-handler siblings MUST stay ambiguous - do not over-collapse. The collapse is bounded by the existing typeText work budget and cycle guard and fails closed on truncation. HELPERS_VERSION bumped 58->59. Required proof, present and verified fail-before/pass-after at 004b20bf: composite ForwardRef TextInput plus host both carrying testID, value and the same onChangeText; designation tap succeeds; designated typing succeeds with no ambiguity; plain typing on the same stock shape succeeds (issue-840-type-text-resolution.test.ts, textinput-designation-replay.test.ts stockTextInput fixture); plus a distinct-onChangeText composite+host control that still refuses. Every previously accepted guarantee is preserved: no synthetic press or onFocus, focusOnly on every envelope including the aborted tap, single-use consume-first token with release in finally, assertExactInteractable on both legs, mutation-boundary rechecks including controlled inputs, cross-segment revocation in both directions, allowInputDesignation absent from the public cdp_interact schema. The changeset sentence names the stock-TextInput typeText resolution change. Known macOS-only pre-existing suite failures (action-engine-compat, save-as-action overwrite, managed-metro Darwin sandbox) fail identically on main via the /var -> /private/var TMPDIR realpath and are not regressions. Do not merge; independent exact-head acceptance remains required and is a separate lane.

## What Changed

- React-tree replay `tapOn` on an enabled exact host `TextInput` without `onPress` now returns a single-use, token-bound designation instead of refusing. The step is traced as `focusOnly`, dispatches no synthetic press and no `onFocus`, and only the immediately adjacent `inputText` may consume it. The typing leg re-derives the exact input identity (including its React alternate), rechecks occlusion, `pointerEvents`, disabled/`editable`/`readOnly`, duplicate targets and controlled state at the mutation boundary, and releases the token in `finally`. A designation staled by any intervening step or left unconsumed fails the replay with `INTERACTION_NOT_ACTUATED` blaming the designation tap index; truncated designation scans report `ASSERTION_FAILED`.
- The shared `resolveTypeTextTarget` in the injected helpers now collapses bindings that share one handler function, one contract and an ancestor/descendant lineage down to the deepest fiber, so a stock RN `TextInput` (composite ForwardRef plus host child carrying the same `testID`/`value`/`onChangeText`) resolves as one typeText target instead of "Ambiguous typeText resolution count=2". Distinct handlers, distinct contracts and same-handler siblings stay ambiguous; the collapse runs under the existing work budget and cycle guard and fails closed on truncation. `HELPERS_VERSION` bumped to 59.
- `maestro_run` propagates `focusOnly` into the partitioned iOS step trace and treats a designation-only tap as an authoritative React-focus revocation across proof segments (`retainedReactFocusId` may now be `null`). `interact` surfaces `ASSERTION_FAILED` codes from the helpers, and `allowInputDesignation` is a replay-only internal flag not exposed on the public `cdp_interact` schema. New unit suites cover the designation domain, replay negative controls, cross-segment revocation and stock-TextInput resolution; docs, changeset and plugin dist bundles are updated.

## Risk Assessment

✅ Low: The lineage collapse is confined to the shared typeText resolver, only affects cases that previously refused as ambiguous, keeps distinct handlers, distinct contracts, and siblings ambiguous, fails closed on budget or cycle truncation, is exercised by fail-before/pass-after behavioral tests for both plain and designated typing on the composite+host shape, and the tracked dist bundles carry the new helper version and code.

## Testing

Installed and built the core package, ran the four targeted suites covering designation replay, domain rules, typeText resolution, and iOS proof-domain routing (144 pass on HEAD), and drove the public maestro_run and cdp_interact handlers against the real injected helpers with a stock composite+host TextInput fixture to show the end-user flow: the tap designates with focusOnly, no press or focus callbacks fire, typing reaches the input with exact read-back, plain typeText on the stock shape succeeds, and every required negative control refuses without touching the input. The same demo reproduces the original refusal at the base commit and the ambiguity refusal at the pre-collapse helpers, where the two new success tests fail, so the fix is proven fail-before/pass-after. Tracked plugin bundles carry the new helper code. No screenshot or video was captured because the change is in injected JS helpers and the replay domain with no rendered surface, no simulator was booted, and the repository has no test app; the public tool envelopes are the user-facing surface. Worktree restored clean with the build output removed.

<details>
<summary>Evidence: Before/after summary of public envelopes (base, pre-collapse, HEAD) plus negative controls</summary>

```text
# Stock TextInput designation: before / after (public maestro_run + cdp_interact envelopes)

Fixture: composite ForwardRef TextInput (tag 11) + host RCTSinglelineTextInputView, both testID=login_email, same value and onChangeText; a 'continue' pressable; real injected helpers in a vm sandbox.

## === designation demo [base af7ecb7d] HELPERS_VERSION=50 ===

`` `
--- 1. maestro_run: tapOn login_email (bare stock TextInput) -> inputText ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: Component has no onPress handler
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onFocus calls: 0
app onPress calls: 0
app onChangeText received: []
host value after: 

--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---
ok: false
code: undefined
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

`` `

## === designation demo [bbed49b3 pre-collapse helpers] HELPERS_VERSION=58 ===

`` `
--- 1. maestro_run: tapOn login_email (bare stock TextInput) -> inputText ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree replay failed at step 1: React-tree input "login_email" has no verifiable controlled onChangeText path.
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"fail"}]
app onFocus calls: 0
app onPress calls: 0
app onChangeText received: []
host value after: 

--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---
ok: false
code: undefined
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

`` `

## === designation demo [HEAD d8546fab] HELPERS_VERSION=59 ===

`` `
--- 1. maestro_run: tapOn login_email (bare stock TextInput) -> inputText ---
ok: true
code: undefined
error: undefined
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"pass"}]
app onFocus calls: 0
app onPress calls: 0
app onChangeText received: ["person@example.test"]
host value after: person@example.test

--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---
ok: true
code: undefined
error: undefined
data: {"success":true,"action":"typeText","component":"RCTSinglelineTextInputView","testID":"login_email","text":"ab","handlerCalled":"onChangeText","controlled":true,"valueBefore":"a","resolvedFrom":"RCTSinglelineTextInputView [testID=\"login_email\"]","visitedFibers":5}
app onChangeText received: ["ab"]

`` `

## Negative controls on HEAD

`` `
--- 3. negative: intervening non-input tap stales the designation ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree replay failed at step 2: React-tree input "continue" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.
failedStepIndex: 2
meta: {"mutation":"none","pathsTried":["react-tree"],"hint":"No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying.","proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":1},{"index":1,"name":"tap","verb":"tap","status":"pass","durationMs":0},{"index":2,"name":"type","verb":"type","status":"fail","durationMs":0}],"failedStepIndex":2}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"tap","status":"pass"},{"index":2,"verb":"type","status":"fail"}]
continue onPress calls: 1
app onChangeText received: []
host value after: 

--- 4. negative: designation without a following inputText ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: TextInput designation for "login_email" must be followed immediately by inputText
failedStepIndex: 0
meta: {"failedSelector":"login_email","focusOnly":true,"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":1}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"}]
designation token issued: mtj46ev6-1
releaseInputDesignation(token) after flow: {"released":false}
later designated type with that token: {"ok":false,"code":"INTERACTION_NOT_ACTUATED","error":"React-tree input \"login_email\" refused: TextInput designation no longer owns the exact host input"}
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (editable=false) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: TextInput is disabled or non-editable
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":3}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (readOnly) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: TextInput is disabled or non-editable
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 8. control: composite+host with DISTINCT onChangeText functions stays ambiguous ---
ok: false
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

--- 9. single-use: a second inputText after the consumed designation refuses ---
ok: false
code: ASSERTION_FAILED
error: React-tree replay failed at step 2: the TextInput designation for "login_email" was already consumed — tapOn the field again before typing
failedStepIndex: 2
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":0},{"index":1,"name":"type","verb":"type","status":"pass","durationMs":152}],"failedStepIndex":2}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"pass"}]
app onChangeText received: ["first"]
host value after: first
`` `
```
</details>
<details>
<summary>Evidence: HEAD demo transcript: maestro_run and cdp_interact on stock composite+host TextInput</summary>

<code>--- 1. maestro_run: tapOn login_email (bare stock TextInput) -&gt; inputText ---&#10;ok: true&#10;steps: [{&#34;index&#34;:0,&#34;verb&#34;:&#34;tap&#34;,&#34;focusOnly&#34;:true,&#34;status&#34;:&#34;pass&#34;},{&#34;index&#34;:1,&#34;verb&#34;:&#34;type&#34;,&#34;status&#34;:&#34;pass&#34;}]&#10;app onFocus calls: 0&#10;app onPress calls: 0&#10;app onChangeText received: [&#34;person@example.test&#34;]&#10;host value after: person@example.test&#10;&#10;--- 4. negative: designation without a following inputText ---&#10;ok: false&#10;code: INTERACTION_NOT_ACTUATED&#10;error: React-tree replay failed at step 0: TextInput designation for &#34;login_email&#34; must be followed immediately by inputText&#10;releaseInputDesignation(token) after flow: {&#34;released&#34;:false}&#10;later designated type with that token: {&#34;ok&#34;:false,&#34;code&#34;:&#34;INTERACTION_NOT_ACTUATED&#34;,&#34;error&#34;:&#34;React-tree input \&#34;login_email\&#34; refused: TextInput designation no longer owns the exact host input&#34;}&#10;&#10;--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---&#10;ok: true&#10;data: {&#34;success&#34;:true,&#34;action&#34;:&#34;typeText&#34;,&#34;component&#34;:&#34;RCTSinglelineTextInputView&#34;,&#34;testID&#34;:&#34;login_email&#34;,&#34;text&#34;:&#34;ab&#34;,&#34;handlerCalled&#34;:&#34;onChangeText&#34;,&#34;controlled&#34;:true,&#34;valueBefore&#34;:&#34;a&#34;,&#34;resolvedFrom&#34;:&#34;RCTSinglelineTextInputView [testID=\&#34;login_email\&#34;]&#34;,&#34;visitedFibers&#34;:5}&#10;&#10;--- 8. control: composite+host with DISTINCT onChangeText functions stays ambiguous ---&#10;ok: false&#10;error: Interact failed: Ambiguous typeText resolution</code>

```text
=== designation demo [HEAD d8546fab] HELPERS_VERSION=59 ===
createReplayPressByTestId exported: true

--- 1. maestro_run: tapOn login_email (bare stock TextInput) -> inputText ---
ok: true
code: undefined
error: undefined
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"pass"}]
app onFocus calls: 0
app onPress calls: 0
app onChangeText received: ["person@example.test"]
host value after: person@example.test

--- 2. maestro_run: designated typing appends to the controlled value "a" ---
ok: true
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"pass"}]
app onChangeText received: ["ab"]
host value after: ab
onFocus calls: 0

--- 3. negative: intervening non-input tap stales the designation ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree replay failed at step 2: React-tree input "continue" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.
failedStepIndex: 2
meta: {"mutation":"none","pathsTried":["react-tree"],"hint":"No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying.","proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":1},{"index":1,"name":"tap","verb":"tap","status":"pass","durationMs":0},{"index":2,"name":"type","verb":"type","status":"fail","durationMs":0}],"failedStepIndex":2}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"tap","status":"pass"},{"index":2,"verb":"type","status":"fail"}]
continue onPress calls: 1
app onChangeText received: []
host value after: 

--- 4. negative: designation without a following inputText ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: TextInput designation for "login_email" must be followed immediately by inputText
failedStepIndex: 0
meta: {"failedSelector":"login_email","focusOnly":true,"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":1}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"}]
designation token issued: mtj46ev6-1
releaseInputDesignation(token) after flow: {"released":false}
later designated type with that token: {"ok":false,"code":"INTERACTION_NOT_ACTUATED","error":"React-tree input \"login_email\" refused: TextInput designation no longer owns the exact host input"}
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (editable=false) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: TextInput is disabled or non-editable
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":3}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (readOnly) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: TextInput is disabled or non-editable
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---
ok: true
code: undefined
error: undefined
data: {"success":true,"action":"typeText","component":"RCTSinglelineTextInputView","testID":"login_email","text":"ab","handlerCalled":"onChangeText","controlled":true,"valueBefore":"a","resolvedFrom":"RCTSinglelineTextInputView [testID=\"login_email\"]","visitedFibers":5}
app onChangeText received: ["ab"]

--- 7. React-tree fill (device_fill react path) on the stock shape ---
ok: true
code: undefined
error: undefined
data: {"filled":true,"method":"js-onChangeText","length":17}
host value after: user@example.test

--- 8. control: composite+host with DISTINCT onChangeText functions stays ambiguous ---
ok: false
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

--- 9. single-use: a second inputText after the consumed designation refuses ---
ok: false
code: ASSERTION_FAILED
error: React-tree replay failed at step 2: the TextInput designation for "login_email" was already consumed — tapOn the field again before typing
failedStepIndex: 2
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":0},{"index":1,"name":"type","verb":"type","status":"pass","durationMs":152}],"failedStepIndex":2}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"pass"}]
app onChangeText received: ["first"]
host value after: first
```
</details>
<details>
<summary>Evidence: Base-commit demo transcript (original defect reproduced)</summary>

<code>=== designation demo [base af7ecb7d] HELPERS_VERSION=50 ===&#10;--- 1. maestro_run: tapOn login_email (bare stock TextInput) -&gt; inputText ---&#10;ok: false&#10;code: INTERACTION_NOT_ACTUATED&#10;error: React-tree replay failed at step 0: press &#34;login_email&#34; failed: Interact failed: Component has no onPress handler&#10;app onChangeText received: []&#10;&#10;--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---&#10;ok: false&#10;error: Interact failed: Ambiguous typeText resolution</code>

```text
=== designation demo [base af7ecb7d] HELPERS_VERSION=50 ===
createReplayPressByTestId exported: false

--- 1. maestro_run: tapOn login_email (bare stock TextInput) -> inputText ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: Component has no onPress handler
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onFocus calls: 0
app onPress calls: 0
app onChangeText received: []
host value after: 

--- 2. maestro_run: designated typing appends to the controlled value "a" ---
ok: false
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
host value after: a
onFocus calls: 0

--- 3. negative: intervening non-input tap stales the designation ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: Component has no onPress handler
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
continue onPress calls: 0
app onChangeText received: []
host value after: 

--- 4. negative: designation without a following inputText ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: Component has no onPress handler
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
designation token issued: (none)
releaseInputDesignation(token) after flow: n/a
later designated type with that token: n/a
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (editable=false) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: Component has no onPress handler
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (readOnly) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: Component has no onPress handler
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---
ok: false
code: undefined
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

--- 7. React-tree fill (device_fill react path) on the stock shape ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree input "login_email" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.
data: undefined
host value after: 

--- 8. control: composite+host with DISTINCT onChangeText functions stays ambiguous ---
ok: false
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

--- 9. single-use: a second inputText after the consumed designation refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: Component has no onPress handler
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
host value after: 
```
</details>
<details>
<summary>Evidence: Pre-collapse helpers (bbed49b3): designation ok, adjacent typing refused, new tests fail</summary>

<code>✖ typeText collapses a stock TextInput composite and host that share one onChangeText&#10;✔ typeText keeps a stock-shaped composite and host ambiguous when they own distinct onChangeText functions&#10;✖ replay designates and types into a stock TextInput rendered as composite plus host&#10;ℹ tests 3 / pass 1 / fail 2&#10;AssertionError: {&#34;error&#34;:&#34;Ambiguous typeText resolution&#34;,&#34;testID&#34;:&#34;login_email&#34;,&#34;handler&#34;:&#34;onChangeText&#34;,&#34;count&#34;:2,...}&#10;&#10;[demo] 1. maestro_run: tapOn login_email -&gt; inputText&#10;ok: false code: TEXT_ENTRY_UNVERIFIED&#10;error: React-tree replay failed at step 1: React-tree input &#34;login_email&#34; has no verifiable controlled onChangeText path.&#10;steps: [{&#34;index&#34;:0,&#34;verb&#34;:&#34;tap&#34;,&#34;focusOnly&#34;:true,&#34;status&#34;:&#34;pass&#34;},{&#34;index&#34;:1,&#34;verb&#34;:&#34;type&#34;,&#34;status&#34;:&#34;fail&#34;}]</code>

```text
=== injected-helpers.ts from bbed49b3 (pre-collapse), rest of src at HEAD ===
✖ typeText collapses a stock TextInput composite and host that share one onChangeText (5.469208ms)
✔ typeText keeps a stock-shaped composite and host ambiguous when they own distinct onChangeText functions (1.238166ms)
✖ replay designates and types into a stock TextInput rendered as composite plus host (10.767667ms)
ℹ tests 3
ℹ pass 1
ℹ fail 2
✖ failing tests:
✖ typeText collapses a stock TextInput composite and host that share one onChangeText (5.469208ms)
  AssertionError [ERR_ASSERTION]: {"error":"Ambiguous typeText resolution","testID":"login_email","handler":"onChangeText","count":2,"candidates":[{"component":"TextInput","testID":"login_email","handler":"onChangeText","contract":"onChangeText:string"},{"component":"RCTSinglelineTextInputView","testID":"login_email","handler":"onChangeText","contract":"onChangeText:string"}],"hint":"Multiple distinct typeable handlers match this selector. Pass a more specific testID for the inner TextInput."}
✖ replay designates and types into a stock TextInput rendered as composite plus host (10.767667ms)
```
</details>
<details>
<summary>Evidence: Pre-collapse helpers demo transcript</summary>

```text
=== designation demo [bbed49b3 pre-collapse helpers] HELPERS_VERSION=58 ===
createReplayPressByTestId exported: true

--- 1. maestro_run: tapOn login_email (bare stock TextInput) -> inputText ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree replay failed at step 1: React-tree input "login_email" has no verifiable controlled onChangeText path.
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"fail"}]
app onFocus calls: 0
app onPress calls: 0
app onChangeText received: []
host value after: 

--- 2. maestro_run: designated typing appends to the controlled value "a" ---
ok: false
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"fail"}]
app onChangeText received: []
host value after: a
onFocus calls: 0

--- 3. negative: intervening non-input tap stales the designation ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree replay failed at step 2: React-tree input "continue" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.
failedStepIndex: 2
meta: {"mutation":"none","pathsTried":["react-tree"],"hint":"No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying.","proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":1},{"index":1,"name":"tap","verb":"tap","status":"pass","durationMs":0},{"index":2,"name":"type","verb":"type","status":"fail","durationMs":0}],"failedStepIndex":2}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"tap","status":"pass"},{"index":2,"verb":"type","status":"fail"}]
continue onPress calls: 1
app onChangeText received: []
host value after: 

--- 4. negative: designation without a following inputText ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: TextInput designation for "login_email" must be followed immediately by inputText
failedStepIndex: 0
meta: {"failedSelector":"login_email","focusOnly":true,"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":0}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"}]
designation token issued: mtj46wkw-1
releaseInputDesignation(token) after flow: {"released":false}
later designated type with that token: {"ok":false,"code":"INTERACTION_NOT_ACTUATED","error":"React-tree input \"login_email\" refused: TextInput designation no longer owns the exact host input"}
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (editable=false) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: TextInput is disabled or non-editable
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":2}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 5. negative: non-editable bare input (readOnly) refuses ---
ok: false
code: INTERACTION_NOT_ACTUATED
error: React-tree replay failed at step 0: press "login_email" failed: Interact failed: TextInput is disabled or non-editable
failedStepIndex: 0
meta: {"proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","status":"fail","durationMs":1}],"failedStepIndex":0}
steps: [{"index":0,"verb":"tap","status":"fail"}]
app onChangeText received: []
onFocus calls: 0

--- 6. cdp_interact typeText on the stock composite+host shape (no designation) ---
ok: false
code: undefined
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

--- 7. React-tree fill (device_fill react path) on the stock shape ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree input "login_email" is uncontrolled or unreadable. Run this native text-entry check on a WDA-healthy runtime; secure masked native values are not plaintext proof.
data: undefined
host value after: 

--- 8. control: composite+host with DISTINCT onChangeText functions stays ambiguous ---
ok: false
error: Interact failed: Ambiguous typeText resolution
data: undefined
app onChangeText received: []

--- 9. single-use: a second inputText after the consumed designation refuses ---
ok: false
code: TEXT_ENTRY_UNVERIFIED
error: React-tree replay failed at step 1: React-tree input "login_email" has no verifiable controlled onChangeText path.
failedStepIndex: 1
meta: {"mutation":"none","pathsTried":["react-tree"],"hint":"No text was entered. Refresh the snapshot (device_snapshot action=snapshot) and rebind the input before retrying.","proofDomain":"react-tree","proofDomains":["react-tree"],"failedProofDomain":"react-tree","steps":[{"index":0,"name":"tap","verb":"tap","focusOnly":true,"status":"pass","durationMs":1},{"index":1,"name":"type","verb":"type","status":"fail","durationMs":1}],"failedStepIndex":1}
steps: [{"index":0,"verb":"tap","focusOnly":true,"status":"pass"},{"index":1,"verb":"type","status":"fail"}]
app onChangeText received: []
host value after: 
```
</details>

- Evidence: Four targeted suites on HEAD after restore (144 pass) (local file: <code>~/.no-mistakes/evidence/01M1F98V8MM1A95DGHEQ9XQPWH/targeted-suites-head-final.log</code>)
- Evidence: Demo script driving the public handlers against the real injected helpers (local file: <code>~/.no-mistakes/evidence/01M1F98V8MM1A95DGHEQ9XQPWH/designation-demo.mjs</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e40396ce9e83c35a85ba5f5bda8a7163d54d8ac0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `packages/rn-dev-agent-core/src/injected-helpers.ts:2179` - collapseLineageBindings checks every same-handler pair in both directions, and bindingDescendsFrom walks the descendant&#39;s full return chain to the root when the pair is not in lineage. For the stock composite+host pair the host-&gt;composite check costs one work unit, but the composite-&gt;host check charges one unit per ancestor up to the root, so the collapse adds roughly the TextInput&#39;s depth to a budget already spent on the scan; a scan that finished with fewer than depth+1 of the 2000 units left now reports &#39;typeText resolution truncated&#39; where it would previously have completed. For N same-handler siblings sharing a testID (e.g. two inputs with onChangeText={setQuery}) the cost is N^2 walks to the root, which flips the prior &#39;Ambiguous typeText resolution count=N&#39; refusal with its candidates list into the truncation refusal. Both outcomes are refusals and the intent explicitly accepts the shared budget and fail-closed truncation, so no change is proposed. If it ever matters, candidates are collected in DFS preorder so ancestors always precede descendants in `bindings`, which would allow checking only later bindings against earlier ones; that relies on an implicit ordering invariant and would make the refusal harder to audit, so it is recorded here rather than recommended.
- ℹ️ `packages/rn-dev-agent-core/test/unit/issue-840-type-text-resolution.test.ts:172` - The intent marks &#39;same-handler siblings MUST stay ambiguous&#39; as a required constraint of the collapse rule, but no regression pins it: the new distinct-handler control uses two different closures, and the existing ambiguity tests (&#39;mixed component-name candidates&#39;, &#39;nested matching sources&#39;) also use distinct closures, while the &#39;cross-contract&#39; test covers the shared-function/different-contract case only. Code trace confirms siblings are not collapsed (bindingDescendsFrom only follows the return chain, and a sibling&#39;s chain never reaches the other sibling), so behavior is correct today. A focused test in this suite, two sibling AndroidTextInput fibers under one root with the same testID and the same onChangeText function reference, asserting `error === &#39;Ambiguous typeText resolution&#39;`, `count === 2`, and no handler calls, would make the constraint fail if a future edit widened the collapse to same-handler-anywhere.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install --immutable` then `yarn build:core` in the worktree (no node_modules or dist existed)</code>
- <code>`node --test test/unit/textinput-designation-replay.test.ts test/unit/textinput-designation-domain.test.ts test/unit/issue-840-type-text-resolution.test.ts test/unit/ios-proof-domain-routing.test.ts` on HEAD: 144 pass, 0 fail (run twice, before and after the fail-before swaps)</code>
- <code>`node designation-demo.mjs &lt;core pkg&gt; &#39;HEAD d8546fab&#39;`: public maestro_run + cdp_interact envelopes against real injected helpers with a composite ForwardRef + host RCTSinglelineTextInputView fixture (testID login_email): designation tap traced focusOnly, onFocus=0, onPress=0, onChangeText receives text, host value reads back; plain typeText and React-tree fill succeed; distinct-handler control stays ambiguous; stale-after-tap, unconsumed-designation (token already released, later designated type refuses), editable=false, readOnly, and second-inputText controls all refuse with no text reaching the input</code>
- <code>Fail-before (pre-collapse): swapped src/injected-helpers.ts to bbed49b3 (HELPERS_VERSION 58), rebuilt, `node --test --test-name-pattern=stock` on issue-840 and designation-replay suites: 2 of 3 fail with &#39;Ambiguous typeText resolution&#39; count=2; demo shows designation ok but adjacent typing refused and plain typeText ambiguous</code>
- `Fail-before (base): checked out af7ecb7d src, rebuilt, demo shows maestro_run tap on bare TextInput refused with 'Component has no onPress handler' (INTERACTION_NOT_ACTUATED) and plain typeText ambiguous`
- <code>Restored HEAD src (`git status` and `git diff HEAD` empty), rebuilt, re-ran the four suites: 144 pass</code>
- <code>Verified tracked bundles packages/{claude,codex}-plugin/rn-dev-agent-core/dist/{index,supervisor}.js contain `HELPERS_VERSION = 59` and `collapseLineageBindings`; cdp_interact public schema in src/index.ts has no allowInputDesignation field</code>
- `Cleanup: removed packages/rn-dev-agent-core/dist build output; node_modules and .yarn/install-state.gz remain as gitignored toolchain state`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
