### PR TITLE
fix(core): recognize CLAUDE.local.md in preflight and retain bounded runner failure evidence

### DIFF
--- a/.changeset/retain-runner-failure-evidence.md
+++ b/.changeset/retain-runner-failure-evidence.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Retain a bounded closed-vocabulary projection of runner failure evidence on `maestro_run` results and `cdp_run_action` RunRecords before the temporary report tree is deleted, withholding text, images, terminal output and original artifacts.

--- a/.changeset/tidy-local-preflight.md
+++ b/.changeset/tidy-local-preflight.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Recognize the rn-dev-agent instruction block in CLAUDE.local.md during workflow preflight without modifying either Claude instruction file or hiding read errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,15 @@ Several suite tests fail only on macOS because `$TMPDIR` resolves through the
 They fail identically on `main`; confirm against `main` before treating a local
 failure in those files as a regression.
 
+Every `cdp_run_action` RunRecord write goes through the proven-identity action
+write lock (`src/domain/atomic-writer.ts`, `currentLockOwner`). A shell that
+cannot execute setuid `/bin/ps` or read `kern.bootsessionuuid` (the Codex
+`workspace-write` sandbox does both) makes `probeProcessBirth` return `unknown`,
+so persistence throws, the outer catch in `src/tools/run-action.ts` swallows it,
+and handler-driven tests report zero RunRecords with a code-less envelope. Run
+those tests from an unsandboxed shell before treating that as a regression; do
+not weaken the identity requirement.
+
 Native runner checks:
 
 ```bash

--- a/packages/claude-plugin/commands/run-action.md
+++ b/packages/claude-plugin/commands/run-action.md
@@ -167,6 +167,13 @@ Example calls:
    temporary artifact that is deleted after every run — no report path is
    returned, and none should be looked for.
 
+   A failed replay may also carry `meta.runnerFailureEvidence`, persisted on
+   the RunRecord: a bounded closed-vocabulary projection of each runner
+   failure (exit code, timeout/signal flags, report state, per-command
+   status) marked `incomplete: true`, with text, screenshots, and terminal
+   output withheld. It is diagnostic context only and never changes the
+   outcome, refusal, or auto-repair decision.
+
    When `meta.trailingVerification.trailingVerificationOnly === true`, the
    result remains failed and the goal state remains unproven, but the ledger
    proved every authored mutation completed and only trailing verification

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -424,11 +424,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants10);
+          this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -445,10 +445,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants10);
+        this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -509,8 +509,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants10) {
-        this.code = optimizeExpr(this.code, names, constants10);
+      optimizeNames(names, constants11) {
+        this.code = optimizeExpr(this.code, names, constants11);
         return this;
       }
       get names() {
@@ -539,12 +539,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants10))
+          if (n.optimizeNames(names, constants11))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -597,12 +597,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        if (!(super.optimizeNames(names, constants10) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        if (!(super.optimizeNames(names, constants11) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants10);
+        this.condition = optimizeExpr(this.condition, names, constants11);
         return this;
       }
       get names() {
@@ -625,10 +625,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants10);
+        this.iteration = optimizeExpr(this.iteration, names, constants11);
         return this;
       }
       get names() {
@@ -664,10 +664,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants10);
+        this.iterable = optimizeExpr(this.iterable, names, constants11);
         return this;
       }
       get names() {
@@ -709,11 +709,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a, _b;
-        super.optimizeNames(names, constants10);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants10);
+        super.optimizeNames(names, constants11);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants11);
         return this;
       }
       get names() {
@@ -1014,7 +1014,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants10) {
+    function optimizeExpr(expr, names, constants11) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -1029,14 +1029,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants10[n.str];
+        const c = constants11[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants10[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants11[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -2683,18 +2683,18 @@ var require_validate = __commonJS({
         const { schemaCode } = this;
         this.fail((0, codegen_1._)`${schemaCode} !== undefined && (${(0, codegen_1.or)(this.invalid$data(), condition)})`);
       }
-      error(append, errorParams, errorPaths) {
+      error(append2, errorParams, errorPaths) {
         if (errorParams) {
           this.setParams(errorParams);
-          this._error(append, errorPaths);
+          this._error(append2, errorPaths);
           this.setParams({});
           return;
         }
-        this._error(append, errorPaths);
+        this._error(append2, errorPaths);
       }
-      _error(append, errorPaths) {
+      _error(append2, errorPaths) {
         ;
-        (append ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
+        (append2 ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
       }
       $dataError() {
         (0, errors_1.reportError)(this, this.def.$dataError || errors_1.keyword$DataError);
@@ -11012,17 +11012,17 @@ function getFreshRefTarget(ref, opts = {}) {
     return null;
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
   const rect = refMap.get(key);
-  const record2 = metadataMap.get(key);
-  if (!rect || !record2 || record2.snapshotGeneration !== snapshotGeneration || record2.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
+  const record3 = metadataMap.get(key);
+  if (!rect || !record3 || record3.snapshotGeneration !== snapshotGeneration || record3.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
     return null;
   return {
     rect,
-    snapshotGeneration: record2.snapshotGeneration,
-    snapshotNodeIndex: record2.snapshotNodeIndex,
-    snapshotElementType: record2.type,
-    ...record2.label !== void 0 ? { snapshotLabel: record2.label } : {},
-    ...record2.identifier !== void 0 ? { snapshotIdentifier: record2.identifier } : {},
-    keyboardStateAtSnapshot: record2.keyboardStateAtSnapshot
+    snapshotGeneration: record3.snapshotGeneration,
+    snapshotNodeIndex: record3.snapshotNodeIndex,
+    snapshotElementType: record3.type,
+    ...record3.label !== void 0 ? { snapshotLabel: record3.label } : {},
+    ...record3.identifier !== void 0 ? { snapshotIdentifier: record3.identifier } : {},
+    keyboardStateAtSnapshot: record3.keyboardStateAtSnapshot
   };
 }
 function getCachedMetadata(ref) {
@@ -19530,10 +19530,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -19547,7 +19547,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep11) {
+          if (!keyProps.anchor && !keyProps.tag && !sep12) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -19571,7 +19571,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+        const valueProps = resolveProps.resolveProps(sep12 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -19587,7 +19587,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep11, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep12, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -19678,7 +19678,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep11 = "";
+        let sep12 = "";
         for (const token2 of end) {
           const { source, type } = token2;
           switch (type) {
@@ -19692,13 +19692,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep11 + cb;
-              sep11 = "";
+                comment += sep12 + cb;
+              sep12 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep11 += source;
+                sep12 += source;
               hasSpace = true;
               break;
             default:
@@ -19741,18 +19741,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep11 && !value) {
+          if (!props.anchor && !props.tag && !sep12 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -19806,8 +19806,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep11 && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep11, null, props, onError);
+        if (!isMap && !sep12 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep12, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -19819,7 +19819,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+          const valueProps = resolveProps.resolveProps(sep12 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -19830,8 +19830,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep11)
-                for (const st of sep11) {
+              if (sep12)
+                for (const st of sep12) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -19848,7 +19848,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep11, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep12, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -20028,7 +20028,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep11 = "";
+      let sep12 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -20045,24 +20045,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep11 === " ")
-            sep11 = "\n";
-          else if (!prevMoreIndented && sep11 === "\n")
-            sep11 = "\n\n";
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          if (sep12 === " ")
+            sep12 = "\n";
+          else if (!prevMoreIndented && sep12 === "\n")
+            sep12 = "\n\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep11 === "\n")
+          if (sep12 === "\n")
             value += "\n";
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          value += sep11 + content;
-          sep11 = " ";
+          value += sep12 + content;
+          sep12 = " ";
           prevMoreIndented = false;
         }
       }
@@ -20244,25 +20244,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep11 = " ";
+      let sep12 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep11 === "\n")
-            res += sep11;
+          if (sep12 === "\n")
+            res += sep12;
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          res += sep11 + match[1];
-          sep11 = " ";
+          res += sep12 + match[1];
+          sep12 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep11 + (match?.[1] ?? "");
+      return res + sep12 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -21072,14 +21072,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep: sep11, value }) {
+    function stringifyItem({ start, key, sep: sep12, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep11)
-        for (const st of sep11)
+      if (sep12)
+        for (const st of sep12)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -22246,18 +22246,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep11;
+          let sep12;
           if (scalar.end) {
-            sep11 = scalar.end;
-            sep11.push(this.sourceToken);
+            sep12 = scalar.end;
+            sep12.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep11 = [this.sourceToken];
+            sep12 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep: sep11 }]
+            items: [{ start, key: scalar, sep: sep12 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -22410,15 +22410,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep11 = it.sep;
-                  sep11.push(this.sourceToken);
+                  const sep12 = it.sep;
+                  sep12.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep: sep11 }]
+                    items: [{ start: start2, key, sep: sep12 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -22612,13 +22612,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep11 = fc.end.splice(1, fc.end.length);
-            sep11.push(this.sourceToken);
+            const sep12 = fc.end.splice(1, fc.end.length);
+            sep12.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep: sep11 }]
+              items: [{ start, key: fc, sep: sep12 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -23332,7 +23332,7 @@ function recordNavigation(projectRoot, input) {
   if (!targetScreen)
     return null;
   const now = (/* @__PURE__ */ new Date()).toISOString();
-  const record2 = {
+  const record3 = {
     method: input.method,
     success: input.success,
     latency_ms: input.latency_ms ?? 0,
@@ -23340,7 +23340,7 @@ function recordNavigation(projectRoot, input) {
   };
   if (!targetScreen.action_records)
     targetScreen.action_records = [];
-  targetScreen.action_records.push(record2);
+  targetScreen.action_records.push(record3);
   if (targetScreen.action_records.length > MAX_ACTION_RECORDS) {
     targetScreen.action_records = targetScreen.action_records.slice(-MAX_ACTION_RECORDS);
   }
@@ -25277,10 +25277,10 @@ function referencesMetroEvidenceSocket(value, path) {
   }
   if (!value || typeof value !== "object")
     return false;
-  const record2 = value;
-  if (record2.runtimeEvidenceSocket === path)
+  const record3 = value;
+  if (record3.runtimeEvidenceSocket === path)
     return true;
-  return Object.values(record2).some((entry) => referencesMetroEvidenceSocket(entry, path));
+  return Object.values(record3).some((entry) => referencesMetroEvidenceSocket(entry, path));
 }
 function authorityRemedyNextAction(code) {
   return errorNextActions[code];
@@ -25350,14 +25350,14 @@ function readStartupCleanupBlocker(bindingsJson) {
   const refusal = journal.refusal;
   if (!refusal || typeof refusal !== "object")
     return void 0;
-  const record2 = refusal;
-  if (typeof record2.code !== "string" || typeof record2.reason !== "string")
+  const record3 = refusal;
+  if (typeof record3.code !== "string" || typeof record3.reason !== "string")
     return void 0;
   return {
-    code: record2.code,
-    reason: record2.reason,
-    ...record2.cause === "managed-metro-stop-proof-missing" ? { cause: record2.cause } : {},
-    ...typeof record2.nextAction === "string" ? { nextAction: record2.nextAction } : {}
+    code: record3.code,
+    reason: record3.reason,
+    ...record3.cause === "managed-metro-stop-proof-missing" ? { cause: record3.cause } : {},
+    ...typeof record3.nextAction === "string" ? { nextAction: record3.nextAction } : {}
   };
 }
 function bindingsRunnerPresent(bindingsJson) {
@@ -26297,21 +26297,21 @@ var init_registry = __esm({
               integration: existing.integration ?? null
             };
           }
-          const record2 = (value) => value && typeof value === "object" ? { ...value } : null;
+          const record3 = (value) => value && typeof value === "object" ? { ...value } : null;
           const obligation = (source, claimKey) => source ? {
             ...source,
             claimKey: String(source.claimKey ?? claimKey ?? ""),
             stopRequestedAt: typeof source.stopRequestedAt === "number" ? source.stopRequestedAt : now,
             completedAt: typeof source.completedAt === "number" ? source.completedAt : null
           } : void 0;
-          const handoffCleanup = record2(bindings.handoffCleanup);
-          const staleDevice = record2(bindings.staleDeviceCleanup);
-          const androidMetroReverseSource = record2(bindings.androidMetroReverse) ?? record2(staleDevice?.androidMetroReverse);
-          const recorderSource = record2(bindings.recorder) ?? record2(staleDevice?.recorder) ?? record2(handoffCleanup?.recorder);
-          const runnerSource = record2(bindings.runner) ?? record2(staleDevice?.runner) ?? record2(handoffCleanup?.runner);
-          const observeSource = record2(bindings.observe) ?? record2(handoffCleanup?.observe);
-          const liveMetro = record2(bindings.metroCleanup) ?? record2(bindings.metro);
-          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record2(handoffCleanup?.metro);
+          const handoffCleanup = record3(bindings.handoffCleanup);
+          const staleDevice = record3(bindings.staleDeviceCleanup);
+          const androidMetroReverseSource = record3(bindings.androidMetroReverse) ?? record3(staleDevice?.androidMetroReverse);
+          const recorderSource = record3(bindings.recorder) ?? record3(staleDevice?.recorder) ?? record3(handoffCleanup?.recorder);
+          const runnerSource = record3(bindings.runner) ?? record3(staleDevice?.runner) ?? record3(handoffCleanup?.runner);
+          const observeSource = record3(bindings.observe) ?? record3(handoffCleanup?.observe);
+          const liveMetro = record3(bindings.metroCleanup) ?? record3(bindings.metro);
+          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record3(handoffCleanup?.metro);
           const obligations = {};
           const androidMetroReverseEntry = obligation(androidMetroReverseSource, androidMetroReverseSource ? `android:${String(androidMetroReverseSource.deviceId)}` : null);
           if (androidMetroReverseEntry) {
@@ -26329,7 +26329,7 @@ var init_registry = __esm({
           const metroEntry = obligation(metroSource, metroSource ? String(metroSource.port) : null);
           if (metroEntry)
             obligations.metro = metroEntry;
-          const integrationBinding = record2(bindings.packageIntegration);
+          const integrationBinding = record3(bindings.packageIntegration);
           const integration = integrationBinding ? {
             installedBySessionId: integrationBinding.installedBySessionId ?? null,
             manifestSha256: integrationBinding.manifestSha256 ?? null,
@@ -26584,8 +26584,8 @@ var init_registry = __esm({
       #bindingMatchesDevice(binding, target) {
         if (!binding || typeof binding !== "object")
           return false;
-        const record2 = binding;
-        return record2.platform === target.platform && record2.deviceId === target.deviceId;
+        const record3 = binding;
+        return record3.platform === target.platform && record3.deviceId === target.deviceId;
       }
       #requireProvenDeadOwner(sessionId, claimEpoch) {
         const prior = asSession(this.#database.prepare(`SELECT session_id, claim_epoch, state, supervisor_pid, supervisor_birth, bindings_json
@@ -36358,7 +36358,7 @@ import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
-import { dirname as dirname31, join as join60 } from "node:path";
+import { dirname as dirname31, join as join61 } from "node:path";
 
 // node_modules/zod/v3/external.js
 var external_exports = {};
@@ -58943,10 +58943,10 @@ function openActionDb(projectRoot, opts = {}) {
     const handle = {
       db,
       close: () => db.close(),
-      insertRunRecord(actionId, record2) {
+      insertRunRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
@@ -58955,7 +58955,7 @@ function openActionDb(projectRoot, opts = {}) {
                (action_id, ts, trigger, status, failure_code, failure_detail,
                 transport, auto_repair_json, duration_ms, device_id, blind_probe_json,
                 trailing_verification_json)
-             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.trigger, record2.status, record2.failureCode ?? null, record2.failureDetail ?? null, record2.transport ?? null, record2.autoRepair ? JSON.stringify(record2.autoRepair) : null, record2.durationMs, record2.deviceId ?? null, record2.blindProbe ? JSON.stringify(record2.blindProbe) : null, record2.trailingVerification ? JSON.stringify(record2.trailingVerification) : null);
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.trigger, record3.status, record3.failureCode ?? null, record3.failureDetail ?? null, record3.transport ?? null, record3.autoRepair ? JSON.stringify(record3.autoRepair) : null, record3.durationMs, record3.deviceId ?? null, record3.blindProbe ? JSON.stringify(record3.blindProbe) : null, record3.trailingVerification ? JSON.stringify(record3.trailingVerification) : null);
           db.prepare(`DELETE FROM run_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -58970,17 +58970,17 @@ function openActionDb(projectRoot, opts = {}) {
           throw e;
         }
       },
-      insertRepairRecord(actionId, record2) {
+      insertRepairRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
           }
           db.prepare(`INSERT INTO repair_records
                (action_id, ts, failure_code, diff_json, duration_ms, agent_reasoning)
-             VALUES (?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.failureCode, JSON.stringify(record2.diff ?? {}), record2.durationMs, record2.agentReasoning ?? null);
+             VALUES (?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.failureCode, JSON.stringify(record3.diff ?? {}), record3.durationMs, record3.agentReasoning ?? null);
           db.prepare(`DELETE FROM repair_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -59151,36 +59151,36 @@ function freshRuntimeState(now = () => /* @__PURE__ */ new Date(), mtimeMs = 0) 
     }
   };
 }
-function appendRunRecord(state, record2) {
-  const newHistory = [...state.runHistory, record2];
+function appendRunRecord(state, record3) {
+  const newHistory = [...state.runHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.RUN_HISTORY_MAX)
     newHistory.shift();
   const totalRuns = state.stats.totalRuns + 1;
-  const successCount = state.stats.successCount + (record2.status === "pass" ? 1 : 0);
-  const failureCount = state.stats.failureCount + (record2.status === "fail" ? 1 : 0);
+  const successCount = state.stats.successCount + (record3.status === "pass" ? 1 : 0);
+  const failureCount = state.stats.failureCount + (record3.status === "fail" ? 1 : 0);
   const successDurations = newHistory.filter((r) => r.status === "pass").map((r) => r.durationMs);
   const avgDurationMs = successDurations.length ? Math.round(successDurations.reduce((s, n) => s + n, 0) / successDurations.length) : state.stats.avgDurationMs;
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     runHistory: newHistory,
     stats: {
       totalRuns,
       successCount,
       failureCount,
       avgDurationMs,
-      lastSuccessAt: record2.status === "pass" ? record2.timestamp : state.stats.lastSuccessAt,
-      lastFailureAt: record2.status === "fail" ? record2.timestamp : state.stats.lastFailureAt
+      lastSuccessAt: record3.status === "pass" ? record3.timestamp : state.stats.lastSuccessAt,
+      lastFailureAt: record3.status === "fail" ? record3.timestamp : state.stats.lastFailureAt
     }
   };
 }
-function appendRepairRecord(state, record2) {
-  const newHistory = [...state.repairHistory, record2];
+function appendRepairRecord(state, record3) {
+  const newHistory = [...state.repairHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.REPAIR_HISTORY_MAX)
     newHistory.shift();
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     revision: state.revision + 1,
     repairHistory: newHistory
   };
@@ -73853,11 +73853,11 @@ function redactBatchFillSteps(args) {
   const redactedSteps = steps.map((step) => {
     if (!step || typeof step !== "object" || Array.isArray(step))
       return step;
-    const record2 = step;
-    if (record2.action !== "fill")
+    const record3 = step;
+    if (record3.action !== "fill")
       return step;
-    const redacted = redactTypedValue(record2, "text");
-    if (redacted !== record2)
+    const redacted = redactTypedValue(record3, "text");
+    if (redacted !== record3)
       changed = true;
     return redacted;
   });
@@ -77140,8 +77140,8 @@ function acknowledgeExternalEdit(action) {
 function canonicalRuntimeJson(state) {
   return JSON.stringify(state, (_key, value) => {
     if (value && typeof value === "object" && !Array.isArray(value)) {
-      const record2 = value;
-      return Object.fromEntries(Object.keys(record2).sort().map((k) => [k, record2[k]]));
+      const record3 = value;
+      return Object.fromEntries(Object.keys(record3).sort().map((k) => [k, record3[k]]));
     }
     return value;
   });
@@ -78744,6 +78744,359 @@ function createSaveAsActionHandler() {
 }
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
+init_agent_device_wrapper();
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+import { closeSync as closeSync11, constants as constants10, fstatSync as fstatSync9, lstatSync as lstatSync17, openSync as openSync11, readSync as readSync5, realpathSync as realpathSync15 } from "node:fs";
+import { join as join42, sep as sep10 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
+import { existsSync as existsSync28, readFileSync as readFileSync28, readdirSync as readdirSync11, realpathSync as realpathSync14, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash14 } from "node:crypto";
+import { tmpdir as tmpdir8 } from "node:os";
+import { isAbsolute as isAbsolute14, join as join41, sep as sep9 } from "node:path";
+var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
+var WEAK_DEVICE_ID_KEYS = ["id"];
+var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
+function idsFrom(value, keys) {
+  if (!value || typeof value !== "object")
+    return [];
+  const record3 = value;
+  for (const key of keys) {
+    const id = record3[key];
+    if (typeof id === "string")
+      return [id];
+  }
+  return [];
+}
+function deviceIdsFrom(value) {
+  return idsFrom(value, DEVICE_ID_KEYS);
+}
+function weakDeviceIdsFrom(value) {
+  if (typeof value === "string")
+    return [value];
+  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
+}
+function containerDeviceIdsFrom(value) {
+  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
+}
+function reportDeviceIds(reportDir) {
+  const reportPath = join41(reportDir, "report.json");
+  if (!existsSync28(reportPath))
+    return { ids: [], strength: "none" };
+  try {
+    const report = JSON.parse(readFileSync28(reportPath, "utf8"));
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    const devices = [report.device, ...flows.map((flow) => flow?.device)];
+    const strong = [
+      ...devices.flatMap((device) => deviceIdsFrom(device)),
+      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
+    ];
+    const usingStrong = strong.length > 0;
+    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
+    const accepted = [
+      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
+    ];
+    return {
+      ids: accepted,
+      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
+    };
+  } catch {
+    return { ids: [], strength: "none" };
+  }
+}
+function createRunnerReportDir(runner, prefix) {
+  if (runner !== "maestro-runner")
+    return null;
+  return join41(tmpdir8(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+}
+function runnerReportArgs(reportDir) {
+  return reportDir ? ["--output", reportDir, "--flatten"] : [];
+}
+function collectDirectRunnerEvidence(reportDir, output) {
+  if (!reportDir)
+    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
+  const report = reportDeviceIds(reportDir);
+  const evidence = {
+    output,
+    reportDeviceIds: report.ids,
+    reportDeviceIdStrength: report.strength
+  };
+  const logPath = join41(reportDir, "maestro-runner.log");
+  if (!existsSync28(logPath))
+    return evidence;
+  try {
+    evidence.output = `${output}
+${readFileSync28(logPath, "utf8")}`;
+  } catch {
+  }
+  return evidence;
+}
+var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
+  "passed",
+  "failed",
+  "skipped",
+  "running",
+  "pending"
+]);
+function observationStatus(value) {
+  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
+}
+var FINGERPRINT_INCONCLUSIVE = "unreadable";
+function contentHash(path) {
+  try {
+    return createHash14("sha256").update(readFileSync28(path)).digest("hex");
+  } catch (error2) {
+    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
+  }
+}
+function runnerReportFingerprint(reportDir) {
+  const fingerprint = {};
+  if (!reportDir)
+    return fingerprint;
+  const reportHash = contentHash(join41(reportDir, "report.json"));
+  if (reportHash)
+    fingerprint["report.json"] = reportHash;
+  let flowEntries = [];
+  try {
+    flowEntries = readdirSync11(join41(reportDir, "flows"));
+  } catch (error2) {
+    if (error2?.code !== "ENOENT") {
+      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
+    }
+    return fingerprint;
+  }
+  for (const entry of flowEntries.sort()) {
+    const flowHash = contentHash(join41(reportDir, "flows", entry));
+    if (flowHash)
+      fingerprint[`flows/${entry}`] = flowHash;
+  }
+  return fingerprint;
+}
+function readStructuredFlowArtifact(reportDir, previous, readText = (path) => readFileSync28(path, "utf8")) {
+  if (!reportDir)
+    return null;
+  const reportPath = join41(reportDir, "report.json");
+  if (!existsSync28(reportPath))
+    return null;
+  const unfinalized = {
+    finalized: false,
+    flowStatus: "unknown",
+    commands: []
+  };
+  try {
+    const reportText = readText(reportPath);
+    if (previous) {
+      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
+        return unfinalized;
+      const reportHash = createHash14("sha256").update(reportText).digest("hex");
+      if (previous["report.json"] === reportHash)
+        return null;
+    }
+    const report = JSON.parse(reportText);
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    if (flows.length !== 1)
+      return unfinalized;
+    const flow = flows[0];
+    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
+    if (flowStatus === "unknown")
+      return unfinalized;
+    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
+      return unfinalized;
+    const normalizedDataFile = flow.dataFile;
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+      return unfinalized;
+    }
+    const realDataFile = realpathSync14(join41(reportDir, normalizedDataFile));
+    if (!realDataFile.startsWith(realpathSync14(reportDir) + sep9))
+      return unfinalized;
+    const dataText = readText(realDataFile);
+    if (previous) {
+      const dataHash = createHash14("sha256").update(dataText).digest("hex");
+      if (previous[normalizedDataFile] === dataHash)
+        return unfinalized;
+    }
+    const data = JSON.parse(dataText);
+    if (!Array.isArray(data.commands))
+      return unfinalized;
+    let malformedRow = false;
+    const seenIndices = /* @__PURE__ */ new Set();
+    const commands = data.commands.map((entry) => {
+      const record3 = entry ?? {};
+      const error2 = record3.error ?? void 0;
+      const status = observationStatus(record3.status);
+      const producerIndex = typeof record3.index === "number" && Number.isInteger(record3.index) && record3.index >= 0 ? record3.index : null;
+      if (producerIndex === null || seenIndices.has(producerIndex)) {
+        malformedRow = true;
+      } else {
+        seenIndices.add(producerIndex);
+      }
+      if (typeof record3.type !== "string" || record3.type.length === 0 || status === "unknown") {
+        malformedRow = true;
+      }
+      return {
+        index: producerIndex ?? -1,
+        type: typeof record3.type === "string" ? record3.type : "unknown",
+        status,
+        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
+      };
+    });
+    if (malformedRow)
+      return { finalized: false, flowStatus, commands: [] };
+    const counts = flow.commands ?? {};
+    const statusCount = (status) => commands.filter((command) => command.status === status).length;
+    const countExact = (key, actual) => counts[key] === actual;
+    const anyFailedRow = commands.some((command) => command.status === "failed");
+    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
+    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
+    return { finalized, flowStatus, commands };
+  } catch {
+    return unfinalized;
+  }
+}
+function disposeRunnerReportDir(reportDir) {
+  if (!reportDir)
+    return;
+  try {
+    rmSync11(reportDir, { recursive: true, force: true });
+  } catch {
+  }
+}
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+var MAX_CAPTURES = 8;
+var MAX_ROWS = 64;
+var MAX_REPORT_BYTES = 256 * 1024;
+var STATUSES = ["passed", "failed", "skipped", "running", "pending", "unknown"];
+var REPORT_STATES = ["missing", "unavailable", "oversized", "unfinalized", "finalized"];
+function createRunnerFailureEvidence() {
+  return {
+    version: 1,
+    incomplete: true,
+    withheld: "text-images-terminal-output-and-original-artifacts",
+    capturesTruncated: false,
+    captures: []
+  };
+}
+function append(evidence, capture) {
+  evidence.captures.push(capture);
+  if (evidence.captures.length > MAX_CAPTURES) {
+    evidence.captures.splice(1, 1);
+    evidence.capturesTruncated = true;
+  }
+}
+function captureRunnerFailure(evidence, reportDir, previous, stage, invocation, termination, attempt = 1) {
+  const capture = {
+    attempt,
+    stage,
+    invocation,
+    exitCode: Number.isSafeInteger(termination.exitCode) ? termination.exitCode : null,
+    signalPresent: termination.signal !== null,
+    timedOut: termination.timedOut,
+    outputTruncated: termination.outputTruncated,
+    bootstrapFailure: termination.bootstrapFailure,
+    transportFailure: termination.transportFailure,
+    report: "missing",
+    rowsTruncated: false,
+    commands: []
+  };
+  try {
+    if (reportDir) {
+      if (!lstatSync17(reportDir).isDirectory())
+        throw new Error();
+      const root = realpathSync15(reportDir);
+      const reportPath = join42(root, "report.json");
+      lstatSync17(reportPath);
+      let readFailure;
+      let remaining = MAX_REPORT_BYTES;
+      const artifact = readStructuredFlowArtifact(root, previous, (path) => {
+        let fd;
+        try {
+          if (!realpathSync15(path).startsWith(root + sep10))
+            throw new Error();
+          fd = openSync11(path, constants10.O_RDONLY | constants10.O_NOFOLLOW);
+          const stat2 = fstatSync9(fd);
+          if (!stat2.isFile())
+            throw new Error();
+          if (stat2.size > remaining) {
+            readFailure = "oversized";
+            throw new Error();
+          }
+          const bytes = Buffer.alloc(stat2.size + 1);
+          const size = readSync5(fd, bytes, 0, bytes.length, 0);
+          if (size !== stat2.size || fstatSync9(fd).size !== size)
+            throw new Error();
+          remaining -= size;
+          return bytes.subarray(0, size).toString("utf8");
+        } catch (error2) {
+          readFailure ??= "unavailable";
+          throw error2;
+        } finally {
+          if (fd !== void 0)
+            closeSync11(fd);
+        }
+      });
+      capture.report = readFailure ?? (artifact ? artifact.finalized ? "finalized" : "unfinalized" : "missing");
+      if (artifact?.finalized && !readFailure) {
+        capture.rowsTruncated = artifact.commands.length > MAX_ROWS;
+        const rows = [...artifact.commands].sort((a, b) => Number(b.status === "failed") - Number(a.status === "failed"));
+        capture.commands = rows.slice(0, MAX_ROWS).map((row) => ({
+          index: row.index,
+          status: row.status,
+          errorPresent: row.error !== void 0
+        }));
+      }
+    }
+  } catch (error2) {
+    capture.report = error2.code === "ENOENT" ? "missing" : "unavailable";
+  }
+  append(evidence, capture);
+}
+function record2(value) {
+  return value !== null && typeof value === "object" ? value : {};
+}
+function collectRunnerFailureEvidence(evidence, value) {
+  const input = record2(value);
+  if (input.version !== 1 || !Array.isArray(input.captures))
+    return;
+  evidence.capturesTruncated ||= input.capturesTruncated === true || input.captures.length > MAX_CAPTURES;
+  const captures = input.captures.length > MAX_CAPTURES ? [input.captures[0], ...input.captures.slice(-(MAX_CAPTURES - 1))] : input.captures;
+  for (const item of captures) {
+    const row = record2(item);
+    if (!Number.isSafeInteger(row.stage) || !Number.isSafeInteger(row.invocation))
+      continue;
+    const state = REPORT_STATES.find((state2) => state2 === row.report) ?? "unavailable";
+    const commands = Array.isArray(row.commands) ? row.commands : [];
+    append(evidence, {
+      attempt: Number.isSafeInteger(row.attempt) ? Number(row.attempt) : 1,
+      stage: Number(row.stage),
+      invocation: Number(row.invocation),
+      exitCode: Number.isSafeInteger(row.exitCode) ? Number(row.exitCode) : null,
+      signalPresent: row.signalPresent === true,
+      timedOut: row.timedOut === true,
+      outputTruncated: row.outputTruncated === true,
+      bootstrapFailure: row.bootstrapFailure === true,
+      transportFailure: row.transportFailure === true,
+      report: state,
+      rowsTruncated: row.rowsTruncated === true || commands.length > MAX_ROWS,
+      commands: commands.slice(0, MAX_ROWS).flatMap((item2) => {
+        const command = record2(item2);
+        if (!Number.isSafeInteger(command.index))
+          return [];
+        return [
+          {
+            index: Number(command.index),
+            status: STATUSES.find((status) => status === command.status) ?? "unknown",
+            errorPresent: command.errorPresent === true
+          }
+        ];
+      })
+    });
+  }
+}
+
+// packages/rn-dev-agent-core/dist/tools/run-action.js
 init_utils();
 import { randomUUID as randomUUID9 } from "node:crypto";
 
@@ -78924,7 +79277,7 @@ import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
 import { existsSync as existsSync29, readFileSync as readFileSync29, writeFileSync as writeFileSync13 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
-import { basename as basename10, join as join42, dirname as dirname21 } from "node:path";
+import { basename as basename10, join as join43, dirname as dirname21 } from "node:path";
 init_agent_device_wrapper();
 init_project_config();
 
@@ -79250,220 +79603,6 @@ function maestroAuthorityRefusal(authority, underlyingError) {
     return null;
   const headline = `Maestro device authority refused: requested ${authority.requestedDeviceId}, direct runner/WDA evidence was ${authority.reportedDeviceId ?? "missing"} (${authority.reason}).`;
   return underlyingError ? `${headline} Underlying failure: ${underlyingError}` : headline;
-}
-
-// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
-import { existsSync as existsSync28, readFileSync as readFileSync28, readdirSync as readdirSync11, realpathSync as realpathSync14, rmSync as rmSync11 } from "node:fs";
-import { createHash as createHash14 } from "node:crypto";
-import { tmpdir as tmpdir8 } from "node:os";
-import { isAbsolute as isAbsolute14, join as join41, sep as sep9 } from "node:path";
-var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
-var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
-var WEAK_DEVICE_ID_KEYS = ["id"];
-var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
-function idsFrom(value, keys) {
-  if (!value || typeof value !== "object")
-    return [];
-  const record2 = value;
-  for (const key of keys) {
-    const id = record2[key];
-    if (typeof id === "string")
-      return [id];
-  }
-  return [];
-}
-function deviceIdsFrom(value) {
-  return idsFrom(value, DEVICE_ID_KEYS);
-}
-function weakDeviceIdsFrom(value) {
-  if (typeof value === "string")
-    return [value];
-  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
-}
-function containerDeviceIdsFrom(value) {
-  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
-}
-function reportDeviceIds(reportDir) {
-  const reportPath = join41(reportDir, "report.json");
-  if (!existsSync28(reportPath))
-    return { ids: [], strength: "none" };
-  try {
-    const report = JSON.parse(readFileSync28(reportPath, "utf8"));
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    const devices = [report.device, ...flows.map((flow) => flow?.device)];
-    const strong = [
-      ...devices.flatMap((device) => deviceIdsFrom(device)),
-      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
-    ];
-    const usingStrong = strong.length > 0;
-    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
-    const accepted = [
-      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
-    ];
-    return {
-      ids: accepted,
-      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
-    };
-  } catch {
-    return { ids: [], strength: "none" };
-  }
-}
-function createRunnerReportDir(runner, prefix) {
-  if (runner !== "maestro-runner")
-    return null;
-  return join41(tmpdir8(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-}
-function runnerReportArgs(reportDir) {
-  return reportDir ? ["--output", reportDir, "--flatten"] : [];
-}
-function collectDirectRunnerEvidence(reportDir, output) {
-  if (!reportDir)
-    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
-  const report = reportDeviceIds(reportDir);
-  const evidence = {
-    output,
-    reportDeviceIds: report.ids,
-    reportDeviceIdStrength: report.strength
-  };
-  const logPath = join41(reportDir, "maestro-runner.log");
-  if (!existsSync28(logPath))
-    return evidence;
-  try {
-    evidence.output = `${output}
-${readFileSync28(logPath, "utf8")}`;
-  } catch {
-  }
-  return evidence;
-}
-var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
-  "passed",
-  "failed",
-  "skipped",
-  "running",
-  "pending"
-]);
-function observationStatus(value) {
-  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
-}
-var FINGERPRINT_INCONCLUSIVE = "unreadable";
-function contentHash(path) {
-  try {
-    return createHash14("sha256").update(readFileSync28(path)).digest("hex");
-  } catch (error2) {
-    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
-  }
-}
-function runnerReportFingerprint(reportDir) {
-  const fingerprint = {};
-  if (!reportDir)
-    return fingerprint;
-  const reportHash = contentHash(join41(reportDir, "report.json"));
-  if (reportHash)
-    fingerprint["report.json"] = reportHash;
-  let flowEntries = [];
-  try {
-    flowEntries = readdirSync11(join41(reportDir, "flows"));
-  } catch (error2) {
-    if (error2?.code !== "ENOENT") {
-      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
-    }
-    return fingerprint;
-  }
-  for (const entry of flowEntries.sort()) {
-    const flowHash = contentHash(join41(reportDir, "flows", entry));
-    if (flowHash)
-      fingerprint[`flows/${entry}`] = flowHash;
-  }
-  return fingerprint;
-}
-function readStructuredFlowArtifact(reportDir, previous) {
-  if (!reportDir)
-    return null;
-  const reportPath = join41(reportDir, "report.json");
-  if (!existsSync28(reportPath))
-    return null;
-  const unfinalized = {
-    finalized: false,
-    flowStatus: "unknown",
-    commands: []
-  };
-  try {
-    const reportText = readFileSync28(reportPath, "utf8");
-    if (previous) {
-      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
-        return unfinalized;
-      const reportHash = createHash14("sha256").update(reportText).digest("hex");
-      if (previous["report.json"] === reportHash)
-        return null;
-    }
-    const report = JSON.parse(reportText);
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    if (flows.length !== 1)
-      return unfinalized;
-    const flow = flows[0];
-    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
-    if (flowStatus === "unknown")
-      return unfinalized;
-    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
-      return unfinalized;
-    const normalizedDataFile = flow.dataFile;
-    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
-      return unfinalized;
-    }
-    const realDataFile = realpathSync14(join41(reportDir, normalizedDataFile));
-    if (!realDataFile.startsWith(realpathSync14(reportDir) + sep9))
-      return unfinalized;
-    const dataText = readFileSync28(realDataFile, "utf8");
-    if (previous) {
-      const dataHash = createHash14("sha256").update(dataText).digest("hex");
-      if (previous[normalizedDataFile] === dataHash)
-        return unfinalized;
-    }
-    const data = JSON.parse(dataText);
-    if (!Array.isArray(data.commands))
-      return unfinalized;
-    let malformedRow = false;
-    const seenIndices = /* @__PURE__ */ new Set();
-    const commands = data.commands.map((entry) => {
-      const record2 = entry ?? {};
-      const error2 = record2.error ?? void 0;
-      const status = observationStatus(record2.status);
-      const producerIndex = typeof record2.index === "number" && Number.isInteger(record2.index) && record2.index >= 0 ? record2.index : null;
-      if (producerIndex === null || seenIndices.has(producerIndex)) {
-        malformedRow = true;
-      } else {
-        seenIndices.add(producerIndex);
-      }
-      if (typeof record2.type !== "string" || record2.type.length === 0 || status === "unknown") {
-        malformedRow = true;
-      }
-      return {
-        index: producerIndex ?? -1,
-        type: typeof record2.type === "string" ? record2.type : "unknown",
-        status,
-        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
-      };
-    });
-    if (malformedRow)
-      return { finalized: false, flowStatus, commands: [] };
-    const counts = flow.commands ?? {};
-    const statusCount = (status) => commands.filter((command) => command.status === status).length;
-    const countExact = (key, actual) => counts[key] === actual;
-    const anyFailedRow = commands.some((command) => command.status === "failed");
-    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
-    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
-    return { finalized, flowStatus, commands };
-  } catch {
-    return unfinalized;
-  }
-}
-function disposeRunnerReportDir(reportDir) {
-  if (!reportDir)
-    return;
-  try {
-    rmSync11(reportDir, { recursive: true, force: true });
-  } catch {
-  }
 }
 
 // packages/rn-dev-agent-core/dist/domain/maestro-run-ledger.js
@@ -80927,7 +81066,7 @@ function createMaestroRunHandler(deps = {}) {
   const resolveEngineStatus = deps.resolveEngineStatus ?? (() => getEngineStatus().catch(() => null));
   const replayFactory = deps.replayDeps;
   const nativeOnlyHandler = replayFactory ? createMaestroRunHandler({ ...deps, replayDeps: void 0 }) : null;
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (args.params) {
       for (const [key, value] of Object.entries(args.params)) {
         if (!PARAM_KEY_RE.test(key)) {
@@ -81005,7 +81144,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join42(tmpdir9(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join43(tmpdir9(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -81235,15 +81374,15 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of result.replay.steps) {
               if (!step || typeof step !== "object")
                 continue;
-              const record2 = step;
+              const record3 = step;
               combinedSteps.push({
-                index: sourceIndices[record2.sourceIndex ?? -1] ?? record2.sourceIndex ?? combinedSteps.length,
-                name: String(record2.t ?? "unknown"),
-                verb: String(record2.t ?? "unknown"),
-                ...record2.target !== void 0 ? { target: String(record2.target) } : {},
-                ...record2.focusOnly === true ? { focusOnly: true } : {},
-                status: record2.ok === false ? "fail" : "pass",
-                durationMs: Number(record2.durationMs ?? 0)
+                index: sourceIndices[record3.sourceIndex ?? -1] ?? record3.sourceIndex ?? combinedSteps.length,
+                name: String(record3.t ?? "unknown"),
+                verb: String(record3.t ?? "unknown"),
+                ...record3.target !== void 0 ? { target: String(record3.target) } : {},
+                ...record3.focusOnly === true ? { focusOnly: true } : {},
+                status: record3.ok === false ? "fail" : "pass",
+                durationMs: Number(record3.durationMs ?? 0)
               });
             }
           }
@@ -81408,6 +81547,7 @@ function createMaestroRunHandler(deps = {}) {
     })();
     const stageCaptures = [];
     let ledgerStageCursor = 0;
+    let invocationOrdinal = 0;
     const stageTerminationFromError = (error2) => {
       const errorClass = classifyExecError(error2);
       const raw = error2;
@@ -81475,7 +81615,8 @@ function createMaestroRunHandler(deps = {}) {
                 Object.assign(error2, { code: "ETIMEDOUT" });
                 throw error2;
               }
-              const executeRunner = (runnerPath, prefixArgs = []) => {
+              const executeRunner = async (runnerPath, prefixArgs = []) => {
+                const fingerprint = runnerReportFingerprint(runnerReportDir);
                 beforeDispatch?.();
                 const remainingTimeout = flowDeadline - now();
                 if (remainingTimeout <= 0) {
@@ -81483,12 +81624,29 @@ function createMaestroRunHandler(deps = {}) {
                   Object.assign(error2, { code: "ETIMEDOUT" });
                   throw error2;
                 }
-                return execute2(runnerPath, [...prefixArgs, ...finalArgs], {
-                  timeout: remainingTimeout,
-                  encoding: "utf8",
-                  maxBuffer: 10 * 1024 * 1024,
-                  signal: flowAbort.signal
-                });
+                const invocation = ++invocationOrdinal;
+                try {
+                  const result = await execute2(runnerPath, [...prefixArgs, ...finalArgs], {
+                    timeout: remainingTimeout,
+                    encoding: "utf8",
+                    maxBuffer: 10 * 1024 * 1024,
+                    signal: flowAbort.signal
+                  });
+                  if (outputIndicatesFlowFailure(combineRunnerOutput(result.stdout, result.stderr))) {
+                    captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, {
+                      exitCode: 0,
+                      signal: null,
+                      timedOut: false,
+                      outputTruncated: false,
+                      bootstrapFailure: false,
+                      transportFailure: false
+                    }, ledgerAttempt.ordinal);
+                  }
+                  return result;
+                } catch (error2) {
+                  captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, stageTerminationFromError(error2), ledgerAttempt.ordinal);
+                  throw error2;
+                }
               };
               if (deps.execFile) {
                 const immediateStatus = await resolveEngineStatus();
@@ -81886,6 +82044,18 @@ function createMaestroRunHandler(deps = {}) {
       }
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 
 // packages/rn-dev-agent-core/dist/nav-graph/route-sequence.js
@@ -82275,7 +82445,7 @@ function createRunActionHandler(deps = {}) {
   const installReceipt = deps.installReceipt ?? boundInstallReceipt;
   const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   const resolveEngineStatus = deps.engineStatus ?? (() => getEngineStatus().catch(() => null));
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
     }
@@ -82363,10 +82533,10 @@ function createRunActionHandler(deps = {}) {
     const startedAt = new Date(t0).toISOString();
     const runId = randomUUID9();
     const timingSteps = [];
-    const measureStep = async (name, run) => {
+    const measureStep = async (name, run2) => {
       const stepStartedMs = Date.now();
       try {
-        return await run();
+        return await run2();
       } finally {
         const stepEndedMs = Date.now();
         timingSteps.push({
@@ -82389,14 +82559,15 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => {
+    const persistRunWithDevice = (record3) => {
       assertReadableActionLoadContextStable(loadContext);
       if (proofReplay) {
         return Promise.resolve({ promoted: false, promotionRefused: false });
       }
       const endedMs = Date.now();
       const timedRecord = {
-        ...record2,
+        ...record3,
+        ...evidence.captures.length ? { runnerFailureEvidence: structuredClone(evidence) } : {},
         runId,
         timing: {
           startedAt,
@@ -82436,6 +82607,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, firstEnv.meta?.runnerFailureEvidence);
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
@@ -82768,6 +82940,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, retryEnv.meta?.runnerFailureEvidence);
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
@@ -82905,34 +83078,46 @@ function createRunActionHandler(deps = {}) {
       });
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 function promotionDisclosure(outcome) {
   if (outcome.promoted)
     return "lifecycle-promotion";
   return outcome.promotionRefused ? "lifecycle-promotion-refused" : "none";
 }
-async function persistRun(actionId, projectRoot, record2) {
+async function persistRun(actionId, projectRoot, record3) {
   const MAX_ATTEMPTS = 5;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const fresh = loadAction(projectRoot, actionId);
     if (!fresh) {
-      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record2.status}, autoRepair.outcome=${record2.autoRepair?.outcome ?? "n/a"})`);
+      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record3.status}, autoRepair.outcome=${record3.autoRepair?.outcome ?? "n/a"})`);
       return { promoted: false, promotionRefused: false };
     }
-    const nextState = appendRunRecord(fresh.state, record2);
-    const promotes = shouldAutoPromoteToActive(fresh.metadata, record2);
+    const nextState = appendRunRecord(fresh.state, record3);
+    const promotes = shouldAutoPromoteToActive(fresh.metadata, record3);
     const commit = (runtimeStatePath, promoted, promotionRefused2) => {
       mirrorToDb({
         yamlFilePath: fresh.filePath,
         state: fresh.state,
-        newRunRecord: record2,
+        newRunRecord: record3,
         meta: {
           appId: fresh.metadata.appId,
           status: promoted ? "active" : fresh.metadata.status,
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record2.runId };
+      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record3.runId };
     };
     const promotion = promotes ? promoteActionRuntimeWithCAS(fresh, nextState) : null;
     const promotionRefused = promotion?.ok === false;
@@ -82942,7 +83127,7 @@ async function persistRun(actionId, projectRoot, record2) {
     if (runtimeWrite.ok)
       return commit(runtimeWrite.sidecarPath, false, promotionRefused);
     if (attempt === MAX_ATTEMPTS) {
-      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record2.status}).`);
+      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record3.status}).`);
       return { promoted: false, promotionRefused, runtimeStateRefused: true };
     }
   }
@@ -83089,7 +83274,7 @@ function createLoginPrologueHandler(deps) {
     try {
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record3) => record3.runId === strictRunRecordId) : void 0;
       });
     } catch (error2) {
       return unresolved(`could not verify the exact ${LOGIN_PROLOGUE_ALIAS} learned action: ${error2 instanceof Error ? error2.message : String(error2)}`, replayWrites);
@@ -83575,13 +83760,13 @@ import { promisify as promisify19 } from "node:util";
 import { createHash as createHash16, randomBytes as randomBytes7, randomUUID as randomUUID10 } from "node:crypto";
 import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname22, join as join43 } from "node:path";
+import { dirname as dirname22, join as join44 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 var UNKNOWN_CLASSIFICATION = "UNKNOWN";
 var DEFAULT_MAX_RECORDS = 500;
 var DEFAULT_RETENTION_DAYS = 14;
 var MAX_EVIDENCE_POINTERS = 3;
-var EXPERIENCE_DIRECTORY = join43(homedir9(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_DIRECTORY = join44(homedir9(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var MAX_SYMPTOM_LENGTH = 2048;
 var RUNNER_DIAGNOSTICS_MAX_BYTES = 256 * 1024;
@@ -83670,7 +83855,7 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join43(root, "app.json");
+  const manifest = join44(root, "app.json");
   try {
     if (!existsSync30(manifest))
       return { name: null, slug: null };
@@ -83697,7 +83882,7 @@ var ExperienceRecorder = class {
   previousFailure = null;
   constructor(options) {
     this.directory = options.directory ?? configuredExperienceDirectory();
-    this.path = join43(this.directory, EXPERIENCE_STORE_NAME);
+    this.path = join44(this.directory, EXPERIENCE_STORE_NAME);
     this.candidate = {
       pluginVersion: options.pluginVersion ?? null,
       coreVersion: options.coreVersion
@@ -83743,9 +83928,9 @@ var ExperienceRecorder = class {
       return;
     }
     this.persistRunnerDiagnostics(event);
-    const record2 = this.buildFailureRecord(event);
-    this.persistFailure(record2);
-    this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+    const record3 = this.buildFailureRecord(event);
+    this.persistFailure(record3);
+    this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record3.signature } : null;
   }
   persistRunnerDiagnostics(event) {
     const trace = event.runnerDiagnostics;
@@ -83825,7 +84010,7 @@ var ExperienceRecorder = class {
   }
   persistFailure(incoming) {
     const records = readExperienceStore(this.path);
-    const existing = records.find((record2) => record2.signature === incoming.signature);
+    const existing = records.find((record3) => record3.signature === incoming.signature);
     if (existing) {
       existing.count += 1;
       existing.lastSeen = incoming.lastSeen;
@@ -83846,7 +84031,7 @@ var ExperienceRecorder = class {
   }
   persistRecovery(signature, tool) {
     const records = readExperienceStore(this.path);
-    const existing = records.find((record2) => record2.signature === signature);
+    const existing = records.find((record3) => record3.signature === signature);
     if (!existing)
       return;
     const now = this.now().toISOString();
@@ -83861,13 +84046,13 @@ var ExperienceRecorder = class {
   }
   write(records) {
     mkdirSync19(this.directory, { recursive: true, mode: 448 });
-    const temp = join43(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
+    const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
     try {
-      const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
-        ...sanitizeForEvidence(record2),
+      const sanitized = records.map((record3) => record3.redactionVersion === REDACTION_RULES_VERSION ? record3 : {
+        ...sanitizeForEvidence(record3),
         redactionVersion: REDACTION_RULES_VERSION
       });
-      const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+      const contents = sanitized.map((record3) => JSON.stringify(record3)).join("\n");
       writeFileSync14(temp, contents.length > 0 ? `${contents}
 ` : "", {
         encoding: "utf8",
@@ -83890,10 +84075,10 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
   const start = dirname22(fileURLToPath3(fromUrl));
   const candidates = [
-    join43(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join43(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join43(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join43(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join44(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
@@ -83927,8 +84112,8 @@ function readExperienceStore(path) {
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
-  return records.filter((record2) => {
-    const lastSeen = Date.parse(record2.lastSeen);
+  return records.filter((record3) => {
+    const lastSeen = Date.parse(record3.lastSeen);
     return Number.isFinite(lastSeen) && lastSeen >= cutoff;
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
@@ -84158,7 +84343,7 @@ function stableDeviceHash(directory, deviceId) {
   return createHash16("sha256").update(readOrCreateRunnerDiagnosticsSalt(directory)).update("\0").update(deviceId).digest("hex");
 }
 function readOrCreateRunnerDiagnosticsSalt(directory) {
-  const path = join43(directory, ".runner-diagnostics-salt");
+  const path = join44(directory, ".runner-diagnostics-salt");
   mkdirSync19(directory, { recursive: true, mode: 448 });
   try {
     const existing = readFileSync30(path);
@@ -84183,7 +84368,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   const files = runnerDiagnosticsFiles(directory);
   const nextSequence = files.reduce((maximum, file) => Math.max(maximum, runnerDiagnosticsSequence(file)), 0) + 1;
   const sessionKey = (bundle.context.sessionId ?? "unknown").slice(0, 64).replace(/[^A-Za-z0-9_-]/g, "-");
-  const outputPath = join43(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
+  const outputPath = join44(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
   const bounded = boundRunnerDiagnosticsBundle(bundle);
   let serialized = `${JSON.stringify(bounded, null, 2)}
 `;
@@ -84201,17 +84386,17 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   if (Buffer.byteLength(serialized) > RUNNER_DIAGNOSTICS_MAX_BYTES) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
-  const temporary = join43(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
+  const temporary = join44(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
   writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync14(join43(directory, file)).mtimeMs,
+    mtimeMs: statSync14(join44(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => left.mtimeMs - right.mtimeMs || left.sequence - right.sequence || left.file.localeCompare(right.file));
   for (const stale of retained.slice(0, Math.max(0, retained.length - RUNNER_DIAGNOSTICS_RETENTION))) {
-    unlinkSync13(join43(directory, stale.file));
+    unlinkSync13(join44(directory, stale.file));
   }
   return outputPath;
 }
@@ -84281,11 +84466,11 @@ function latestRunnerDiagnosticsPath(sessionId, directory = configuredExperience
     return null;
   const files = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync14(join43(directory, file)).mtimeMs,
+    mtimeMs: statSync14(join44(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => right.mtimeMs - left.mtimeMs || right.sequence - left.sequence || right.file.localeCompare(left.file));
   for (const file of files) {
-    const path = join43(directory, file.file);
+    const path = join44(directory, file.file);
     try {
       const contents = readFileSync30(path);
       if (contents.byteLength > RUNNER_DIAGNOSTICS_MAX_BYTES)
@@ -85707,7 +85892,7 @@ init_utils();
 init_project_config();
 init_maestro_validator();
 import { writeFileSync as writeFileSync15 } from "node:fs";
-import { join as join44 } from "node:path";
+import { join as join45 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
 init_agent_device_wrapper();
 
@@ -85968,7 +86153,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join44(tmpdir10(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join45(tmpdir10(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -86507,7 +86692,7 @@ import { createHash as createHash17 } from "node:crypto";
 import { existsSync as existsSync31 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
-import { dirname as dirname23, join as join45 } from "node:path";
+import { dirname as dirname23, join as join46 } from "node:path";
 init_process_birth();
 var execFileAsync5 = promisify23(execFile22);
 var START_TIMEOUT_MS = 1e4;
@@ -86596,15 +86781,15 @@ function candidateRecordScripts(baseDir = dirname23(fileURLToPath4(import.meta.u
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join45(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join45(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join45(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join46(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join46(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join46(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join45(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join46(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join45(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join46(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join45(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join46(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
 function resolveRecordScript(baseDir = dirname23(fileURLToPath4(import.meta.url))) {
@@ -86927,8 +87112,8 @@ function createDeviceRecordHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute15, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
+import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync18, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync32, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
+import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute15, join as join47, relative as relative9, resolve as resolve17, sep as sep11 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
@@ -87062,12 +87247,12 @@ function observedAssertionPassed(event) {
   const data = resultEnvelopeData(event.result);
   if (!data || typeof data !== "object")
     return !tool.endsWith("proof_step");
-  const record2 = data;
-  if (tool.endsWith("proof_step") && record2.verified !== true)
+  const record3 = data;
+  if (tool.endsWith("proof_step") && record3.verified !== true)
     return false;
-  if (record2.verified === false || record2.ok === false)
+  if (record3.verified === false || record3.ok === false)
     return false;
-  return !Array.isArray(record2.errors) || record2.errors.length === 0;
+  return !Array.isArray(record3.errors) || record3.errors.length === 0;
 }
 var readOnlyTools = /* @__PURE__ */ new Set([
   "cdp_status",
@@ -87583,14 +87768,14 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let coreBundleSha256 = null;
   try {
     if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
-      executedEntrypointPath = realpathSync15(argv[1]);
+      executedEntrypointPath = realpathSync16(argv[1]);
     }
   } catch {
     executedEntrypointPath = null;
   }
   if (attestation) {
     try {
-      loadedCoreBundlePath = realpathSync15(fileURLToPath5(attestation.entrypointUrl));
+      loadedCoreBundlePath = realpathSync16(fileURLToPath5(attestation.entrypointUrl));
       coreBundleSha256 = attestation.coreBundleSha256;
     } catch {
       loadedCoreBundlePath = null;
@@ -87607,7 +87792,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
 var proofWorkerStartup = captureProofWorkerStartup();
 function realpathOrSelf(path) {
   try {
-    return realpathSync15(path);
+    return realpathSync16(path);
   } catch {
     return path;
   }
@@ -87615,7 +87800,7 @@ function realpathOrSelf(path) {
 function resolveProofCandidateEntrypoint(candidateRoot, argv) {
   let root;
   try {
-    root = realpathSync15(candidateRoot);
+    root = realpathSync16(candidateRoot);
   } catch {
     return null;
   }
@@ -87624,14 +87809,14 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   let arg;
   try {
-    arg = realpathSync15(authorityArg);
+    arg = realpathSync16(authorityArg);
   } catch {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join46(root, "packages", host);
-    const coreIndex = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join47(root, "packages", host);
+    const coreIndex = realpathOrSelf(join47(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join47(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -87650,7 +87835,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join46(hostRoot, "bin", "cdp-supervisor.js"))) {
+    if (host === "codex-plugin" && arg === realpathOrSelf(join47(hostRoot, "bin", "cdp-supervisor.js"))) {
       if (!existsSync32(coreIndex) || !existsSync32(coreSupervisor))
         return null;
       return {
@@ -87672,7 +87857,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
     if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
-      return realpathSync15(value);
+      return realpathSync16(value);
     } catch {
       return null;
     }
@@ -87685,7 +87870,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join46(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join47(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -87694,7 +87879,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
 }
 function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   try {
-    const root = realpathSync15(candidateRoot);
+    const root = realpathSync16(candidateRoot);
     const statusArgs = [
       "-C",
       root,
@@ -87707,8 +87892,8 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       return null;
     const verifiedBytes = [];
     for (const artifactPath of artifactPaths) {
-      const resolvedArtifactPath = realpathSync15(artifactPath);
-      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep10).join("/");
+      const resolvedArtifactPath = realpathSync16(artifactPath);
+      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep11).join("/");
       if (!artifactRelativePath || artifactRelativePath === ".." || artifactRelativePath.startsWith("../")) {
         return null;
       }
@@ -87727,7 +87912,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   }
 }
 function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) {
-  const root = realpathSync15(resolve17(candidateRoot));
+  const root = realpathSync16(resolve17(candidateRoot));
   const sha = execFileSync15("git", ["-C", root, "rev-parse", "HEAD"], {
     encoding: "utf8"
   }).trim();
@@ -87743,7 +87928,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join46(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join47(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -87812,14 +87997,14 @@ function isNormalizedDescendant(root, path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep11}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
-  const parts = relative9(root, path).split(sep10);
+  const parts = relative9(root, path).split(sep11);
   for (let length = 0; length <= parts.length; length += 1) {
     const candidate = resolve17(root, ...parts.slice(0, length));
     try {
-      if (lstatSync17(candidate).isSymbolicLink())
+      if (lstatSync18(candidate).isSymbolicLink())
         return true;
     } catch {
     }
@@ -87838,7 +88023,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join46(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join47(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -87852,9 +88037,9 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join47(args.projectRoot, "docs", "proof", args.runId);
   try {
-    lstatSync17(proofRoot);
+    lstatSync18(proofRoot);
     return true;
   } catch (error2) {
     return error2.code !== "ENOENT";
@@ -87878,15 +88063,15 @@ function parseProofGitChanges(porcelain) {
   const records = porcelain.split("\0");
   const changes = [];
   for (let index = 0; index < records.length; index += 1) {
-    const record2 = records[index];
-    if (!record2 || record2.length < 4)
+    const record3 = records[index];
+    if (!record3 || record3.length < 4)
       continue;
     const change = {
-      path: record2.slice(3).replaceAll("\\", "/"),
-      indexStatus: record2[0],
-      worktreeStatus: record2[1]
+      path: record3.slice(3).replaceAll("\\", "/"),
+      indexStatus: record3[0],
+      worktreeStatus: record3[1]
     };
-    if (/[RC]/.test(record2.slice(0, 2))) {
+    if (/[RC]/.test(record3.slice(0, 2))) {
       const sourcePath = records[index + 1];
       if (sourcePath)
         change.sourcePath = sourcePath.replaceAll("\\", "/");
@@ -87908,7 +88093,7 @@ function readProofGitInfo(root) {
 function proofRootHasTrackedEntries(root, proofRoot) {
   if (!isNormalizedDescendant(root, proofRoot))
     throw new Error("INVALID_PROOF_ROOT");
-  const path = relative9(root, proofRoot).replaceAll(sep10, "/");
+  const path = relative9(root, proofRoot).replaceAll(sep11, "/");
   return execFileSync15("git", ["ls-files", "-z", "--", path], {
     cwd: root,
     encoding: "utf8"
@@ -88005,17 +88190,17 @@ function writeProofReceiptAtomic(path, receipt2) {
   const temporary = resolve17(directory, `.${randomUUID11()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
-    descriptor = openSync11(temporary, "wx", 384);
+    descriptor = openSync12(temporary, "wx", 384);
     writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
-    closeSync11(descriptor);
+    closeSync12(descriptor);
     descriptor = null;
     renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
-      closeSync11(descriptor);
+      closeSync12(descriptor);
     try {
       unlinkSync15(temporary);
     } catch {
@@ -88177,7 +88362,7 @@ function createProofCaptureHandler(deps) {
       return current.reasons;
     return sameProofAction(current.value, active.actionIdentity) ? [] : ["PROOF_ACTION_IDENTITY_CHANGED"];
   };
-  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep10, "/");
+  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep11, "/");
   const observedSetupScreenshots = (active) => {
     const owned = /* @__PURE__ */ new Set();
     for (const observation of deps.monitor.observations()) {
@@ -88337,7 +88522,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join47(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -88807,7 +88992,7 @@ import { createHash as createHash20 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir11 } from "node:os";
-import { dirname as dirname25, join as join47 } from "node:path";
+import { dirname as dirname25, join as join48 } from "node:path";
 var MediaFailure = class extends Error {
   reason;
   constructor(reason) {
@@ -88944,7 +89129,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join47(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join48(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -88969,7 +89154,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join47(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join48(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -89093,7 +89278,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir11();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join47(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join48(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -90280,8 +90465,8 @@ init_agent_device_wrapper();
 init_storage();
 init_project_config();
 init_maestro_validator();
-import { lstatSync as lstatSync18, readFileSync as readFileSync33, readdirSync as readdirSync14, realpathSync as realpathSync16 } from "node:fs";
-import { dirname as dirname26, join as join48, resolve as resolve18 } from "node:path";
+import { lstatSync as lstatSync19, readFileSync as readFileSync33, readdirSync as readdirSync14, realpathSync as realpathSync17 } from "node:fs";
+import { dirname as dirname26, join as join49, resolve as resolve18 } from "node:path";
 var AUTH_ROUTE_PATTERNS = [
   "login",
   "signin",
@@ -90341,13 +90526,13 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join48(projectRoot, ".maestro");
-  const searchDirs = [join48(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join49(projectRoot, ".maestro");
+  const searchDirs = [join49(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
-      const maestroStat = lstatSync18(maestroDir);
-      const dirStat = lstatSync18(dir);
+      const maestroStat = lstatSync19(maestroDir);
+      const dirStat = lstatSync19(dir);
       if (maestroStat.isSymbolicLink() || dirStat.isSymbolicLink()) {
         throw new Error(`Refusing legacy login directory symlink at ${dir}.`);
       }
@@ -90361,17 +90546,17 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join48(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join49(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join48(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join49(dir, authFile));
   }
   return null;
 }
 function assertLegacyLoginFlow(projectRoot, flowPath) {
-  const stat2 = lstatSync18(flowPath);
+  const stat2 = lstatSync19(flowPath);
   if (!stat2.isFile() || stat2.isSymbolicLink()) {
     throw new Error(`Refusing legacy login flow symlink at ${flowPath}.`);
   }
@@ -90397,7 +90582,7 @@ function boundSessionProjectRoot() {
 }
 function canonicalRoot(path) {
   try {
-    return realpathSync16(path);
+    return realpathSync17(path);
   } catch {
     return null;
   }
@@ -90482,7 +90667,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   try {
     const parsed = parseAndValidateFlow(originalContent, {
       flowDir: dirname26(flowPath),
-      flowRoot: join48(projectRoot, ".maestro")
+      flowRoot: join49(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -90997,9 +91182,9 @@ function buildGracefulShutdown(deps) {
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
 import { createHash as createHash21 } from "node:crypto";
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { closeSync as closeSync12, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17, writeSync as writeSync3 } from "node:fs";
+import { closeSync as closeSync13, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync13, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
-import { join as join49, resolve as resolve19 } from "node:path";
+import { join as join50, resolve as resolve19 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var DEFAULT_PROCESS_NAME_NEEDLE = "cdp-bridge";
 var PROCESS_IDENTITY_MARKERS = ["cdp-bridge", "rn-dev-agent", "supervisor.js"];
@@ -91075,7 +91260,7 @@ var Lockfile = class {
       processIdentity: opts.processIdentity ?? defaultProcessIdentity(),
       staleMs: opts.staleMs ?? DEFAULT_STALE_MS
     };
-    this.lockPath = join49(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
+    this.lockPath = join50(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
   }
   // GH#251: acquire via atomic exclusive-create (same pattern as DeviceLock).
   // The previous read-then-writeFileSync let two bridges starting in the same
@@ -91242,11 +91427,11 @@ var Lockfile = class {
     if (!existsSync33(dir)) {
       mkdirSync21(dir, { recursive: true });
     }
-    const fd = openSync12(this.lockPath, "wx");
+    const fd = openSync13(this.lockPath, "wx");
     try {
       writeSync3(fd, JSON.stringify(body, null, 2));
     } finally {
-      closeSync12(fd);
+      closeSync13(fd);
     }
   }
 };
@@ -91314,7 +91499,7 @@ init_agent_device_wrapper();
 init_utils();
 init_storage();
 init_maestro_validator();
-import { basename as basename12, dirname as dirname27, join as join50 } from "node:path";
+import { basename as basename12, dirname as dirname27, join as join51 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -91373,7 +91558,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join50(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join51(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -91446,7 +91631,7 @@ init_storage();
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
-import { basename as basename13, dirname as dirname28, join as join51, resolve as resolve20 } from "node:path";
+import { basename as basename13, dirname as dirname28, join as join52, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 init_maestro_validator();
 init_registry();
@@ -91475,7 +91660,7 @@ function filterFlows(yamls, pattern) {
 function discoverFlows(dir, pattern) {
   if (!existsSync34(dir))
     return [];
-  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join51(dir, f)).sort();
+  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join52(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -91500,12 +91685,12 @@ function createMaestroTestAllHandler(deps = {}) {
     const requestedDeviceId = args.deviceId ?? matchingSessionDeviceId;
     const engineStatus = await resolveEngineStatus();
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join51(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join52(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve20(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join51(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join52(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
@@ -91538,7 +91723,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if ("error" in dispatch) {
       return failResult(dispatch.error);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join51(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join52(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -91697,7 +91882,7 @@ function createMaestroTestAllHandler(deps = {}) {
           break;
         continue;
       }
-      const safeFlowFile = join51(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      const safeFlowFile = join52(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
@@ -91868,8 +92053,8 @@ function createMaestroTestAllHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/cross-platform-verify.js
 init_agent_device_wrapper();
 init_utils();
-import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync19 } from "node:fs";
-import { join as join52, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync20 } from "node:fs";
+import { join as join53, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -91894,9 +92079,9 @@ function discoverTestIDs(dir) {
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join52(d, entry);
+      const full = join53(d, entry);
       try {
-        const st = lstatSync19(full);
+        const st = lstatSync20(full);
         if (st.isSymbolicLink())
           continue;
         if (st.isDirectory()) {
@@ -92242,7 +92427,7 @@ function instrumentTool(toolName, handler) {
 }
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join53 } from "node:path";
+import { join as join54 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -92430,7 +92615,7 @@ function buildLiveDeps(input) {
     readShotFile: input.readShotFile,
     // Preserve Recorder.pushLive's `this` binding.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join53(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join54(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive,
     reportBlocked: input.reportBlocked
   };
@@ -92448,7 +92633,7 @@ import { createServer as createServer3 } from "node:http";
 import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync37 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname29, join as join54 } from "node:path";
+import { dirname as dirname29, join as join55 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
 import { randomBytes as randomBytes8, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
@@ -92778,7 +92963,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync37(join54(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync37(join55(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -92981,10 +93166,10 @@ init_project_config();
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
 init_secure_state_file();
 init_storage();
-import { join as join55 } from "node:path";
+import { join as join56 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join55(getStateDir(), "observe", `${safe}.json`);
+  return join56(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -93666,17 +93851,17 @@ function buildMirrorTargetResolver(deps) {
 init_sources();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname30, join as join56 } from "node:path";
+import { dirname as dirname30, join as join57 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash22 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
-  return join56(projectRoot, ".rn-agent", "e2e");
+  return join57(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join56(dir, `${id}.yaml`);
+  const file = join57(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -93785,9 +93970,9 @@ function parseLockedTest(text, filePath) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
-import { join as join57 } from "node:path";
+import { join as join58 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join57(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join58(projectRoot, ".rn-agent", "e2e.config.json");
   try {
     const raw = readFileSync39(filePath, "utf8");
     return JSON.parse(raw);
@@ -93921,7 +94106,7 @@ function createLockE2eTestHandler(deps = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
-import { join as join58 } from "node:path";
+import { join as join59 } from "node:path";
 import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
@@ -93977,16 +94162,16 @@ function diffNewlyFailing(current, previousGreen) {
 }
 var INDEX_MAX = 100;
 function e2eRunsDirFor(projectRoot) {
-  return join58(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join59(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync23(join58(file, ".."), { recursive: true });
+  mkdirSync23(join59(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join58(e2eRunsDirFor(projectRoot), "index.json");
+  const file = join59(e2eRunsDirFor(projectRoot), "index.json");
   if (!existsSync36(file))
     return [];
   try {
@@ -93999,7 +94184,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join58(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join59(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -94007,11 +94192,11 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join58(dir, "index.json"), next);
+  writeJsonAtomic(join59(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join58(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  const file = join59(e2eRunsDirFor(projectRoot), `${runId}.json`);
   if (!existsSync36(file))
     return null;
   try {
@@ -94030,7 +94215,7 @@ init_storage();
 init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join59 } from "node:path";
+import { join as join60 } from "node:path";
 import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
@@ -94039,11 +94224,11 @@ var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "interrupted"
 ]);
 function requestsDir(projectRoot) {
-  return join59(e2eRunsDirFor(projectRoot), "requests");
+  return join60(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join59(requestsDir(projectRoot), `${runId}.json`);
+  return join60(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
@@ -94208,7 +94393,7 @@ async function runE2eSuiteCore(args, deps = {}) {
   const verdict = computeVerdict(results);
   const prevGreenId = lastGreenRunId(projectRoot);
   const prevGreen = prevGreenId ? loadRunRecord(projectRoot, prevGreenId) : null;
-  const record2 = {
+  const record3 = {
     runId,
     startedAt,
     finishedAt: now().toISOString(),
@@ -94228,13 +94413,13 @@ async function runE2eSuiteCore(args, deps = {}) {
     results,
     previousGreenRunId: prevGreenId
   };
-  writeRunRecord(projectRoot, record2);
+  writeRunRecord(projectRoot, record3);
   return okResult({
     runId,
     verdict,
-    totals: record2.totals,
+    totals: record3.totals,
     results,
-    newlyFailing: diffNewlyFailing(record2, prevGreen),
+    newlyFailing: diffNewlyFailing(record3, prevGreen),
     metroReloaded
   });
 }
@@ -95275,7 +95460,7 @@ async function withRecoveredAuthoritativeRuntime(status, connectedClient, operat
 }
 
 // packages/rn-dev-agent-core/dist/index.js
-var pkgPath = join60(dirname31(fileURLToPath7(import.meta.url)), "..", "package.json");
+var pkgPath = join61(dirname31(fileURLToPath7(import.meta.url)), "..", "package.json");
 var pkgVersion = JSON.parse(readFileSync42(pkgPath, "utf8")).version;
 var lockfile = null;
 var diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
@@ -96030,7 +96215,7 @@ var getSessionSignerCapability = (sessionId) => {
     return null;
   if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
     return null;
-  const secretPath = sessionId ? join60(dirname31(dirname31(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+  const secretPath = sessionId ? join61(dirname31(dirname31(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
   return readJsonStateFile(secretPath)?.signerCapability ?? null;
 };
 var spawningSupervisorPid = process.ppid;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -4517,10 +4517,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep: sep8, value } = collItem;
+        const { start, key, sep: sep9, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep8?.[0],
+          next: key ?? sep9?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -4534,7 +4534,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep8) {
+          if (!keyProps.anchor && !keyProps.tag && !sep9) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -4558,7 +4558,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep8 ?? [], {
+        const valueProps = resolveProps.resolveProps(sep9 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -4574,7 +4574,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep8, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep9, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -4665,7 +4665,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep8 = "";
+        let sep9 = "";
         for (const token2 of end) {
           const { source, type } = token2;
           switch (type) {
@@ -4679,13 +4679,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep8 + cb;
-              sep8 = "";
+                comment += sep9 + cb;
+              sep9 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep8 += source;
+                sep9 += source;
               hasSpace = true;
               break;
             default:
@@ -4728,18 +4728,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep: sep8, value } = collItem;
+        const { start, key, sep: sep9, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep8?.[0],
+          next: key ?? sep9?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep8 && !value) {
+          if (!props.anchor && !props.tag && !sep9 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -4793,8 +4793,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep8 && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep8, null, props, onError);
+        if (!isMap && !sep9 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep9, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -4806,7 +4806,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep8 ?? [], {
+          const valueProps = resolveProps.resolveProps(sep9 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -4817,8 +4817,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep8)
-                for (const st of sep8) {
+              if (sep9)
+                for (const st of sep9) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -4835,7 +4835,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep8, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep9, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -5015,7 +5015,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep8 = "";
+      let sep9 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -5032,24 +5032,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep8 + indent.slice(trimIndent) + content;
-          sep8 = "\n";
+          value += sep9 + indent.slice(trimIndent) + content;
+          sep9 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep8 === " ")
-            sep8 = "\n";
-          else if (!prevMoreIndented && sep8 === "\n")
-            sep8 = "\n\n";
-          value += sep8 + indent.slice(trimIndent) + content;
-          sep8 = "\n";
+          if (sep9 === " ")
+            sep9 = "\n";
+          else if (!prevMoreIndented && sep9 === "\n")
+            sep9 = "\n\n";
+          value += sep9 + indent.slice(trimIndent) + content;
+          sep9 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep8 === "\n")
+          if (sep9 === "\n")
             value += "\n";
           else
-            sep8 = "\n";
+            sep9 = "\n";
         } else {
-          value += sep8 + content;
-          sep8 = " ";
+          value += sep9 + content;
+          sep9 = " ";
           prevMoreIndented = false;
         }
       }
@@ -5231,25 +5231,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep8 = " ";
+      let sep9 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep8 === "\n")
-            res += sep8;
+          if (sep9 === "\n")
+            res += sep9;
           else
-            sep8 = "\n";
+            sep9 = "\n";
         } else {
-          res += sep8 + match[1];
-          sep8 = " ";
+          res += sep9 + match[1];
+          sep9 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep8 + (match?.[1] ?? "");
+      return res + sep9 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -6059,14 +6059,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep: sep8, value }) {
+    function stringifyItem({ start, key, sep: sep9, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep8)
-        for (const st of sep8)
+      if (sep9)
+        for (const st of sep9)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -7233,18 +7233,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep8;
+          let sep9;
           if (scalar.end) {
-            sep8 = scalar.end;
-            sep8.push(this.sourceToken);
+            sep9 = scalar.end;
+            sep9.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep8 = [this.sourceToken];
+            sep9 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep: sep8 }]
+            items: [{ start, key: scalar, sep: sep9 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -7397,15 +7397,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep8 = it.sep;
-                  sep8.push(this.sourceToken);
+                  const sep9 = it.sep;
+                  sep9.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep: sep8 }]
+                    items: [{ start: start2, key, sep: sep9 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -7599,13 +7599,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep8 = fc.end.splice(1, fc.end.length);
-            sep8.push(this.sourceToken);
+            const sep9 = fc.end.splice(1, fc.end.length);
+            sep9.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep: sep8 }]
+              items: [{ start, key: fc, sep: sep9 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -8354,28 +8354,28 @@ var init_keyboard_guard = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/util/secure-state-file.js
-import { readFileSync as readFileSync10, writeFileSync as writeFileSync4, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
-import { join as join12, dirname as dirname12 } from "node:path";
+import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync10 } from "node:fs";
+import { join as join14, dirname as dirname12 } from "node:path";
 import { homedir as homedir3 } from "node:os";
 function getStateDir() {
   if (process.env.XDG_STATE_HOME) {
-    return join12(process.env.XDG_STATE_HOME, "rn-dev-agent");
+    return join14(process.env.XDG_STATE_HOME, "rn-dev-agent");
   }
   if (process.platform === "darwin") {
-    return join12(homedir3(), "Library", "Application Support", "rn-dev-agent");
+    return join14(homedir3(), "Library", "Application Support", "rn-dev-agent");
   }
-  return join12(homedir3(), ".rn-dev-agent");
+  return join14(homedir3(), ".rn-dev-agent");
 }
 function runnerStatePath(key) {
   const safe = key.replace(/[^A-Za-z0-9._:-]/g, "_");
-  return join12(getStateDir(), "runner-state", `${safe}.json`);
+  return join14(getStateDir(), "runner-state", `${safe}.json`);
 }
 function readJsonStateFile(path) {
   try {
-    const stat = lstatSync9(path);
+    const stat = lstatSync10(path);
     if (stat.isSymbolicLink())
       return null;
-    return JSON.parse(readFileSync10(path, "utf8"));
+    return JSON.parse(readFileSync11(path, "utf8"));
   } catch {
     return null;
   }
@@ -8411,8 +8411,8 @@ var init_secure_state_file = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/runtime-paths.js
-import { existsSync as existsSync11, statSync as statSync5 } from "node:fs";
-import { join as join13 } from "node:path";
+import { existsSync as existsSync12, statSync as statSync5 } from "node:fs";
+import { join as join15 } from "node:path";
 function compactUnique(paths) {
   const out = [];
   for (const path of paths) {
@@ -8435,21 +8435,21 @@ function candidateNativeRunnerDirs(runnerName, baseDir = import.meta.dirname) {
   const codexPluginRoot = process.env.RN_DEV_AGENT_CODEX_PLUGIN_ROOT;
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique([
-    runnerRoot ? join13(runnerRoot, runnerName) : void 0,
-    repoRoot ? join13(repoRoot, "packages", runnerName) : void 0,
-    repoRoot ? join13(repoRoot, "scripts", runnerName) : void 0,
-    codexPluginRoot ? join13(codexPluginRoot, "scripts", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "..", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "..", "..", "packages", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "..", "..", "scripts", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "scripts", runnerName) : void 0,
+    runnerRoot ? join15(runnerRoot, runnerName) : void 0,
+    repoRoot ? join15(repoRoot, "packages", runnerName) : void 0,
+    repoRoot ? join15(repoRoot, "scripts", runnerName) : void 0,
+    codexPluginRoot ? join15(codexPluginRoot, "scripts", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "..", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "..", "..", "packages", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "..", "..", "scripts", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "scripts", runnerName) : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join13(baseDir, "..", "..", "scripts", runnerName),
+    join15(baseDir, "..", "..", "scripts", runnerName),
     // Source checkout: packages/rn-dev-agent-core/dist/runners.
     // Also covers the legacy scripts/cdp-bridge/dist/runners layout.
-    join13(baseDir, "..", "..", "..", runnerName),
+    join15(baseDir, "..", "..", "..", runnerName),
     // Legacy source checkout: packages/rn-dev-agent-core/dist/runners before runner package split.
-    join13(baseDir, "..", "..", "..", "..", "scripts", runnerName)
+    join15(baseDir, "..", "..", "..", "..", "scripts", runnerName)
   ]);
 }
 function resolveNativeRunnerDir(runnerName, baseDir = import.meta.dirname) {
@@ -8493,7 +8493,7 @@ var init_transport_recovery = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
-import { join as join14 } from "node:path";
+import { join as join16 } from "node:path";
 function resolveReadyTimeoutMs() {
   const raw = Number(process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : 3e4;
@@ -8783,9 +8783,9 @@ var init_rn_fast_runner_client = __esm({
     runnerState = null;
     lastKnownCapabilities = [];
     quiescenceAnnouncementPending = false;
-    REBUILD_LOCK_DIR = join14(FAST_RUNNER_PROJECT, "build", ".rebuild-lock");
+    REBUILD_LOCK_DIR = join16(FAST_RUNNER_PROJECT, "build", ".rebuild-lock");
     REBUILD_LOCK_STALE_MS = 15 * 6e4;
-    REBUILD_BUDGET_FILE = join14(FAST_RUNNER_PROJECT, "build", "commands-rebuild.json");
+    REBUILD_BUDGET_FILE = join16(FAST_RUNNER_PROJECT, "build", "commands-rebuild.json");
     fetchImpl = globalThis.fetch;
   }
 });
@@ -8820,14 +8820,14 @@ var init_declared_source_contract = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/nav-graph/storage.js
-import { readFileSync as readFileSync11, writeFileSync as writeFileSync5, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
-import { join as join15, dirname as dirname13 } from "node:path";
+import { readFileSync as readFileSync12, writeFileSync as writeFileSync5, existsSync as existsSync13, renameSync as renameSync5, readdirSync as readdirSync6, lstatSync as lstatSync11, mkdirSync as mkdirSync9, realpathSync as realpathSync8 } from "node:fs";
+import { join as join17, dirname as dirname13 } from "node:path";
 function isRnProject(dir) {
-  const pkgPath = join15(dir, "package.json");
-  if (!existsSync12(pkgPath))
+  const pkgPath = join17(dir, "package.json");
+  if (!existsSync13(pkgPath))
     return false;
   try {
-    const pkg = JSON.parse(readFileSync11(pkgPath, "utf-8"));
+    const pkg = JSON.parse(readFileSync12(pkgPath, "utf-8"));
     const deps = { ...pkg.dependencies, ...pkg.devDependencies };
     return !!(deps["react-native"] || deps["expo"]);
   } catch {
@@ -8839,7 +8839,7 @@ function scanForRnProject(rootDir, maxDepth) {
     return null;
   let entries;
   try {
-    entries = readdirSync5(rootDir);
+    entries = readdirSync6(rootDir);
   } catch {
     return null;
   }
@@ -8848,9 +8848,9 @@ function scanForRnProject(rootDir, maxDepth) {
   for (const name of entries) {
     if (name.startsWith(".") || name === "node_modules")
       continue;
-    const full = join15(rootDir, name);
+    const full = join17(rootDir, name);
     try {
-      const stat = lstatSync10(full);
+      const stat = lstatSync11(full);
       if (!(stat.isDirectory() || stat.isSymbolicLink()))
         continue;
     } catch {
@@ -8874,7 +8874,7 @@ function collectRnProjects(rootDir, maxDepth, out) {
     return;
   let entries;
   try {
-    entries = readdirSync5(rootDir);
+    entries = readdirSync6(rootDir);
   } catch {
     return;
   }
@@ -8883,9 +8883,9 @@ function collectRnProjects(rootDir, maxDepth, out) {
   for (const name of entries) {
     if (name.startsWith(".") || name === "node_modules")
       continue;
-    const full = join15(rootDir, name);
+    const full = join17(rootDir, name);
     try {
-      const stat = lstatSync10(full);
+      const stat = lstatSync11(full);
       if (!(stat.isDirectory() || stat.isSymbolicLink()))
         continue;
     } catch {
@@ -8903,11 +8903,11 @@ function collectRnProjects(rootDir, maxDepth, out) {
   }
 }
 function readProjectBundleId(projectRoot) {
-  const appJsonPath = join15(projectRoot, "app.json");
-  if (!existsSync12(appJsonPath))
+  const appJsonPath = join17(projectRoot, "app.json");
+  if (!existsSync13(appJsonPath))
     return null;
   try {
-    const raw = JSON.parse(readFileSync11(appJsonPath, "utf-8"));
+    const raw = JSON.parse(readFileSync12(appJsonPath, "utf-8"));
     const iosId = raw.expo?.ios?.bundleIdentifier ?? raw.ios?.bundleIdentifier;
     const androidId = raw.expo?.android?.package ?? raw.android?.package;
     if (typeof iosId === "string" && iosId.length > 0)
@@ -8941,7 +8941,7 @@ function findProjectRoot(opts = {}) {
         walkupHit = walkupHit ?? dir;
         break;
       }
-      const parent = join15(dir, "..");
+      const parent = join17(dir, "..");
       if (parent === dir)
         break;
       dir = parent;
@@ -8950,7 +8950,7 @@ function findProjectRoot(opts = {}) {
   if (!targetBundleId && walkupHit)
     return walkupHit;
   const cwd = process.cwd();
-  const parentOfCwd = join15(cwd, "..");
+  const parentOfCwd = join17(cwd, "..");
   if (targetBundleId) {
     const all = [];
     collectRnProjects(cwd, 0, all);
@@ -9101,15 +9101,15 @@ var init_sources = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/project-config.js
-import { existsSync as existsSync13, readFileSync as readFileSync12 } from "node:fs";
-import { join as join16 } from "node:path";
+import { existsSync as existsSync14, readFileSync as readFileSync13 } from "node:fs";
+import { join as join18 } from "node:path";
 function readAppId(projectRoot, platform) {
   for (const filename of ["app.json", "app.config.json"]) {
-    const p = join16(projectRoot, filename);
-    if (!existsSync13(p))
+    const p = join18(projectRoot, filename);
+    if (!existsSync14(p))
       continue;
     try {
-      const raw = JSON.parse(readFileSync12(p, "utf-8"));
+      const raw = JSON.parse(readFileSync13(p, "utf-8"));
       const expo = raw.expo ?? raw;
       const iosBundleId = expo?.ios?.bundleIdentifier;
       const androidPkg = expo?.android?.package;
@@ -9133,11 +9133,11 @@ function readExpoSlug() {
   if (!projectRoot)
     return null;
   for (const filename of ["app.json", "app.config.json"]) {
-    const p = join16(projectRoot, filename);
-    if (!existsSync13(p))
+    const p = join18(projectRoot, filename);
+    if (!existsSync14(p))
       continue;
     try {
-      const raw = JSON.parse(readFileSync12(p, "utf-8"));
+      const raw = JSON.parse(readFileSync13(p, "utf-8"));
       return raw.expo?.slug ?? null;
     } catch {
       continue;
@@ -9155,11 +9155,11 @@ var init_project_config = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/agent-device-wrapper.js
-import { join as join17 } from "node:path";
-import { createHash as createHash3 } from "node:crypto";
+import { join as join19 } from "node:path";
+import { createHash as createHash4 } from "node:crypto";
 function getSessionFilePath() {
-  const projectId = createHash3("sha256").update(process.cwd()).digest("hex").slice(0, 12);
-  return join17(getStateDir(), `session-${projectId}.json`);
+  const projectId = createHash4("sha256").update(process.cwd()).digest("hex").slice(0, 12);
+  return join19(getStateDir(), `session-${projectId}.json`);
 }
 function getActiveSession() {
   return activeSession;
@@ -9171,6 +9171,30 @@ function getAdbSerial() {
   if (process.env.ANDROID_SERIAL)
     return ["-s", process.env.ANDROID_SERIAL];
   return [];
+}
+function attachMeta(result, patch) {
+  try {
+    const first = result.content?.[0];
+    if (!first || first.type !== "text")
+      return result;
+    const envelope = JSON.parse(first.text);
+    const prevTimings = envelope.meta?.timings_ms ?? {};
+    const patchTimings = patch.timings_ms ?? {};
+    envelope.meta = {
+      ...envelope.meta,
+      ...patch,
+      ...Object.keys(prevTimings).length + Object.keys(patchTimings).length > 0 ? { timings_ms: { ...prevTimings, ...patchTimings } } : {}
+    };
+    return {
+      ...result,
+      content: [
+        { type: "text", text: JSON.stringify(envelope) },
+        ...result.content.slice(1)
+      ]
+    };
+  } catch {
+    return result;
+  }
 }
 var SESSION_FILE, LEGACY_SESSION_FILE, activeSession;
 var init_agent_device_wrapper = __esm({
@@ -9223,7 +9247,7 @@ var init_free_port = __esm({
 // packages/rn-dev-agent-core/dist/runners/rn-android-runner-client.js
 import { spawn as spawn2, execFile as execFile3 } from "node:child_process";
 import { promisify as promisify3 } from "node:util";
-import { join as join18 } from "node:path";
+import { join as join20 } from "node:path";
 function androidStatePath(serial) {
   return runnerStatePath(`android-${serial}`);
 }
@@ -9346,11 +9370,11 @@ var init_rn_android_runner_client = __esm({
     init_authority_store();
     execFileAsync2 = promisify3(execFile3);
     RN_ANDROID_RUNNER_DIR = resolveNativeRunnerDir("rn-android-runner");
-    GRADLEW = join18(RN_ANDROID_RUNNER_DIR, "gradlew");
-    APK_APP = join18(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
-    APK_TEST = join18(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
-    ANDROID_REBUILD_ROOT = join18(RN_ANDROID_RUNNER_DIR, "app", "build");
-    ANDROID_REBUILD_LOCK_DATABASE = join18(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
+    GRADLEW = join20(RN_ANDROID_RUNNER_DIR, "gradlew");
+    APK_APP = join20(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
+    APK_TEST = join20(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
+    ANDROID_REBUILD_ROOT = join20(RN_ANDROID_RUNNER_DIR, "app", "build");
+    ANDROID_REBUILD_LOCK_DATABASE = join20(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
     ANDROID_REBUILD_LOCK_STALE_MS = 15 * 6e4;
     ADB_CLEANUP_TIMEOUT_MS = 5e3;
     runnerProcess2 = null;
@@ -9462,14 +9486,14 @@ var init_discovery = __esm({
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
 import { homedir as homedir4 } from "node:os";
-import { join as join19 } from "node:path";
+import { join as join21 } from "node:path";
 var DAEMON_JSON, DAEMON_LOCK;
 var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON = join19(homedir4(), ".agent-device", "daemon.json");
-    DAEMON_LOCK = join19(homedir4(), ".agent-device", "daemon.lock");
+    DAEMON_JSON = join21(homedir4(), ".agent-device", "daemon.json");
+    DAEMON_LOCK = join21(homedir4(), ".agent-device", "daemon.lock");
   }
 });
 
@@ -10234,9 +10258,9 @@ var init_utils = __esm({
 // packages/rn-dev-agent-core/dist/runners/release-android-slot.js
 import { execFile as execFileCb9 } from "node:child_process";
 import { promisify as promisify12 } from "node:util";
-import { existsSync as existsSync15, readFileSync as readFileSync13, unlinkSync as unlinkSync7 } from "node:fs";
+import { existsSync as existsSync16, readFileSync as readFileSync14, unlinkSync as unlinkSync7 } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { join as join21 } from "node:path";
+import { join as join23 } from "node:path";
 function isProtectedPid(pid, selfPid, parentPid) {
   return pid === selfPid || pid === parentPid;
 }
@@ -10253,7 +10277,7 @@ function defaultDeps() {
     resolveSerial: (deviceId) => deviceId ? ["-s", deviceId] : getAdbSerial(),
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync13(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync14(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -10269,7 +10293,7 @@ function defaultDeps() {
     },
     protectedPids: () => ({ selfPid: process.pid, parentPid: process.ppid }),
     kill: (pid, sig) => process.kill(pid, sig),
-    fileExists: (p) => existsSync15(p),
+    fileExists: (p) => existsSync16(p),
     removeFile: (p) => unlinkSync7(p),
     delay: (ms) => new Promise((resolve9) => setTimeout(resolve9, ms)),
     killLegacy: () => process.env.RN_DEVICE_KILL_LEGACY !== "0",
@@ -10383,8 +10407,8 @@ var init_release_android_slot = __esm({
     init_rn_android_runner_client();
     init_agent_device_wrapper();
     execFile12 = promisify12(execFileCb9);
-    DAEMON_JSON2 = join21(homedir5(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join21(homedir5(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join23(homedir5(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join23(homedir5(), ".agent-device", "daemon.lock");
     DAEMON_FILES = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS = 500;
     ADB_TIMEOUT_MS = 5e3;
@@ -10405,7 +10429,7 @@ var init_release_android_slot = __esm({
 // packages/rn-dev-agent-core/dist/maestro-runner-pin.js
 import { spawnSync as spawnSync3 } from "node:child_process";
 import { existsSync as existsSync18 } from "node:fs";
-import { dirname as dirname15, join as join24, resolve as resolve8 } from "node:path";
+import { dirname as dirname15, join as join25, resolve as resolve8 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
@@ -14361,13 +14385,319 @@ function filterWithBoundedRegex(candidates, pattern, timeoutMs = 500) {
   });
 }
 
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+import { closeSync as closeSync4, constants as constants5, fstatSync as fstatSync4, lstatSync as lstatSync9, openSync as openSync4, readSync as readSync2, realpathSync as realpathSync7 } from "node:fs";
+import { join as join13, sep as sep8 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
+import { existsSync as existsSync11, readFileSync as readFileSync10, readdirSync as readdirSync5, realpathSync as realpathSync6, rmSync as rmSync2 } from "node:fs";
+import { createHash as createHash3 } from "node:crypto";
+import { tmpdir as tmpdir2 } from "node:os";
+import { isAbsolute as isAbsolute6, join as join12, sep as sep7 } from "node:path";
+var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
+var WEAK_DEVICE_ID_KEYS = ["id"];
+var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
+function idsFrom(value, keys) {
+  if (!value || typeof value !== "object")
+    return [];
+  const record = value;
+  for (const key of keys) {
+    const id = record[key];
+    if (typeof id === "string")
+      return [id];
+  }
+  return [];
+}
+function deviceIdsFrom(value) {
+  return idsFrom(value, DEVICE_ID_KEYS);
+}
+function weakDeviceIdsFrom(value) {
+  if (typeof value === "string")
+    return [value];
+  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
+}
+function containerDeviceIdsFrom(value) {
+  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
+}
+function reportDeviceIds(reportDir) {
+  const reportPath = join12(reportDir, "report.json");
+  if (!existsSync11(reportPath))
+    return { ids: [], strength: "none" };
+  try {
+    const report = JSON.parse(readFileSync10(reportPath, "utf8"));
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    const devices = [report.device, ...flows.map((flow) => flow?.device)];
+    const strong = [
+      ...devices.flatMap((device) => deviceIdsFrom(device)),
+      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
+    ];
+    const usingStrong = strong.length > 0;
+    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
+    const accepted = [
+      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
+    ];
+    return {
+      ids: accepted,
+      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
+    };
+  } catch {
+    return { ids: [], strength: "none" };
+  }
+}
+function createRunnerReportDir(runner, prefix) {
+  if (runner !== "maestro-runner")
+    return null;
+  return join12(tmpdir2(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+}
+function runnerReportArgs(reportDir) {
+  return reportDir ? ["--output", reportDir, "--flatten"] : [];
+}
+function collectDirectRunnerEvidence(reportDir, output) {
+  if (!reportDir)
+    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
+  const report = reportDeviceIds(reportDir);
+  const evidence = {
+    output,
+    reportDeviceIds: report.ids,
+    reportDeviceIdStrength: report.strength
+  };
+  const logPath = join12(reportDir, "maestro-runner.log");
+  if (!existsSync11(logPath))
+    return evidence;
+  try {
+    evidence.output = `${output}
+${readFileSync10(logPath, "utf8")}`;
+  } catch {
+  }
+  return evidence;
+}
+var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
+  "passed",
+  "failed",
+  "skipped",
+  "running",
+  "pending"
+]);
+function observationStatus(value) {
+  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
+}
+var FINGERPRINT_INCONCLUSIVE = "unreadable";
+function contentHash(path) {
+  try {
+    return createHash3("sha256").update(readFileSync10(path)).digest("hex");
+  } catch (error) {
+    return error?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
+  }
+}
+function runnerReportFingerprint(reportDir) {
+  const fingerprint = {};
+  if (!reportDir)
+    return fingerprint;
+  const reportHash = contentHash(join12(reportDir, "report.json"));
+  if (reportHash)
+    fingerprint["report.json"] = reportHash;
+  let flowEntries = [];
+  try {
+    flowEntries = readdirSync5(join12(reportDir, "flows"));
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
+    }
+    return fingerprint;
+  }
+  for (const entry of flowEntries.sort()) {
+    const flowHash = contentHash(join12(reportDir, "flows", entry));
+    if (flowHash)
+      fingerprint[`flows/${entry}`] = flowHash;
+  }
+  return fingerprint;
+}
+function readStructuredFlowArtifact(reportDir, previous, readText = (path) => readFileSync10(path, "utf8")) {
+  if (!reportDir)
+    return null;
+  const reportPath = join12(reportDir, "report.json");
+  if (!existsSync11(reportPath))
+    return null;
+  const unfinalized = {
+    finalized: false,
+    flowStatus: "unknown",
+    commands: []
+  };
+  try {
+    const reportText = readText(reportPath);
+    if (previous) {
+      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
+        return unfinalized;
+      const reportHash = createHash3("sha256").update(reportText).digest("hex");
+      if (previous["report.json"] === reportHash)
+        return null;
+    }
+    const report = JSON.parse(reportText);
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    if (flows.length !== 1)
+      return unfinalized;
+    const flow = flows[0];
+    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
+    if (flowStatus === "unknown")
+      return unfinalized;
+    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
+      return unfinalized;
+    const normalizedDataFile = flow.dataFile;
+    if (isAbsolute6(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+      return unfinalized;
+    }
+    const realDataFile = realpathSync6(join12(reportDir, normalizedDataFile));
+    if (!realDataFile.startsWith(realpathSync6(reportDir) + sep7))
+      return unfinalized;
+    const dataText = readText(realDataFile);
+    if (previous) {
+      const dataHash = createHash3("sha256").update(dataText).digest("hex");
+      if (previous[normalizedDataFile] === dataHash)
+        return unfinalized;
+    }
+    const data = JSON.parse(dataText);
+    if (!Array.isArray(data.commands))
+      return unfinalized;
+    let malformedRow = false;
+    const seenIndices = /* @__PURE__ */ new Set();
+    const commands = data.commands.map((entry) => {
+      const record = entry ?? {};
+      const error = record.error ?? void 0;
+      const status = observationStatus(record.status);
+      const producerIndex = typeof record.index === "number" && Number.isInteger(record.index) && record.index >= 0 ? record.index : null;
+      if (producerIndex === null || seenIndices.has(producerIndex)) {
+        malformedRow = true;
+      } else {
+        seenIndices.add(producerIndex);
+      }
+      if (typeof record.type !== "string" || record.type.length === 0 || status === "unknown") {
+        malformedRow = true;
+      }
+      return {
+        index: producerIndex ?? -1,
+        type: typeof record.type === "string" ? record.type : "unknown",
+        status,
+        ...error && typeof error.message === "string" ? { error: error.message.slice(0, 500) } : {}
+      };
+    });
+    if (malformedRow)
+      return { finalized: false, flowStatus, commands: [] };
+    const counts = flow.commands ?? {};
+    const statusCount = (status) => commands.filter((command) => command.status === status).length;
+    const countExact = (key, actual) => counts[key] === actual;
+    const anyFailedRow = commands.some((command) => command.status === "failed");
+    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
+    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
+    return { finalized, flowStatus, commands };
+  } catch {
+    return unfinalized;
+  }
+}
+function disposeRunnerReportDir(reportDir) {
+  if (!reportDir)
+    return;
+  try {
+    rmSync2(reportDir, { recursive: true, force: true });
+  } catch {
+  }
+}
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+var MAX_CAPTURES = 8;
+var MAX_ROWS = 64;
+var MAX_REPORT_BYTES = 256 * 1024;
+function createRunnerFailureEvidence() {
+  return {
+    version: 1,
+    incomplete: true,
+    withheld: "text-images-terminal-output-and-original-artifacts",
+    capturesTruncated: false,
+    captures: []
+  };
+}
+function append(evidence, capture) {
+  evidence.captures.push(capture);
+  if (evidence.captures.length > MAX_CAPTURES) {
+    evidence.captures.splice(1, 1);
+    evidence.capturesTruncated = true;
+  }
+}
+function captureRunnerFailure(evidence, reportDir, previous, stage, invocation, termination, attempt = 1) {
+  const capture = {
+    attempt,
+    stage,
+    invocation,
+    exitCode: Number.isSafeInteger(termination.exitCode) ? termination.exitCode : null,
+    signalPresent: termination.signal !== null,
+    timedOut: termination.timedOut,
+    outputTruncated: termination.outputTruncated,
+    bootstrapFailure: termination.bootstrapFailure,
+    transportFailure: termination.transportFailure,
+    report: "missing",
+    rowsTruncated: false,
+    commands: []
+  };
+  try {
+    if (reportDir) {
+      if (!lstatSync9(reportDir).isDirectory())
+        throw new Error();
+      const root2 = realpathSync7(reportDir);
+      const reportPath = join13(root2, "report.json");
+      lstatSync9(reportPath);
+      let readFailure;
+      let remaining = MAX_REPORT_BYTES;
+      const artifact = readStructuredFlowArtifact(root2, previous, (path) => {
+        let fd;
+        try {
+          if (!realpathSync7(path).startsWith(root2 + sep8))
+            throw new Error();
+          fd = openSync4(path, constants5.O_RDONLY | constants5.O_NOFOLLOW);
+          const stat = fstatSync4(fd);
+          if (!stat.isFile())
+            throw new Error();
+          if (stat.size > remaining) {
+            readFailure = "oversized";
+            throw new Error();
+          }
+          const bytes = Buffer.alloc(stat.size + 1);
+          const size = readSync2(fd, bytes, 0, bytes.length, 0);
+          if (size !== stat.size || fstatSync4(fd).size !== size)
+            throw new Error();
+          remaining -= size;
+          return bytes.subarray(0, size).toString("utf8");
+        } catch (error) {
+          readFailure ??= "unavailable";
+          throw error;
+        } finally {
+          if (fd !== void 0)
+            closeSync4(fd);
+        }
+      });
+      capture.report = readFailure ?? (artifact ? artifact.finalized ? "finalized" : "unfinalized" : "missing");
+      if (artifact?.finalized && !readFailure) {
+        capture.rowsTruncated = artifact.commands.length > MAX_ROWS;
+        const rows = [...artifact.commands].sort((a, b) => Number(b.status === "failed") - Number(a.status === "failed"));
+        capture.commands = rows.slice(0, MAX_ROWS).map((row) => ({
+          index: row.index,
+          status: row.status,
+          errorPresent: row.error !== void 0
+        }));
+      }
+    }
+  } catch (error) {
+    capture.report = error.code === "ENOENT" ? "missing" : "unavailable";
+  }
+  append(evidence, capture);
+}
+
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 init_utils();
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
 import { existsSync as existsSync17, readFileSync as readFileSync15, writeFileSync as writeFileSync6 } from "node:fs";
 import { tmpdir as tmpdir4 } from "node:os";
-import { basename as basename8, join as join23, dirname as dirname14 } from "node:path";
+import { basename as basename8, join as join24, dirname as dirname14 } from "node:path";
 init_agent_device_wrapper();
 init_project_config();
 
@@ -14406,17 +14736,17 @@ function chooseMaestroDispatch(inputs) {
 
 // packages/rn-dev-agent-core/dist/tools/resolve-ios-app-file.js
 import { execFileSync as execFileSync3 } from "node:child_process";
-import { existsSync as existsSync14, cpSync as cpSync2, rmSync as rmSync2, mkdirSync as mkdirSync10, readdirSync as readdirSync6, statSync as statSync6 } from "node:fs";
-import { tmpdir as tmpdir2 } from "node:os";
-import { join as join20, basename as basename7 } from "node:path";
+import { existsSync as existsSync15, cpSync as cpSync2, rmSync as rmSync3, mkdirSync as mkdirSync10, readdirSync as readdirSync7, statSync as statSync6 } from "node:fs";
+import { tmpdir as tmpdir3 } from "node:os";
+import { join as join22, basename as basename7 } from "node:path";
 function flowUsesClearState(flowText) {
   return /clearState:\s*true\b/.test(flowText) || /^[ \t]*-[ \t]*clearState[ \t]*$/m.test(flowText);
 }
 function defaultSnapshotApp(appPath) {
   try {
-    const destDir = join20(tmpdir2(), "rn-appfile-snapshots");
-    const dest = join20(destDir, basename7(appPath));
-    rmSync2(dest, { recursive: true, force: true });
+    const destDir = join22(tmpdir3(), "rn-appfile-snapshots");
+    const dest = join22(destDir, basename7(appPath));
+    rmSync3(dest, { recursive: true, force: true });
     mkdirSync10(destDir, { recursive: true });
     try {
       execFileSync3("cp", ["-Rc", appPath, dest], { timeout: 3e4, stdio: "ignore" });
@@ -14429,7 +14759,7 @@ function defaultSnapshotApp(appPath) {
   }
 }
 function resolveIosAppFile(bundleId, deps = {}) {
-  const exists = deps.exists ?? existsSync14;
+  const exists = deps.exists ?? existsSync15;
   const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
   const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
   const fromContainer = getAppContainer(bundleId, deps.deviceId);
@@ -14933,220 +15263,6 @@ function maestroAuthorityRefusal(authority, underlyingError) {
     return null;
   const headline = `Maestro device authority refused: requested ${authority.requestedDeviceId}, direct runner/WDA evidence was ${authority.reportedDeviceId ?? "missing"} (${authority.reason}).`;
   return underlyingError ? `${headline} Underlying failure: ${underlyingError}` : headline;
-}
-
-// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
-import { existsSync as existsSync16, readFileSync as readFileSync14, readdirSync as readdirSync7, realpathSync as realpathSync7, rmSync as rmSync3 } from "node:fs";
-import { createHash as createHash4 } from "node:crypto";
-import { tmpdir as tmpdir3 } from "node:os";
-import { isAbsolute as isAbsolute6, join as join22, sep as sep7 } from "node:path";
-var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
-var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
-var WEAK_DEVICE_ID_KEYS = ["id"];
-var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
-function idsFrom(value, keys) {
-  if (!value || typeof value !== "object")
-    return [];
-  const record = value;
-  for (const key of keys) {
-    const id = record[key];
-    if (typeof id === "string")
-      return [id];
-  }
-  return [];
-}
-function deviceIdsFrom(value) {
-  return idsFrom(value, DEVICE_ID_KEYS);
-}
-function weakDeviceIdsFrom(value) {
-  if (typeof value === "string")
-    return [value];
-  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
-}
-function containerDeviceIdsFrom(value) {
-  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
-}
-function reportDeviceIds(reportDir) {
-  const reportPath = join22(reportDir, "report.json");
-  if (!existsSync16(reportPath))
-    return { ids: [], strength: "none" };
-  try {
-    const report = JSON.parse(readFileSync14(reportPath, "utf8"));
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    const devices = [report.device, ...flows.map((flow) => flow?.device)];
-    const strong = [
-      ...devices.flatMap((device) => deviceIdsFrom(device)),
-      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
-    ];
-    const usingStrong = strong.length > 0;
-    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
-    const accepted = [
-      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
-    ];
-    return {
-      ids: accepted,
-      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
-    };
-  } catch {
-    return { ids: [], strength: "none" };
-  }
-}
-function createRunnerReportDir(runner, prefix) {
-  if (runner !== "maestro-runner")
-    return null;
-  return join22(tmpdir3(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-}
-function runnerReportArgs(reportDir) {
-  return reportDir ? ["--output", reportDir, "--flatten"] : [];
-}
-function collectDirectRunnerEvidence(reportDir, output) {
-  if (!reportDir)
-    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
-  const report = reportDeviceIds(reportDir);
-  const evidence = {
-    output,
-    reportDeviceIds: report.ids,
-    reportDeviceIdStrength: report.strength
-  };
-  const logPath = join22(reportDir, "maestro-runner.log");
-  if (!existsSync16(logPath))
-    return evidence;
-  try {
-    evidence.output = `${output}
-${readFileSync14(logPath, "utf8")}`;
-  } catch {
-  }
-  return evidence;
-}
-var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
-  "passed",
-  "failed",
-  "skipped",
-  "running",
-  "pending"
-]);
-function observationStatus(value) {
-  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
-}
-var FINGERPRINT_INCONCLUSIVE = "unreadable";
-function contentHash(path) {
-  try {
-    return createHash4("sha256").update(readFileSync14(path)).digest("hex");
-  } catch (error) {
-    return error?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
-  }
-}
-function runnerReportFingerprint(reportDir) {
-  const fingerprint = {};
-  if (!reportDir)
-    return fingerprint;
-  const reportHash = contentHash(join22(reportDir, "report.json"));
-  if (reportHash)
-    fingerprint["report.json"] = reportHash;
-  let flowEntries = [];
-  try {
-    flowEntries = readdirSync7(join22(reportDir, "flows"));
-  } catch (error) {
-    if (error?.code !== "ENOENT") {
-      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
-    }
-    return fingerprint;
-  }
-  for (const entry of flowEntries.sort()) {
-    const flowHash = contentHash(join22(reportDir, "flows", entry));
-    if (flowHash)
-      fingerprint[`flows/${entry}`] = flowHash;
-  }
-  return fingerprint;
-}
-function readStructuredFlowArtifact(reportDir, previous) {
-  if (!reportDir)
-    return null;
-  const reportPath = join22(reportDir, "report.json");
-  if (!existsSync16(reportPath))
-    return null;
-  const unfinalized = {
-    finalized: false,
-    flowStatus: "unknown",
-    commands: []
-  };
-  try {
-    const reportText = readFileSync14(reportPath, "utf8");
-    if (previous) {
-      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
-        return unfinalized;
-      const reportHash = createHash4("sha256").update(reportText).digest("hex");
-      if (previous["report.json"] === reportHash)
-        return null;
-    }
-    const report = JSON.parse(reportText);
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    if (flows.length !== 1)
-      return unfinalized;
-    const flow = flows[0];
-    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
-    if (flowStatus === "unknown")
-      return unfinalized;
-    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
-      return unfinalized;
-    const normalizedDataFile = flow.dataFile;
-    if (isAbsolute6(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
-      return unfinalized;
-    }
-    const realDataFile = realpathSync7(join22(reportDir, normalizedDataFile));
-    if (!realDataFile.startsWith(realpathSync7(reportDir) + sep7))
-      return unfinalized;
-    const dataText = readFileSync14(realDataFile, "utf8");
-    if (previous) {
-      const dataHash = createHash4("sha256").update(dataText).digest("hex");
-      if (previous[normalizedDataFile] === dataHash)
-        return unfinalized;
-    }
-    const data = JSON.parse(dataText);
-    if (!Array.isArray(data.commands))
-      return unfinalized;
-    let malformedRow = false;
-    const seenIndices = /* @__PURE__ */ new Set();
-    const commands = data.commands.map((entry) => {
-      const record = entry ?? {};
-      const error = record.error ?? void 0;
-      const status = observationStatus(record.status);
-      const producerIndex = typeof record.index === "number" && Number.isInteger(record.index) && record.index >= 0 ? record.index : null;
-      if (producerIndex === null || seenIndices.has(producerIndex)) {
-        malformedRow = true;
-      } else {
-        seenIndices.add(producerIndex);
-      }
-      if (typeof record.type !== "string" || record.type.length === 0 || status === "unknown") {
-        malformedRow = true;
-      }
-      return {
-        index: producerIndex ?? -1,
-        type: typeof record.type === "string" ? record.type : "unknown",
-        status,
-        ...error && typeof error.message === "string" ? { error: error.message.slice(0, 500) } : {}
-      };
-    });
-    if (malformedRow)
-      return { finalized: false, flowStatus, commands: [] };
-    const counts = flow.commands ?? {};
-    const statusCount = (status) => commands.filter((command) => command.status === status).length;
-    const countExact = (key, actual) => counts[key] === actual;
-    const anyFailedRow = commands.some((command) => command.status === "failed");
-    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
-    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
-    return { finalized, flowStatus, commands };
-  } catch {
-    return unfinalized;
-  }
-}
-function disposeRunnerReportDir(reportDir) {
-  if (!reportDir)
-    return;
-  try {
-    rmSync3(reportDir, { recursive: true, force: true });
-  } catch {
-  }
 }
 
 // packages/rn-dev-agent-core/dist/domain/maestro-run-ledger.js
@@ -16525,7 +16641,7 @@ function createMaestroRunHandler(deps = {}) {
   const resolveEngineStatus = deps.resolveEngineStatus ?? (() => getEngineStatus().catch(() => null));
   const replayFactory = deps.replayDeps;
   const nativeOnlyHandler = replayFactory ? createMaestroRunHandler({ ...deps, replayDeps: void 0 }) : null;
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (args.params) {
       for (const [key, value] of Object.entries(args.params)) {
         if (!PARAM_KEY_RE.test(key)) {
@@ -16603,7 +16719,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join23(tmpdir4(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join24(tmpdir4(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -17006,6 +17122,7 @@ function createMaestroRunHandler(deps = {}) {
     })();
     const stageCaptures = [];
     let ledgerStageCursor = 0;
+    let invocationOrdinal = 0;
     const stageTerminationFromError = (error) => {
       const errorClass = classifyExecError(error);
       const raw = error;
@@ -17073,7 +17190,8 @@ function createMaestroRunHandler(deps = {}) {
                 Object.assign(error, { code: "ETIMEDOUT" });
                 throw error;
               }
-              const executeRunner = (runnerPath, prefixArgs = []) => {
+              const executeRunner = async (runnerPath, prefixArgs = []) => {
+                const fingerprint = runnerReportFingerprint(runnerReportDir);
                 beforeDispatch?.();
                 const remainingTimeout = flowDeadline - now();
                 if (remainingTimeout <= 0) {
@@ -17081,12 +17199,29 @@ function createMaestroRunHandler(deps = {}) {
                   Object.assign(error, { code: "ETIMEDOUT" });
                   throw error;
                 }
-                return execute(runnerPath, [...prefixArgs, ...finalArgs], {
-                  timeout: remainingTimeout,
-                  encoding: "utf8",
-                  maxBuffer: 10 * 1024 * 1024,
-                  signal: flowAbort.signal
-                });
+                const invocation = ++invocationOrdinal;
+                try {
+                  const result = await execute(runnerPath, [...prefixArgs, ...finalArgs], {
+                    timeout: remainingTimeout,
+                    encoding: "utf8",
+                    maxBuffer: 10 * 1024 * 1024,
+                    signal: flowAbort.signal
+                  });
+                  if (outputIndicatesFlowFailure(combineRunnerOutput(result.stdout, result.stderr))) {
+                    captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, {
+                      exitCode: 0,
+                      signal: null,
+                      timedOut: false,
+                      outputTruncated: false,
+                      bootstrapFailure: false,
+                      transportFailure: false
+                    }, ledgerAttempt.ordinal);
+                  }
+                  return result;
+                } catch (error) {
+                  captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, stageTerminationFromError(error), ledgerAttempt.ordinal);
+                  throw error;
+                }
               };
               if (deps.execFile) {
                 const immediateStatus = await resolveEngineStatus();
@@ -17484,6 +17619,18 @@ function createMaestroRunHandler(deps = {}) {
       }
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error) {
+      if (error instanceof SessionAuthorityError && evidence.captures.length) {
+        error.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error;
+    }
+  };
 }
 
 // packages/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -17491,9 +17638,9 @@ var USAGE = "usage: maestro-runner-pin [diagnose|install|migrate-actions|verify-
 function ensureScriptPath() {
   const here = dirname15(fileURLToPath2(import.meta.url));
   const candidates = [
-    join24(here, "..", "..", "..", "scripts", "ensure-maestro-runner.sh"),
-    join24(here, "..", "scripts", "ensure-maestro-runner.sh"),
-    join24(here, "..", "..", "scripts", "ensure-maestro-runner.sh")
+    join25(here, "..", "..", "..", "scripts", "ensure-maestro-runner.sh"),
+    join25(here, "..", "scripts", "ensure-maestro-runner.sh"),
+    join25(here, "..", "..", "scripts", "ensure-maestro-runner.sh")
   ];
   return candidates.find((path) => existsSync18(path)) ?? candidates[0];
 }
@@ -17571,7 +17718,7 @@ async function verifyActions(argv) {
     }
   }
   const flowDir = resolve8(flowDirArg);
-  const flowDirClassification = classifyLearnedActionPath(join24(flowDir, "__action__.yaml"));
+  const flowDirClassification = classifyLearnedActionPath(join25(flowDir, "__action__.yaml"));
   if (flowDirClassification !== "action") {
     console.error(`Refusing to execute flows outside an owned .rn-agent/actions corpus: ${flowDir}.`);
     return 2;
@@ -17598,7 +17745,7 @@ async function verifyActions(argv) {
       console.error(`verify-actions pattern is ${filtered.reason}: ${filtered.message}`);
       return 2;
     }
-    files = filtered.matches.map((file) => join24(flowDir, file)).sort();
+    files = filtered.matches.map((file) => join25(flowDir, file)).sort();
   } catch (err) {
     console.error(`verify-actions could not read ${flowDir}: ${String(err)}`);
     return 2;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -5203,10 +5203,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -5220,7 +5220,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep11) {
+          if (!keyProps.anchor && !keyProps.tag && !sep12) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -5244,7 +5244,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+        const valueProps = resolveProps.resolveProps(sep12 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -5260,7 +5260,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep11, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep12, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -5351,7 +5351,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep11 = "";
+        let sep12 = "";
         for (const token2 of end) {
           const { source, type } = token2;
           switch (type) {
@@ -5365,13 +5365,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep11 + cb;
-              sep11 = "";
+                comment += sep12 + cb;
+              sep12 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep11 += source;
+                sep12 += source;
               hasSpace = true;
               break;
             default:
@@ -5414,18 +5414,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep11 && !value) {
+          if (!props.anchor && !props.tag && !sep12 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -5479,8 +5479,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep11 && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep11, null, props, onError);
+        if (!isMap && !sep12 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep12, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -5492,7 +5492,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+          const valueProps = resolveProps.resolveProps(sep12 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -5503,8 +5503,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep11)
-                for (const st of sep11) {
+              if (sep12)
+                for (const st of sep12) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -5521,7 +5521,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep11, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep12, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -5701,7 +5701,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep11 = "";
+      let sep12 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -5718,24 +5718,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep11 === " ")
-            sep11 = "\n";
-          else if (!prevMoreIndented && sep11 === "\n")
-            sep11 = "\n\n";
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          if (sep12 === " ")
+            sep12 = "\n";
+          else if (!prevMoreIndented && sep12 === "\n")
+            sep12 = "\n\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep11 === "\n")
+          if (sep12 === "\n")
             value += "\n";
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          value += sep11 + content;
-          sep11 = " ";
+          value += sep12 + content;
+          sep12 = " ";
           prevMoreIndented = false;
         }
       }
@@ -5917,25 +5917,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep11 = " ";
+      let sep12 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep11 === "\n")
-            res += sep11;
+          if (sep12 === "\n")
+            res += sep12;
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          res += sep11 + match[1];
-          sep11 = " ";
+          res += sep12 + match[1];
+          sep12 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep11 + (match?.[1] ?? "");
+      return res + sep12 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -6745,14 +6745,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep: sep11, value }) {
+    function stringifyItem({ start, key, sep: sep12, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep11)
-        for (const st of sep11)
+      if (sep12)
+        for (const st of sep12)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -7919,18 +7919,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep11;
+          let sep12;
           if (scalar.end) {
-            sep11 = scalar.end;
-            sep11.push(this.sourceToken);
+            sep12 = scalar.end;
+            sep12.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep11 = [this.sourceToken];
+            sep12 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep: sep11 }]
+            items: [{ start, key: scalar, sep: sep12 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -8083,15 +8083,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep11 = it.sep;
-                  sep11.push(this.sourceToken);
+                  const sep12 = it.sep;
+                  sep12.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep: sep11 }]
+                    items: [{ start: start2, key, sep: sep12 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -8285,13 +8285,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep11 = fc.end.splice(1, fc.end.length);
-            sep11.push(this.sourceToken);
+            const sep12 = fc.end.splice(1, fc.end.length);
+            sep12.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep: sep11 }]
+              items: [{ start, key: fc, sep: sep12 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -9005,7 +9005,7 @@ function recordNavigation(projectRoot, input) {
   if (!targetScreen)
     return null;
   const now = (/* @__PURE__ */ new Date()).toISOString();
-  const record2 = {
+  const record3 = {
     method: input.method,
     success: input.success,
     latency_ms: input.latency_ms ?? 0,
@@ -9013,7 +9013,7 @@ function recordNavigation(projectRoot, input) {
   };
   if (!targetScreen.action_records)
     targetScreen.action_records = [];
-  targetScreen.action_records.push(record2);
+  targetScreen.action_records.push(record3);
   if (targetScreen.action_records.length > MAX_ACTION_RECORDS) {
     targetScreen.action_records = targetScreen.action_records.slice(-MAX_ACTION_RECORDS);
   }
@@ -20071,17 +20071,17 @@ function getFreshRefTarget(ref, opts = {}) {
     return null;
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
   const rect = refMap.get(key);
-  const record2 = metadataMap.get(key);
-  if (!rect || !record2 || record2.snapshotGeneration !== snapshotGeneration || record2.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
+  const record3 = metadataMap.get(key);
+  if (!rect || !record3 || record3.snapshotGeneration !== snapshotGeneration || record3.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
     return null;
   return {
     rect,
-    snapshotGeneration: record2.snapshotGeneration,
-    snapshotNodeIndex: record2.snapshotNodeIndex,
-    snapshotElementType: record2.type,
-    ...record2.label !== void 0 ? { snapshotLabel: record2.label } : {},
-    ...record2.identifier !== void 0 ? { snapshotIdentifier: record2.identifier } : {},
-    keyboardStateAtSnapshot: record2.keyboardStateAtSnapshot
+    snapshotGeneration: record3.snapshotGeneration,
+    snapshotNodeIndex: record3.snapshotNodeIndex,
+    snapshotElementType: record3.type,
+    ...record3.label !== void 0 ? { snapshotLabel: record3.label } : {},
+    ...record3.identifier !== void 0 ? { snapshotIdentifier: record3.identifier } : {},
+    keyboardStateAtSnapshot: record3.keyboardStateAtSnapshot
   };
 }
 function getCachedMetadata(ref) {
@@ -22573,10 +22573,10 @@ function referencesMetroEvidenceSocket(value, path) {
   }
   if (!value || typeof value !== "object")
     return false;
-  const record2 = value;
-  if (record2.runtimeEvidenceSocket === path)
+  const record3 = value;
+  if (record3.runtimeEvidenceSocket === path)
     return true;
-  return Object.values(record2).some((entry) => referencesMetroEvidenceSocket(entry, path));
+  return Object.values(record3).some((entry) => referencesMetroEvidenceSocket(entry, path));
 }
 function authorityRemedyNextAction(code) {
   return errorNextActions[code];
@@ -22646,14 +22646,14 @@ function readStartupCleanupBlocker(bindingsJson) {
   const refusal = journal.refusal;
   if (!refusal || typeof refusal !== "object")
     return void 0;
-  const record2 = refusal;
-  if (typeof record2.code !== "string" || typeof record2.reason !== "string")
+  const record3 = refusal;
+  if (typeof record3.code !== "string" || typeof record3.reason !== "string")
     return void 0;
   return {
-    code: record2.code,
-    reason: record2.reason,
-    ...record2.cause === "managed-metro-stop-proof-missing" ? { cause: record2.cause } : {},
-    ...typeof record2.nextAction === "string" ? { nextAction: record2.nextAction } : {}
+    code: record3.code,
+    reason: record3.reason,
+    ...record3.cause === "managed-metro-stop-proof-missing" ? { cause: record3.cause } : {},
+    ...typeof record3.nextAction === "string" ? { nextAction: record3.nextAction } : {}
   };
 }
 function bindingsRunnerPresent(bindingsJson) {
@@ -23593,21 +23593,21 @@ var init_registry = __esm({
               integration: existing.integration ?? null
             };
           }
-          const record2 = (value) => value && typeof value === "object" ? { ...value } : null;
+          const record3 = (value) => value && typeof value === "object" ? { ...value } : null;
           const obligation = (source, claimKey) => source ? {
             ...source,
             claimKey: String(source.claimKey ?? claimKey ?? ""),
             stopRequestedAt: typeof source.stopRequestedAt === "number" ? source.stopRequestedAt : now,
             completedAt: typeof source.completedAt === "number" ? source.completedAt : null
           } : void 0;
-          const handoffCleanup = record2(bindings.handoffCleanup);
-          const staleDevice = record2(bindings.staleDeviceCleanup);
-          const androidMetroReverseSource = record2(bindings.androidMetroReverse) ?? record2(staleDevice?.androidMetroReverse);
-          const recorderSource = record2(bindings.recorder) ?? record2(staleDevice?.recorder) ?? record2(handoffCleanup?.recorder);
-          const runnerSource = record2(bindings.runner) ?? record2(staleDevice?.runner) ?? record2(handoffCleanup?.runner);
-          const observeSource = record2(bindings.observe) ?? record2(handoffCleanup?.observe);
-          const liveMetro = record2(bindings.metroCleanup) ?? record2(bindings.metro);
-          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record2(handoffCleanup?.metro);
+          const handoffCleanup = record3(bindings.handoffCleanup);
+          const staleDevice = record3(bindings.staleDeviceCleanup);
+          const androidMetroReverseSource = record3(bindings.androidMetroReverse) ?? record3(staleDevice?.androidMetroReverse);
+          const recorderSource = record3(bindings.recorder) ?? record3(staleDevice?.recorder) ?? record3(handoffCleanup?.recorder);
+          const runnerSource = record3(bindings.runner) ?? record3(staleDevice?.runner) ?? record3(handoffCleanup?.runner);
+          const observeSource = record3(bindings.observe) ?? record3(handoffCleanup?.observe);
+          const liveMetro = record3(bindings.metroCleanup) ?? record3(bindings.metro);
+          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record3(handoffCleanup?.metro);
           const obligations = {};
           const androidMetroReverseEntry = obligation(androidMetroReverseSource, androidMetroReverseSource ? `android:${String(androidMetroReverseSource.deviceId)}` : null);
           if (androidMetroReverseEntry) {
@@ -23625,7 +23625,7 @@ var init_registry = __esm({
           const metroEntry = obligation(metroSource, metroSource ? String(metroSource.port) : null);
           if (metroEntry)
             obligations.metro = metroEntry;
-          const integrationBinding = record2(bindings.packageIntegration);
+          const integrationBinding = record3(bindings.packageIntegration);
           const integration = integrationBinding ? {
             installedBySessionId: integrationBinding.installedBySessionId ?? null,
             manifestSha256: integrationBinding.manifestSha256 ?? null,
@@ -23880,8 +23880,8 @@ var init_registry = __esm({
       #bindingMatchesDevice(binding, target) {
         if (!binding || typeof binding !== "object")
           return false;
-        const record2 = binding;
-        return record2.platform === target.platform && record2.deviceId === target.deviceId;
+        const record3 = binding;
+        return record3.platform === target.platform && record3.deviceId === target.deviceId;
       }
       #requireProvenDeadOwner(sessionId, claimEpoch) {
         const prior = asSession(this.#database.prepare(`SELECT session_id, claim_epoch, state, supervisor_pid, supervisor_birth, bindings_json
@@ -50931,11 +50931,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants10);
+          this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -50952,10 +50952,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants10);
+        this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -51016,8 +51016,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants10) {
-        this.code = optimizeExpr(this.code, names, constants10);
+      optimizeNames(names, constants11) {
+        this.code = optimizeExpr(this.code, names, constants11);
         return this;
       }
       get names() {
@@ -51046,12 +51046,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants10))
+          if (n.optimizeNames(names, constants11))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -51104,12 +51104,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        if (!(super.optimizeNames(names, constants10) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        if (!(super.optimizeNames(names, constants11) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants10);
+        this.condition = optimizeExpr(this.condition, names, constants11);
         return this;
       }
       get names() {
@@ -51132,10 +51132,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants10);
+        this.iteration = optimizeExpr(this.iteration, names, constants11);
         return this;
       }
       get names() {
@@ -51171,10 +51171,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants10);
+        this.iterable = optimizeExpr(this.iterable, names, constants11);
         return this;
       }
       get names() {
@@ -51216,11 +51216,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a, _b;
-        super.optimizeNames(names, constants10);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants10);
+        super.optimizeNames(names, constants11);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants11);
         return this;
       }
       get names() {
@@ -51521,7 +51521,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants10) {
+    function optimizeExpr(expr, names, constants11) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -51536,14 +51536,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants10[n.str];
+        const c = constants11[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants10[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants11[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -53190,18 +53190,18 @@ var require_validate = __commonJS({
         const { schemaCode } = this;
         this.fail((0, codegen_1._)`${schemaCode} !== undefined && (${(0, codegen_1.or)(this.invalid$data(), condition)})`);
       }
-      error(append, errorParams, errorPaths) {
+      error(append2, errorParams, errorPaths) {
         if (errorParams) {
           this.setParams(errorParams);
-          this._error(append, errorPaths);
+          this._error(append2, errorPaths);
           this.setParams({});
           return;
         }
-        this._error(append, errorPaths);
+        this._error(append2, errorPaths);
       }
-      _error(append, errorPaths) {
+      _error(append2, errorPaths) {
         ;
-        (append ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
+        (append2 ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
       }
       $dataError() {
         (0, errors_1.reportError)(this, this.def.$dataError || errors_1.keyword$DataError);
@@ -71383,10 +71383,10 @@ function openActionDb(projectRoot, opts = {}) {
     const handle = {
       db,
       close: () => db.close(),
-      insertRunRecord(actionId, record2) {
+      insertRunRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
@@ -71395,7 +71395,7 @@ function openActionDb(projectRoot, opts = {}) {
                (action_id, ts, trigger, status, failure_code, failure_detail,
                 transport, auto_repair_json, duration_ms, device_id, blind_probe_json,
                 trailing_verification_json)
-             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.trigger, record2.status, record2.failureCode ?? null, record2.failureDetail ?? null, record2.transport ?? null, record2.autoRepair ? JSON.stringify(record2.autoRepair) : null, record2.durationMs, record2.deviceId ?? null, record2.blindProbe ? JSON.stringify(record2.blindProbe) : null, record2.trailingVerification ? JSON.stringify(record2.trailingVerification) : null);
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.trigger, record3.status, record3.failureCode ?? null, record3.failureDetail ?? null, record3.transport ?? null, record3.autoRepair ? JSON.stringify(record3.autoRepair) : null, record3.durationMs, record3.deviceId ?? null, record3.blindProbe ? JSON.stringify(record3.blindProbe) : null, record3.trailingVerification ? JSON.stringify(record3.trailingVerification) : null);
           db.prepare(`DELETE FROM run_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -71410,17 +71410,17 @@ function openActionDb(projectRoot, opts = {}) {
           throw e;
         }
       },
-      insertRepairRecord(actionId, record2) {
+      insertRepairRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
           }
           db.prepare(`INSERT INTO repair_records
                (action_id, ts, failure_code, diff_json, duration_ms, agent_reasoning)
-             VALUES (?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.failureCode, JSON.stringify(record2.diff ?? {}), record2.durationMs, record2.agentReasoning ?? null);
+             VALUES (?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.failureCode, JSON.stringify(record3.diff ?? {}), record3.durationMs, record3.agentReasoning ?? null);
           db.prepare(`DELETE FROM repair_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -71630,36 +71630,36 @@ function freshRuntimeState(now = () => /* @__PURE__ */ new Date(), mtimeMs = 0) 
     }
   };
 }
-function appendRunRecord(state, record2) {
-  const newHistory = [...state.runHistory, record2];
+function appendRunRecord(state, record3) {
+  const newHistory = [...state.runHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.RUN_HISTORY_MAX)
     newHistory.shift();
   const totalRuns = state.stats.totalRuns + 1;
-  const successCount = state.stats.successCount + (record2.status === "pass" ? 1 : 0);
-  const failureCount = state.stats.failureCount + (record2.status === "fail" ? 1 : 0);
+  const successCount = state.stats.successCount + (record3.status === "pass" ? 1 : 0);
+  const failureCount = state.stats.failureCount + (record3.status === "fail" ? 1 : 0);
   const successDurations = newHistory.filter((r) => r.status === "pass").map((r) => r.durationMs);
   const avgDurationMs = successDurations.length ? Math.round(successDurations.reduce((s, n) => s + n, 0) / successDurations.length) : state.stats.avgDurationMs;
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     runHistory: newHistory,
     stats: {
       totalRuns,
       successCount,
       failureCount,
       avgDurationMs,
-      lastSuccessAt: record2.status === "pass" ? record2.timestamp : state.stats.lastSuccessAt,
-      lastFailureAt: record2.status === "fail" ? record2.timestamp : state.stats.lastFailureAt
+      lastSuccessAt: record3.status === "pass" ? record3.timestamp : state.stats.lastSuccessAt,
+      lastFailureAt: record3.status === "fail" ? record3.timestamp : state.stats.lastFailureAt
     }
   };
 }
-function appendRepairRecord(state, record2) {
-  const newHistory = [...state.repairHistory, record2];
+function appendRepairRecord(state, record3) {
+  const newHistory = [...state.repairHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.REPAIR_HISTORY_MAX)
     newHistory.shift();
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     revision: state.revision + 1,
     repairHistory: newHistory
   };
@@ -76425,11 +76425,11 @@ function redactBatchFillSteps(args) {
   const redactedSteps = steps.map((step) => {
     if (!step || typeof step !== "object" || Array.isArray(step))
       return step;
-    const record2 = step;
-    if (record2.action !== "fill")
+    const record3 = step;
+    if (record3.action !== "fill")
       return step;
-    const redacted = redactTypedValue(record2, "text");
-    if (redacted !== record2)
+    const redacted = redactTypedValue(record3, "text");
+    if (redacted !== record3)
       changed = true;
     return redacted;
   });
@@ -79080,8 +79080,8 @@ function acknowledgeExternalEdit(action) {
 function canonicalRuntimeJson(state) {
   return JSON.stringify(state, (_key, value) => {
     if (value && typeof value === "object" && !Array.isArray(value)) {
-      const record2 = value;
-      return Object.fromEntries(Object.keys(record2).sort().map((k) => [k, record2[k]]));
+      const record3 = value;
+      return Object.fromEntries(Object.keys(record3).sort().map((k) => [k, record3[k]]));
     }
     return value;
   });
@@ -80760,6 +80760,367 @@ var init_save_as_action = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
+import { existsSync as existsSync29, readFileSync as readFileSync29, readdirSync as readdirSync11, realpathSync as realpathSync15, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash16 } from "node:crypto";
+import { tmpdir as tmpdir9 } from "node:os";
+import { isAbsolute as isAbsolute14, join as join43, sep as sep9 } from "node:path";
+function idsFrom(value, keys) {
+  if (!value || typeof value !== "object")
+    return [];
+  const record3 = value;
+  for (const key of keys) {
+    const id = record3[key];
+    if (typeof id === "string")
+      return [id];
+  }
+  return [];
+}
+function deviceIdsFrom(value) {
+  return idsFrom(value, DEVICE_ID_KEYS);
+}
+function weakDeviceIdsFrom(value) {
+  if (typeof value === "string")
+    return [value];
+  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
+}
+function containerDeviceIdsFrom(value) {
+  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
+}
+function reportDeviceIds(reportDir) {
+  const reportPath = join43(reportDir, "report.json");
+  if (!existsSync29(reportPath))
+    return { ids: [], strength: "none" };
+  try {
+    const report = JSON.parse(readFileSync29(reportPath, "utf8"));
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    const devices = [report.device, ...flows.map((flow) => flow?.device)];
+    const strong = [
+      ...devices.flatMap((device) => deviceIdsFrom(device)),
+      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
+    ];
+    const usingStrong = strong.length > 0;
+    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
+    const accepted = [
+      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
+    ];
+    return {
+      ids: accepted,
+      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
+    };
+  } catch {
+    return { ids: [], strength: "none" };
+  }
+}
+function createRunnerReportDir(runner, prefix) {
+  if (runner !== "maestro-runner")
+    return null;
+  return join43(tmpdir9(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+}
+function runnerReportArgs(reportDir) {
+  return reportDir ? ["--output", reportDir, "--flatten"] : [];
+}
+function collectDirectRunnerEvidence(reportDir, output) {
+  if (!reportDir)
+    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
+  const report = reportDeviceIds(reportDir);
+  const evidence = {
+    output,
+    reportDeviceIds: report.ids,
+    reportDeviceIdStrength: report.strength
+  };
+  const logPath = join43(reportDir, "maestro-runner.log");
+  if (!existsSync29(logPath))
+    return evidence;
+  try {
+    evidence.output = `${output}
+${readFileSync29(logPath, "utf8")}`;
+  } catch {
+  }
+  return evidence;
+}
+function observationStatus(value) {
+  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
+}
+function contentHash(path) {
+  try {
+    return createHash16("sha256").update(readFileSync29(path)).digest("hex");
+  } catch (error2) {
+    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
+  }
+}
+function runnerReportFingerprint(reportDir) {
+  const fingerprint = {};
+  if (!reportDir)
+    return fingerprint;
+  const reportHash = contentHash(join43(reportDir, "report.json"));
+  if (reportHash)
+    fingerprint["report.json"] = reportHash;
+  let flowEntries = [];
+  try {
+    flowEntries = readdirSync11(join43(reportDir, "flows"));
+  } catch (error2) {
+    if (error2?.code !== "ENOENT") {
+      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
+    }
+    return fingerprint;
+  }
+  for (const entry of flowEntries.sort()) {
+    const flowHash = contentHash(join43(reportDir, "flows", entry));
+    if (flowHash)
+      fingerprint[`flows/${entry}`] = flowHash;
+  }
+  return fingerprint;
+}
+function readStructuredFlowArtifact(reportDir, previous, readText = (path) => readFileSync29(path, "utf8")) {
+  if (!reportDir)
+    return null;
+  const reportPath = join43(reportDir, "report.json");
+  if (!existsSync29(reportPath))
+    return null;
+  const unfinalized = {
+    finalized: false,
+    flowStatus: "unknown",
+    commands: []
+  };
+  try {
+    const reportText = readText(reportPath);
+    if (previous) {
+      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
+        return unfinalized;
+      const reportHash = createHash16("sha256").update(reportText).digest("hex");
+      if (previous["report.json"] === reportHash)
+        return null;
+    }
+    const report = JSON.parse(reportText);
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    if (flows.length !== 1)
+      return unfinalized;
+    const flow = flows[0];
+    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
+    if (flowStatus === "unknown")
+      return unfinalized;
+    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
+      return unfinalized;
+    const normalizedDataFile = flow.dataFile;
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+      return unfinalized;
+    }
+    const realDataFile = realpathSync15(join43(reportDir, normalizedDataFile));
+    if (!realDataFile.startsWith(realpathSync15(reportDir) + sep9))
+      return unfinalized;
+    const dataText = readText(realDataFile);
+    if (previous) {
+      const dataHash = createHash16("sha256").update(dataText).digest("hex");
+      if (previous[normalizedDataFile] === dataHash)
+        return unfinalized;
+    }
+    const data = JSON.parse(dataText);
+    if (!Array.isArray(data.commands))
+      return unfinalized;
+    let malformedRow = false;
+    const seenIndices = /* @__PURE__ */ new Set();
+    const commands = data.commands.map((entry) => {
+      const record3 = entry ?? {};
+      const error2 = record3.error ?? void 0;
+      const status = observationStatus(record3.status);
+      const producerIndex = typeof record3.index === "number" && Number.isInteger(record3.index) && record3.index >= 0 ? record3.index : null;
+      if (producerIndex === null || seenIndices.has(producerIndex)) {
+        malformedRow = true;
+      } else {
+        seenIndices.add(producerIndex);
+      }
+      if (typeof record3.type !== "string" || record3.type.length === 0 || status === "unknown") {
+        malformedRow = true;
+      }
+      return {
+        index: producerIndex ?? -1,
+        type: typeof record3.type === "string" ? record3.type : "unknown",
+        status,
+        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
+      };
+    });
+    if (malformedRow)
+      return { finalized: false, flowStatus, commands: [] };
+    const counts = flow.commands ?? {};
+    const statusCount = (status) => commands.filter((command) => command.status === status).length;
+    const countExact = (key, actual) => counts[key] === actual;
+    const anyFailedRow = commands.some((command) => command.status === "failed");
+    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
+    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
+    return { finalized, flowStatus, commands };
+  } catch {
+    return unfinalized;
+  }
+}
+function disposeRunnerReportDir(reportDir) {
+  if (!reportDir)
+    return;
+  try {
+    rmSync11(reportDir, { recursive: true, force: true });
+  } catch {
+  }
+}
+var DIRECT_DEVICE_ID_RE, DEVICE_ID_KEYS, WEAK_DEVICE_ID_KEYS, CONTAINER_DEVICE_ID_KEYS, OBSERVATION_STATUSES, FINGERPRINT_INCONCLUSIVE;
+var init_maestro_runner_report = __esm({
+  "packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js"() {
+    "use strict";
+    DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+    DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
+    WEAK_DEVICE_ID_KEYS = ["id"];
+    CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
+    OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
+      "passed",
+      "failed",
+      "skipped",
+      "running",
+      "pending"
+    ]);
+    FINGERPRINT_INCONCLUSIVE = "unreadable";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+import { closeSync as closeSync12, constants as constants10, fstatSync as fstatSync9, lstatSync as lstatSync17, openSync as openSync12, readSync as readSync5, realpathSync as realpathSync16 } from "node:fs";
+import { join as join44, sep as sep10 } from "node:path";
+function createRunnerFailureEvidence() {
+  return {
+    version: 1,
+    incomplete: true,
+    withheld: "text-images-terminal-output-and-original-artifacts",
+    capturesTruncated: false,
+    captures: []
+  };
+}
+function append(evidence, capture) {
+  evidence.captures.push(capture);
+  if (evidence.captures.length > MAX_CAPTURES) {
+    evidence.captures.splice(1, 1);
+    evidence.capturesTruncated = true;
+  }
+}
+function captureRunnerFailure(evidence, reportDir, previous, stage, invocation, termination, attempt = 1) {
+  const capture = {
+    attempt,
+    stage,
+    invocation,
+    exitCode: Number.isSafeInteger(termination.exitCode) ? termination.exitCode : null,
+    signalPresent: termination.signal !== null,
+    timedOut: termination.timedOut,
+    outputTruncated: termination.outputTruncated,
+    bootstrapFailure: termination.bootstrapFailure,
+    transportFailure: termination.transportFailure,
+    report: "missing",
+    rowsTruncated: false,
+    commands: []
+  };
+  try {
+    if (reportDir) {
+      if (!lstatSync17(reportDir).isDirectory())
+        throw new Error();
+      const root = realpathSync16(reportDir);
+      const reportPath = join44(root, "report.json");
+      lstatSync17(reportPath);
+      let readFailure;
+      let remaining = MAX_REPORT_BYTES;
+      const artifact = readStructuredFlowArtifact(root, previous, (path) => {
+        let fd;
+        try {
+          if (!realpathSync16(path).startsWith(root + sep10))
+            throw new Error();
+          fd = openSync12(path, constants10.O_RDONLY | constants10.O_NOFOLLOW);
+          const stat2 = fstatSync9(fd);
+          if (!stat2.isFile())
+            throw new Error();
+          if (stat2.size > remaining) {
+            readFailure = "oversized";
+            throw new Error();
+          }
+          const bytes = Buffer.alloc(stat2.size + 1);
+          const size = readSync5(fd, bytes, 0, bytes.length, 0);
+          if (size !== stat2.size || fstatSync9(fd).size !== size)
+            throw new Error();
+          remaining -= size;
+          return bytes.subarray(0, size).toString("utf8");
+        } catch (error2) {
+          readFailure ??= "unavailable";
+          throw error2;
+        } finally {
+          if (fd !== void 0)
+            closeSync12(fd);
+        }
+      });
+      capture.report = readFailure ?? (artifact ? artifact.finalized ? "finalized" : "unfinalized" : "missing");
+      if (artifact?.finalized && !readFailure) {
+        capture.rowsTruncated = artifact.commands.length > MAX_ROWS;
+        const rows = [...artifact.commands].sort((a, b) => Number(b.status === "failed") - Number(a.status === "failed"));
+        capture.commands = rows.slice(0, MAX_ROWS).map((row) => ({
+          index: row.index,
+          status: row.status,
+          errorPresent: row.error !== void 0
+        }));
+      }
+    }
+  } catch (error2) {
+    capture.report = error2.code === "ENOENT" ? "missing" : "unavailable";
+  }
+  append(evidence, capture);
+}
+function record2(value) {
+  return value !== null && typeof value === "object" ? value : {};
+}
+function collectRunnerFailureEvidence(evidence, value) {
+  const input = record2(value);
+  if (input.version !== 1 || !Array.isArray(input.captures))
+    return;
+  evidence.capturesTruncated ||= input.capturesTruncated === true || input.captures.length > MAX_CAPTURES;
+  const captures = input.captures.length > MAX_CAPTURES ? [input.captures[0], ...input.captures.slice(-(MAX_CAPTURES - 1))] : input.captures;
+  for (const item of captures) {
+    const row = record2(item);
+    if (!Number.isSafeInteger(row.stage) || !Number.isSafeInteger(row.invocation))
+      continue;
+    const state = REPORT_STATES.find((state2) => state2 === row.report) ?? "unavailable";
+    const commands = Array.isArray(row.commands) ? row.commands : [];
+    append(evidence, {
+      attempt: Number.isSafeInteger(row.attempt) ? Number(row.attempt) : 1,
+      stage: Number(row.stage),
+      invocation: Number(row.invocation),
+      exitCode: Number.isSafeInteger(row.exitCode) ? Number(row.exitCode) : null,
+      signalPresent: row.signalPresent === true,
+      timedOut: row.timedOut === true,
+      outputTruncated: row.outputTruncated === true,
+      bootstrapFailure: row.bootstrapFailure === true,
+      transportFailure: row.transportFailure === true,
+      report: state,
+      rowsTruncated: row.rowsTruncated === true || commands.length > MAX_ROWS,
+      commands: commands.slice(0, MAX_ROWS).flatMap((item2) => {
+        const command = record2(item2);
+        if (!Number.isSafeInteger(command.index))
+          return [];
+        return [
+          {
+            index: Number(command.index),
+            status: STATUSES.find((status) => status === command.status) ?? "unknown",
+            errorPresent: command.errorPresent === true
+          }
+        ];
+      })
+    });
+  }
+}
+var MAX_CAPTURES, MAX_ROWS, MAX_REPORT_BYTES, STATUSES, REPORT_STATES;
+var init_runner_failure_evidence = __esm({
+  "packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js"() {
+    "use strict";
+    init_maestro_runner_report();
+    MAX_CAPTURES = 8;
+    MAX_ROWS = 64;
+    MAX_REPORT_BYTES = 256 * 1024;
+    STATUSES = ["passed", "failed", "skipped", "running", "pending", "unknown"];
+    REPORT_STATES = ["missing", "unavailable", "oversized", "unfinalized", "finalized"];
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/ansi.js
 function stripAnsi(value) {
   return value.replace(ANSI_RE, "");
@@ -81285,226 +81646,6 @@ function maestroAuthorityRefusal(authority, underlyingError) {
 var init_maestro_device_authority = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-device-authority.js"() {
     "use strict";
-  }
-});
-
-// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
-import { existsSync as existsSync29, readFileSync as readFileSync29, readdirSync as readdirSync11, realpathSync as realpathSync15, rmSync as rmSync11 } from "node:fs";
-import { createHash as createHash16 } from "node:crypto";
-import { tmpdir as tmpdir9 } from "node:os";
-import { isAbsolute as isAbsolute14, join as join43, sep as sep9 } from "node:path";
-function idsFrom(value, keys) {
-  if (!value || typeof value !== "object")
-    return [];
-  const record2 = value;
-  for (const key of keys) {
-    const id = record2[key];
-    if (typeof id === "string")
-      return [id];
-  }
-  return [];
-}
-function deviceIdsFrom(value) {
-  return idsFrom(value, DEVICE_ID_KEYS);
-}
-function weakDeviceIdsFrom(value) {
-  if (typeof value === "string")
-    return [value];
-  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
-}
-function containerDeviceIdsFrom(value) {
-  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
-}
-function reportDeviceIds(reportDir) {
-  const reportPath = join43(reportDir, "report.json");
-  if (!existsSync29(reportPath))
-    return { ids: [], strength: "none" };
-  try {
-    const report = JSON.parse(readFileSync29(reportPath, "utf8"));
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    const devices = [report.device, ...flows.map((flow) => flow?.device)];
-    const strong = [
-      ...devices.flatMap((device) => deviceIdsFrom(device)),
-      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
-    ];
-    const usingStrong = strong.length > 0;
-    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
-    const accepted = [
-      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
-    ];
-    return {
-      ids: accepted,
-      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
-    };
-  } catch {
-    return { ids: [], strength: "none" };
-  }
-}
-function createRunnerReportDir(runner, prefix) {
-  if (runner !== "maestro-runner")
-    return null;
-  return join43(tmpdir9(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-}
-function runnerReportArgs(reportDir) {
-  return reportDir ? ["--output", reportDir, "--flatten"] : [];
-}
-function collectDirectRunnerEvidence(reportDir, output) {
-  if (!reportDir)
-    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
-  const report = reportDeviceIds(reportDir);
-  const evidence = {
-    output,
-    reportDeviceIds: report.ids,
-    reportDeviceIdStrength: report.strength
-  };
-  const logPath = join43(reportDir, "maestro-runner.log");
-  if (!existsSync29(logPath))
-    return evidence;
-  try {
-    evidence.output = `${output}
-${readFileSync29(logPath, "utf8")}`;
-  } catch {
-  }
-  return evidence;
-}
-function observationStatus(value) {
-  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
-}
-function contentHash(path) {
-  try {
-    return createHash16("sha256").update(readFileSync29(path)).digest("hex");
-  } catch (error2) {
-    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
-  }
-}
-function runnerReportFingerprint(reportDir) {
-  const fingerprint = {};
-  if (!reportDir)
-    return fingerprint;
-  const reportHash = contentHash(join43(reportDir, "report.json"));
-  if (reportHash)
-    fingerprint["report.json"] = reportHash;
-  let flowEntries = [];
-  try {
-    flowEntries = readdirSync11(join43(reportDir, "flows"));
-  } catch (error2) {
-    if (error2?.code !== "ENOENT") {
-      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
-    }
-    return fingerprint;
-  }
-  for (const entry of flowEntries.sort()) {
-    const flowHash = contentHash(join43(reportDir, "flows", entry));
-    if (flowHash)
-      fingerprint[`flows/${entry}`] = flowHash;
-  }
-  return fingerprint;
-}
-function readStructuredFlowArtifact(reportDir, previous) {
-  if (!reportDir)
-    return null;
-  const reportPath = join43(reportDir, "report.json");
-  if (!existsSync29(reportPath))
-    return null;
-  const unfinalized = {
-    finalized: false,
-    flowStatus: "unknown",
-    commands: []
-  };
-  try {
-    const reportText = readFileSync29(reportPath, "utf8");
-    if (previous) {
-      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
-        return unfinalized;
-      const reportHash = createHash16("sha256").update(reportText).digest("hex");
-      if (previous["report.json"] === reportHash)
-        return null;
-    }
-    const report = JSON.parse(reportText);
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    if (flows.length !== 1)
-      return unfinalized;
-    const flow = flows[0];
-    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
-    if (flowStatus === "unknown")
-      return unfinalized;
-    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
-      return unfinalized;
-    const normalizedDataFile = flow.dataFile;
-    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
-      return unfinalized;
-    }
-    const realDataFile = realpathSync15(join43(reportDir, normalizedDataFile));
-    if (!realDataFile.startsWith(realpathSync15(reportDir) + sep9))
-      return unfinalized;
-    const dataText = readFileSync29(realDataFile, "utf8");
-    if (previous) {
-      const dataHash = createHash16("sha256").update(dataText).digest("hex");
-      if (previous[normalizedDataFile] === dataHash)
-        return unfinalized;
-    }
-    const data = JSON.parse(dataText);
-    if (!Array.isArray(data.commands))
-      return unfinalized;
-    let malformedRow = false;
-    const seenIndices = /* @__PURE__ */ new Set();
-    const commands = data.commands.map((entry) => {
-      const record2 = entry ?? {};
-      const error2 = record2.error ?? void 0;
-      const status = observationStatus(record2.status);
-      const producerIndex = typeof record2.index === "number" && Number.isInteger(record2.index) && record2.index >= 0 ? record2.index : null;
-      if (producerIndex === null || seenIndices.has(producerIndex)) {
-        malformedRow = true;
-      } else {
-        seenIndices.add(producerIndex);
-      }
-      if (typeof record2.type !== "string" || record2.type.length === 0 || status === "unknown") {
-        malformedRow = true;
-      }
-      return {
-        index: producerIndex ?? -1,
-        type: typeof record2.type === "string" ? record2.type : "unknown",
-        status,
-        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
-      };
-    });
-    if (malformedRow)
-      return { finalized: false, flowStatus, commands: [] };
-    const counts = flow.commands ?? {};
-    const statusCount = (status) => commands.filter((command) => command.status === status).length;
-    const countExact = (key, actual) => counts[key] === actual;
-    const anyFailedRow = commands.some((command) => command.status === "failed");
-    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
-    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
-    return { finalized, flowStatus, commands };
-  } catch {
-    return unfinalized;
-  }
-}
-function disposeRunnerReportDir(reportDir) {
-  if (!reportDir)
-    return;
-  try {
-    rmSync11(reportDir, { recursive: true, force: true });
-  } catch {
-  }
-}
-var DIRECT_DEVICE_ID_RE, DEVICE_ID_KEYS, WEAK_DEVICE_ID_KEYS, CONTAINER_DEVICE_ID_KEYS, OBSERVATION_STATUSES, FINGERPRINT_INCONCLUSIVE;
-var init_maestro_runner_report = __esm({
-  "packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js"() {
-    "use strict";
-    DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
-    DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
-    WEAK_DEVICE_ID_KEYS = ["id"];
-    CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
-    OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
-      "passed",
-      "failed",
-      "skipped",
-      "running",
-      "pending"
-    ]);
-    FINGERPRINT_INCONCLUSIVE = "unreadable";
   }
 });
 
@@ -82713,7 +82854,7 @@ import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
 import { existsSync as existsSync30, readFileSync as readFileSync30, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
-import { basename as basename10, join as join44, dirname as dirname23 } from "node:path";
+import { basename as basename10, join as join45, dirname as dirname23 } from "node:path";
 import { randomUUID as randomUUID9 } from "node:crypto";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
@@ -82969,7 +83110,7 @@ function createMaestroRunHandler(deps = {}) {
   const resolveEngineStatus = deps.resolveEngineStatus ?? (() => getEngineStatus().catch(() => null));
   const replayFactory = deps.replayDeps;
   const nativeOnlyHandler = replayFactory ? createMaestroRunHandler({ ...deps, replayDeps: void 0 }) : null;
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (args.params) {
       for (const [key, value] of Object.entries(args.params)) {
         if (!PARAM_KEY_RE.test(key)) {
@@ -83047,7 +83188,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join44(tmpdir10(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join45(tmpdir10(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -83277,15 +83418,15 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of result.replay.steps) {
               if (!step || typeof step !== "object")
                 continue;
-              const record2 = step;
+              const record3 = step;
               combinedSteps.push({
-                index: sourceIndices[record2.sourceIndex ?? -1] ?? record2.sourceIndex ?? combinedSteps.length,
-                name: String(record2.t ?? "unknown"),
-                verb: String(record2.t ?? "unknown"),
-                ...record2.target !== void 0 ? { target: String(record2.target) } : {},
-                ...record2.focusOnly === true ? { focusOnly: true } : {},
-                status: record2.ok === false ? "fail" : "pass",
-                durationMs: Number(record2.durationMs ?? 0)
+                index: sourceIndices[record3.sourceIndex ?? -1] ?? record3.sourceIndex ?? combinedSteps.length,
+                name: String(record3.t ?? "unknown"),
+                verb: String(record3.t ?? "unknown"),
+                ...record3.target !== void 0 ? { target: String(record3.target) } : {},
+                ...record3.focusOnly === true ? { focusOnly: true } : {},
+                status: record3.ok === false ? "fail" : "pass",
+                durationMs: Number(record3.durationMs ?? 0)
               });
             }
           }
@@ -83450,6 +83591,7 @@ function createMaestroRunHandler(deps = {}) {
     })();
     const stageCaptures = [];
     let ledgerStageCursor = 0;
+    let invocationOrdinal = 0;
     const stageTerminationFromError = (error2) => {
       const errorClass = classifyExecError(error2);
       const raw = error2;
@@ -83517,7 +83659,8 @@ function createMaestroRunHandler(deps = {}) {
                 Object.assign(error2, { code: "ETIMEDOUT" });
                 throw error2;
               }
-              const executeRunner = (runnerPath, prefixArgs = []) => {
+              const executeRunner = async (runnerPath, prefixArgs = []) => {
+                const fingerprint = runnerReportFingerprint(runnerReportDir);
                 beforeDispatch?.();
                 const remainingTimeout = flowDeadline - now();
                 if (remainingTimeout <= 0) {
@@ -83525,12 +83668,29 @@ function createMaestroRunHandler(deps = {}) {
                   Object.assign(error2, { code: "ETIMEDOUT" });
                   throw error2;
                 }
-                return execute2(runnerPath, [...prefixArgs, ...finalArgs], {
-                  timeout: remainingTimeout,
-                  encoding: "utf8",
-                  maxBuffer: 10 * 1024 * 1024,
-                  signal: flowAbort.signal
-                });
+                const invocation = ++invocationOrdinal;
+                try {
+                  const result = await execute2(runnerPath, [...prefixArgs, ...finalArgs], {
+                    timeout: remainingTimeout,
+                    encoding: "utf8",
+                    maxBuffer: 10 * 1024 * 1024,
+                    signal: flowAbort.signal
+                  });
+                  if (outputIndicatesFlowFailure(combineRunnerOutput(result.stdout, result.stderr))) {
+                    captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, {
+                      exitCode: 0,
+                      signal: null,
+                      timedOut: false,
+                      outputTruncated: false,
+                      bootstrapFailure: false,
+                      transportFailure: false
+                    }, ledgerAttempt.ordinal);
+                  }
+                  return result;
+                } catch (error2) {
+                  captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, stageTerminationFromError(error2), ledgerAttempt.ordinal);
+                  throw error2;
+                }
               };
               if (deps.execFile) {
                 const immediateStatus = await resolveEngineStatus();
@@ -83928,11 +84088,24 @@ function createMaestroRunHandler(deps = {}) {
       }
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 var defaultExecFile2, MaestroStageExecutionError, lifecycleCommands, PARAM_KEY_RE, ReactReplayFailure, UIAUTOMATION_SESSION_CREATION_FAILURE;
 var init_maestro_run = __esm({
   "packages/rn-dev-agent-core/dist/tools/maestro-run.js"() {
     "use strict";
+    init_runner_failure_evidence();
     init_utils();
     init_engine_pin();
     init_runner_diagnostics();
@@ -84379,7 +84552,7 @@ function createRunActionHandler(deps = {}) {
   const installReceipt = deps.installReceipt ?? boundInstallReceipt;
   const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   const resolveEngineStatus = deps.engineStatus ?? (() => getEngineStatus().catch(() => null));
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
     }
@@ -84467,10 +84640,10 @@ function createRunActionHandler(deps = {}) {
     const startedAt = new Date(t0).toISOString();
     const runId = randomUUID10();
     const timingSteps = [];
-    const measureStep = async (name, run) => {
+    const measureStep = async (name, run2) => {
       const stepStartedMs = Date.now();
       try {
-        return await run();
+        return await run2();
       } finally {
         const stepEndedMs = Date.now();
         timingSteps.push({
@@ -84493,14 +84666,15 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => {
+    const persistRunWithDevice = (record3) => {
       assertReadableActionLoadContextStable(loadContext);
       if (proofReplay) {
         return Promise.resolve({ promoted: false, promotionRefused: false });
       }
       const endedMs = Date.now();
       const timedRecord = {
-        ...record2,
+        ...record3,
+        ...evidence.captures.length ? { runnerFailureEvidence: structuredClone(evidence) } : {},
         runId,
         timing: {
           startedAt,
@@ -84540,6 +84714,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, firstEnv.meta?.runnerFailureEvidence);
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
@@ -84872,6 +85047,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, retryEnv.meta?.runnerFailureEvidence);
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
@@ -85009,34 +85185,46 @@ function createRunActionHandler(deps = {}) {
       });
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 function promotionDisclosure(outcome) {
   if (outcome.promoted)
     return "lifecycle-promotion";
   return outcome.promotionRefused ? "lifecycle-promotion-refused" : "none";
 }
-async function persistRun(actionId, projectRoot, record2) {
+async function persistRun(actionId, projectRoot, record3) {
   const MAX_ATTEMPTS = 5;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const fresh = loadAction(projectRoot, actionId);
     if (!fresh) {
-      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record2.status}, autoRepair.outcome=${record2.autoRepair?.outcome ?? "n/a"})`);
+      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record3.status}, autoRepair.outcome=${record3.autoRepair?.outcome ?? "n/a"})`);
       return { promoted: false, promotionRefused: false };
     }
-    const nextState = appendRunRecord(fresh.state, record2);
-    const promotes = shouldAutoPromoteToActive(fresh.metadata, record2);
+    const nextState = appendRunRecord(fresh.state, record3);
+    const promotes = shouldAutoPromoteToActive(fresh.metadata, record3);
     const commit = (runtimeStatePath, promoted, promotionRefused2) => {
       mirrorToDb({
         yamlFilePath: fresh.filePath,
         state: fresh.state,
-        newRunRecord: record2,
+        newRunRecord: record3,
         meta: {
           appId: fresh.metadata.appId,
           status: promoted ? "active" : fresh.metadata.status,
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record2.runId };
+      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record3.runId };
     };
     const promotion = promotes ? promoteActionRuntimeWithCAS(fresh, nextState) : null;
     const promotionRefused = promotion?.ok === false;
@@ -85046,7 +85234,7 @@ async function persistRun(actionId, projectRoot, record2) {
     if (runtimeWrite.ok)
       return commit(runtimeWrite.sidecarPath, false, promotionRefused);
     if (attempt === MAX_ATTEMPTS) {
-      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record2.status}).`);
+      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record3.status}).`);
       return { promoted: false, promotionRefused, runtimeStateRefused: true };
     }
   }
@@ -85056,6 +85244,8 @@ var strictRunActionPolicy, PROVEN_ENGINE_PIN_DIVERGENCE, OUTPUT_BUDGET, OUTPUT_E
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
+    init_agent_device_wrapper();
+    init_runner_failure_evidence();
     init_utils();
     init_action_store();
     init_action_state_store();
@@ -85233,7 +85423,7 @@ function createLoginPrologueHandler(deps) {
     try {
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record3) => record3.runId === strictRunRecordId) : void 0;
       });
     } catch (error2) {
       return unresolved(`could not verify the exact ${LOGIN_PROLOGUE_ALIAS} learned action: ${error2 instanceof Error ? error2.message : String(error2)}`, replayWrites);
@@ -85750,7 +85940,7 @@ var init_dev_settings = __esm({
 import { createHash as createHash18, randomBytes as randomBytes8, randomUUID as randomUUID11 } from "node:crypto";
 import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync15 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname24, join as join45 } from "node:path";
+import { dirname as dirname24, join as join46 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 function configuredExperienceDirectory() {
   return process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
@@ -85803,7 +85993,7 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join45(root, "app.json");
+  const manifest = join46(root, "app.json");
   try {
     if (!existsSync31(manifest))
       return { name: null, slug: null };
@@ -85822,10 +86012,10 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
   const start = dirname24(fileURLToPath3(fromUrl));
   const candidates = [
-    join45(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join45(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join45(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join45(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join46(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join46(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join46(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join46(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
@@ -85859,8 +86049,8 @@ function readExperienceStore(path) {
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
-  return records.filter((record2) => {
-    const lastSeen = Date.parse(record2.lastSeen);
+  return records.filter((record3) => {
+    const lastSeen = Date.parse(record3.lastSeen);
     return Number.isFinite(lastSeen) && lastSeen >= cutoff;
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
@@ -86044,7 +86234,7 @@ function stableDeviceHash(directory, deviceId) {
   return createHash18("sha256").update(readOrCreateRunnerDiagnosticsSalt(directory)).update("\0").update(deviceId).digest("hex");
 }
 function readOrCreateRunnerDiagnosticsSalt(directory) {
-  const path = join45(directory, ".runner-diagnostics-salt");
+  const path = join46(directory, ".runner-diagnostics-salt");
   mkdirSync20(directory, { recursive: true, mode: 448 });
   try {
     const existing = readFileSync31(path);
@@ -86069,7 +86259,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   const files = runnerDiagnosticsFiles(directory);
   const nextSequence = files.reduce((maximum, file) => Math.max(maximum, runnerDiagnosticsSequence(file)), 0) + 1;
   const sessionKey = (bundle.context.sessionId ?? "unknown").slice(0, 64).replace(/[^A-Za-z0-9_-]/g, "-");
-  const outputPath = join45(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
+  const outputPath = join46(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
   const bounded = boundRunnerDiagnosticsBundle(bundle);
   let serialized = `${JSON.stringify(bounded, null, 2)}
 `;
@@ -86087,17 +86277,17 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   if (Buffer.byteLength(serialized) > RUNNER_DIAGNOSTICS_MAX_BYTES) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
-  const temporary = join45(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
+  const temporary = join46(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
   writeFileSync15(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync15(join45(directory, file)).mtimeMs,
+    mtimeMs: statSync15(join46(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => left.mtimeMs - right.mtimeMs || left.sequence - right.sequence || left.file.localeCompare(right.file));
   for (const stale of retained.slice(0, Math.max(0, retained.length - RUNNER_DIAGNOSTICS_RETENTION))) {
-    unlinkSync14(join45(directory, stale.file));
+    unlinkSync14(join46(directory, stale.file));
   }
   return outputPath;
 }
@@ -86167,11 +86357,11 @@ function latestRunnerDiagnosticsPath(sessionId, directory = configuredExperience
     return null;
   const files = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync15(join45(directory, file)).mtimeMs,
+    mtimeMs: statSync15(join46(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => right.mtimeMs - left.mtimeMs || right.sequence - left.sequence || right.file.localeCompare(left.file));
   for (const file of files) {
-    const path = join45(directory, file.file);
+    const path = join46(directory, file.file);
     try {
       const contents = readFileSync31(path);
       if (contents.byteLength > RUNNER_DIAGNOSTICS_MAX_BYTES)
@@ -86203,7 +86393,7 @@ var init_evidence = __esm({
     DEFAULT_MAX_RECORDS = 500;
     DEFAULT_RETENTION_DAYS = 14;
     MAX_EVIDENCE_POINTERS = 3;
-    EXPERIENCE_DIRECTORY = join45(homedir9(), ".claude", "rn-agent", "experience");
+    EXPERIENCE_DIRECTORY = join46(homedir9(), ".claude", "rn-agent", "experience");
     EXPERIENCE_STORE_NAME = "patterns.jsonl";
     MAX_SYMPTOM_LENGTH = 2048;
     RUNNER_DIAGNOSTICS_MAX_BYTES = 256 * 1024;
@@ -86254,7 +86444,7 @@ var init_evidence = __esm({
       previousFailure = null;
       constructor(options) {
         this.directory = options.directory ?? configuredExperienceDirectory();
-        this.path = join45(this.directory, EXPERIENCE_STORE_NAME);
+        this.path = join46(this.directory, EXPERIENCE_STORE_NAME);
         this.candidate = {
           pluginVersion: options.pluginVersion ?? null,
           coreVersion: options.coreVersion
@@ -86300,9 +86490,9 @@ var init_evidence = __esm({
           return;
         }
         this.persistRunnerDiagnostics(event);
-        const record2 = this.buildFailureRecord(event);
-        this.persistFailure(record2);
-        this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+        const record3 = this.buildFailureRecord(event);
+        this.persistFailure(record3);
+        this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record3.signature } : null;
       }
       persistRunnerDiagnostics(event) {
         const trace = event.runnerDiagnostics;
@@ -86382,7 +86572,7 @@ var init_evidence = __esm({
       }
       persistFailure(incoming) {
         const records = readExperienceStore(this.path);
-        const existing = records.find((record2) => record2.signature === incoming.signature);
+        const existing = records.find((record3) => record3.signature === incoming.signature);
         if (existing) {
           existing.count += 1;
           existing.lastSeen = incoming.lastSeen;
@@ -86403,7 +86593,7 @@ var init_evidence = __esm({
       }
       persistRecovery(signature, tool) {
         const records = readExperienceStore(this.path);
-        const existing = records.find((record2) => record2.signature === signature);
+        const existing = records.find((record3) => record3.signature === signature);
         if (!existing)
           return;
         const now = this.now().toISOString();
@@ -86418,13 +86608,13 @@ var init_evidence = __esm({
       }
       write(records) {
         mkdirSync20(this.directory, { recursive: true, mode: 448 });
-        const temp = join45(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
+        const temp = join46(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
         try {
-          const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
-            ...sanitizeForEvidence(record2),
+          const sanitized = records.map((record3) => record3.redactionVersion === REDACTION_RULES_VERSION ? record3 : {
+            ...sanitizeForEvidence(record3),
             redactionVersion: REDACTION_RULES_VERSION
           });
-          const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+          const contents = sanitized.map((record3) => JSON.stringify(record3)).join("\n");
           writeFileSync15(temp, contents.length > 0 ? `${contents}
 ` : "", {
             encoding: "utf8",
@@ -88146,7 +88336,7 @@ var init_managed_automation = __esm({
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 import { writeFileSync as writeFileSync16 } from "node:fs";
-import { join as join46 } from "node:path";
+import { join as join47 } from "node:path";
 import { tmpdir as tmpdir11 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -88178,7 +88368,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join46(tmpdir11(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join47(tmpdir11(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -88757,7 +88947,7 @@ import { createHash as createHash19 } from "node:crypto";
 import { existsSync as existsSync32 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
-import { dirname as dirname25, join as join47 } from "node:path";
+import { dirname as dirname25, join as join48 } from "node:path";
 function parseAllBootedIosDevices(jsonText) {
   let data;
   try {
@@ -88841,15 +89031,15 @@ function candidateRecordScripts(baseDir = dirname25(fileURLToPath4(import.meta.u
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join47(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join47(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join47(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join48(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join48(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join48(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join47(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join48(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join47(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join48(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join47(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join48(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
 function resolveRecordScript(baseDir = dirname25(fileURLToPath4(import.meta.url))) {
@@ -89253,12 +89443,12 @@ function observedAssertionPassed(event) {
   const data = resultEnvelopeData(event.result);
   if (!data || typeof data !== "object")
     return !tool.endsWith("proof_step");
-  const record2 = data;
-  if (tool.endsWith("proof_step") && record2.verified !== true)
+  const record3 = data;
+  if (tool.endsWith("proof_step") && record3.verified !== true)
     return false;
-  if (record2.verified === false || record2.ok === false)
+  if (record3.verified === false || record3.ok === false)
     return false;
-  return !Array.isArray(record2.errors) || record2.errors.length === 0;
+  return !Array.isArray(record3.errors) || record3.errors.length === 0;
 }
 function normalizeToolName(tool) {
   const bare = tool.startsWith("mcp__") ? tool.split("__").at(-1) ?? tool : tool;
@@ -89729,8 +89919,8 @@ var init_startup_integrity = __esm({
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
-import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute15, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
+import { chmodSync as chmodSync8, closeSync as closeSync13, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync18, mkdirSync as mkdirSync21, openSync as openSync13, readFileSync as readFileSync33, realpathSync as realpathSync17, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
+import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute15, join as join49, relative as relative9, resolve as resolve18, sep as sep11 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
   if (!unparsedArgs || typeof unparsedArgs !== "object" || Array.isArray(unparsedArgs)) {
@@ -89771,14 +89961,14 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let coreBundleSha256 = null;
   try {
     if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
-      executedEntrypointPath = realpathSync16(argv[1]);
+      executedEntrypointPath = realpathSync17(argv[1]);
     }
   } catch {
     executedEntrypointPath = null;
   }
   if (attestation) {
     try {
-      loadedCoreBundlePath = realpathSync16(fileURLToPath5(attestation.entrypointUrl));
+      loadedCoreBundlePath = realpathSync17(fileURLToPath5(attestation.entrypointUrl));
       coreBundleSha256 = attestation.coreBundleSha256;
     } catch {
       loadedCoreBundlePath = null;
@@ -89794,7 +89984,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
 }
 function realpathOrSelf(path) {
   try {
-    return realpathSync16(path);
+    return realpathSync17(path);
   } catch {
     return path;
   }
@@ -89802,7 +89992,7 @@ function realpathOrSelf(path) {
 function resolveProofCandidateEntrypoint(candidateRoot, argv) {
   let root;
   try {
-    root = realpathSync16(candidateRoot);
+    root = realpathSync17(candidateRoot);
   } catch {
     return null;
   }
@@ -89811,14 +90001,14 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   let arg;
   try {
-    arg = realpathSync16(authorityArg);
+    arg = realpathSync17(authorityArg);
   } catch {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join48(root, "packages", host);
-    const coreIndex = realpathOrSelf(join48(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join48(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join49(root, "packages", host);
+    const coreIndex = realpathOrSelf(join49(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join49(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -89837,7 +90027,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join48(hostRoot, "bin", "cdp-supervisor.js"))) {
+    if (host === "codex-plugin" && arg === realpathOrSelf(join49(hostRoot, "bin", "cdp-supervisor.js"))) {
       if (!existsSync33(coreIndex) || !existsSync33(coreSupervisor))
         return null;
       return {
@@ -89859,7 +90049,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
     if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
-      return realpathSync16(value);
+      return realpathSync17(value);
     } catch {
       return null;
     }
@@ -89872,7 +90062,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join48(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join49(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -89881,7 +90071,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
 }
 function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   try {
-    const root = realpathSync16(candidateRoot);
+    const root = realpathSync17(candidateRoot);
     const statusArgs = [
       "-C",
       root,
@@ -89894,8 +90084,8 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       return null;
     const verifiedBytes = [];
     for (const artifactPath of artifactPaths) {
-      const resolvedArtifactPath = realpathSync16(artifactPath);
-      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep10).join("/");
+      const resolvedArtifactPath = realpathSync17(artifactPath);
+      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep11).join("/");
       if (!artifactRelativePath || artifactRelativePath === ".." || artifactRelativePath.startsWith("../")) {
         return null;
       }
@@ -89914,7 +90104,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   }
 }
 function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) {
-  const root = realpathSync16(resolve18(candidateRoot));
+  const root = realpathSync17(resolve18(candidateRoot));
   const sha = execFileSync16("git", ["-C", root, "rev-parse", "HEAD"], {
     encoding: "utf8"
   }).trim();
@@ -89930,7 +90120,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join48(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join49(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -89999,14 +90189,14 @@ function isNormalizedDescendant(root, path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep11}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
-  const parts = relative9(root, path).split(sep10);
+  const parts = relative9(root, path).split(sep11);
   for (let length = 0; length <= parts.length; length += 1) {
     const candidate = resolve18(root, ...parts.slice(0, length));
     try {
-      if (lstatSync17(candidate).isSymbolicLink())
+      if (lstatSync18(candidate).isSymbolicLink())
         return true;
     } catch {
     }
@@ -90025,7 +90215,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join48(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join49(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -90039,9 +90229,9 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join48(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join49(args.projectRoot, "docs", "proof", args.runId);
   try {
-    lstatSync17(proofRoot);
+    lstatSync18(proofRoot);
     return true;
   } catch (error2) {
     return error2.code !== "ENOENT";
@@ -90065,15 +90255,15 @@ function parseProofGitChanges(porcelain) {
   const records = porcelain.split("\0");
   const changes = [];
   for (let index = 0; index < records.length; index += 1) {
-    const record2 = records[index];
-    if (!record2 || record2.length < 4)
+    const record3 = records[index];
+    if (!record3 || record3.length < 4)
       continue;
     const change = {
-      path: record2.slice(3).replaceAll("\\", "/"),
-      indexStatus: record2[0],
-      worktreeStatus: record2[1]
+      path: record3.slice(3).replaceAll("\\", "/"),
+      indexStatus: record3[0],
+      worktreeStatus: record3[1]
     };
-    if (/[RC]/.test(record2.slice(0, 2))) {
+    if (/[RC]/.test(record3.slice(0, 2))) {
       const sourcePath = records[index + 1];
       if (sourcePath)
         change.sourcePath = sourcePath.replaceAll("\\", "/");
@@ -90095,7 +90285,7 @@ function readProofGitInfo(root) {
 function proofRootHasTrackedEntries(root, proofRoot) {
   if (!isNormalizedDescendant(root, proofRoot))
     throw new Error("INVALID_PROOF_ROOT");
-  const path = relative9(root, proofRoot).replaceAll(sep10, "/");
+  const path = relative9(root, proofRoot).replaceAll(sep11, "/");
   return execFileSync16("git", ["ls-files", "-z", "--", path], {
     cwd: root,
     encoding: "utf8"
@@ -90192,17 +90382,17 @@ function writeProofReceiptAtomic(path, receipt2) {
   const temporary = resolve18(directory, `.${randomUUID12()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
-    descriptor = openSync12(temporary, "wx", 384);
+    descriptor = openSync13(temporary, "wx", 384);
     writeFileSync17(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
-    closeSync12(descriptor);
+    closeSync13(descriptor);
     descriptor = null;
     renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
-      closeSync12(descriptor);
+      closeSync13(descriptor);
     try {
       unlinkSync16(temporary);
     } catch {
@@ -90364,7 +90554,7 @@ function createProofCaptureHandler(deps) {
       return current.reasons;
     return sameProofAction(current.value, active.actionIdentity) ? [] : ["PROOF_ACTION_IDENTITY_CHANGED"];
   };
-  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep10, "/");
+  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep11, "/");
   const observedSetupScreenshots = (active) => {
     const owned = /* @__PURE__ */ new Set();
     for (const observation of deps.monitor.observations()) {
@@ -90524,7 +90714,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join48(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join49(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -91094,7 +91284,7 @@ import { createHash as createHash22 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir12 } from "node:os";
-import { dirname as dirname27, join as join49 } from "node:path";
+import { dirname as dirname27, join as join50 } from "node:path";
 function fail2(reason) {
   throw new MediaFailure(reason);
 }
@@ -91223,7 +91413,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join49(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join50(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -91248,7 +91438,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join49(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join50(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -91372,7 +91562,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir12();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join49(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join50(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -92594,8 +92784,8 @@ var init_nav_graph = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/auto-login.js
-import { lstatSync as lstatSync18, readFileSync as readFileSync34, readdirSync as readdirSync14, realpathSync as realpathSync17 } from "node:fs";
-import { dirname as dirname28, join as join50, resolve as resolve19 } from "node:path";
+import { lstatSync as lstatSync19, readFileSync as readFileSync34, readdirSync as readdirSync14, realpathSync as realpathSync18 } from "node:fs";
+import { dirname as dirname28, join as join51, resolve as resolve19 } from "node:path";
 function matchesAuthPattern(routeName) {
   const lower = routeName.toLowerCase();
   return AUTH_ROUTE_PATTERNS.some((p) => lower.includes(p));
@@ -92625,13 +92815,13 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join50(projectRoot, ".maestro");
-  const searchDirs = [join50(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join51(projectRoot, ".maestro");
+  const searchDirs = [join51(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
-      const maestroStat = lstatSync18(maestroDir);
-      const dirStat = lstatSync18(dir);
+      const maestroStat = lstatSync19(maestroDir);
+      const dirStat = lstatSync19(dir);
       if (maestroStat.isSymbolicLink() || dirStat.isSymbolicLink()) {
         throw new Error(`Refusing legacy login directory symlink at ${dir}.`);
       }
@@ -92645,17 +92835,17 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join50(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join51(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join50(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join51(dir, authFile));
   }
   return null;
 }
 function assertLegacyLoginFlow(projectRoot, flowPath) {
-  const stat2 = lstatSync18(flowPath);
+  const stat2 = lstatSync19(flowPath);
   if (!stat2.isFile() || stat2.isSymbolicLink()) {
     throw new Error(`Refusing legacy login flow symlink at ${flowPath}.`);
   }
@@ -92681,7 +92871,7 @@ function boundSessionProjectRoot() {
 }
 function canonicalRoot(path) {
   try {
-    return realpathSync17(path);
+    return realpathSync18(path);
   } catch {
     return null;
   }
@@ -92766,7 +92956,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   try {
     const parsed = parseAndValidateFlow(originalContent, {
       flowDir: dirname28(flowPath),
-      flowRoot: join50(projectRoot, ".maestro")
+      flowRoot: join51(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -93351,7 +93541,7 @@ var init_graceful_shutdown = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/maestro-generate.js
-import { basename as basename12, dirname as dirname29, join as join51 } from "node:path";
+import { basename as basename12, dirname as dirname29, join as join52 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -93410,7 +93600,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join51(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join52(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -93493,7 +93683,7 @@ var init_maestro_generate = __esm({
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
-import { basename as basename13, dirname as dirname30, join as join52, resolve as resolve20 } from "node:path";
+import { basename as basename13, dirname as dirname30, join as join53, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function readNestedFlowEnvelope(result) {
   try {
@@ -93519,7 +93709,7 @@ function filterFlows(yamls, pattern) {
 function discoverFlows(dir, pattern) {
   if (!existsSync34(dir))
     return [];
-  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join52(dir, f)).sort();
+  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join53(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -93544,12 +93734,12 @@ function createMaestroTestAllHandler(deps = {}) {
     const requestedDeviceId = args.deviceId ?? matchingSessionDeviceId;
     const engineStatus = await resolveEngineStatus();
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join52(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join53(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve20(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join52(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join53(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
@@ -93582,7 +93772,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if ("error" in dispatch) {
       return failResult(dispatch.error);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join52(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join53(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -93741,7 +93931,7 @@ function createMaestroTestAllHandler(deps = {}) {
           break;
         continue;
       }
-      const safeFlowFile = join52(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      const safeFlowFile = join53(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
@@ -93933,8 +94123,8 @@ var init_maestro_test_all = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cross-platform-verify.js
-import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync19 } from "node:fs";
-import { join as join53, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync20 } from "node:fs";
+import { join as join54, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -93957,9 +94147,9 @@ function discoverTestIDs(dir) {
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join53(d, entry);
+      const full = join54(d, entry);
       try {
-        const st = lstatSync19(full);
+        const st = lstatSync20(full);
         if (st.isSymbolicLink())
           continue;
         if (st.isDirectory()) {
@@ -94328,7 +94518,7 @@ var init_instrumentation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join54 } from "node:path";
+import { join as join55 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -94468,7 +94658,7 @@ function buildLiveDeps(input) {
     readShotFile: input.readShotFile,
     // Preserve Recorder.pushLive's `this` binding.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join54(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join55(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive,
     reportBlocked: input.reportBlocked
   };
@@ -94627,7 +94817,7 @@ import { createServer as createServer3 } from "node:http";
 import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync37 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname31, join as join55 } from "node:path";
+import { dirname as dirname31, join as join56 } from "node:path";
 function listen(server3, port) {
   return new Promise((resolve22, reject) => {
     const onErr = (e) => {
@@ -94893,7 +95083,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync37(join55(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync37(join56(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -95079,10 +95269,10 @@ var init_server3 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
-import { join as join56 } from "node:path";
+import { join as join57 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join56(getStateDir(), "observe", `${safe}.json`);
+  return join57(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -95795,16 +95985,16 @@ var init_target = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname32, join as join57 } from "node:path";
+import { dirname as dirname32, join as join58 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash23 } from "node:crypto";
 function e2eDirFor(projectRoot) {
-  return join57(projectRoot, ".rn-agent", "e2e");
+  return join58(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join57(dir, `${id}.yaml`);
+  const file = join58(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -95921,9 +96111,9 @@ var init_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
-import { join as join58 } from "node:path";
+import { join as join59 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join58(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join59(projectRoot, ".rn-agent", "e2e.config.json");
   try {
     const raw = readFileSync39(filePath, "utf8");
     return JSON.parse(raw);
@@ -96078,7 +96268,7 @@ var init_lock_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
-import { join as join59 } from "node:path";
+import { join as join60 } from "node:path";
 import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
@@ -96133,16 +96323,16 @@ function diffNewlyFailing(current, previousGreen) {
   return current.results.filter((r) => !r.passed && r.classification !== "skipped" && (previousGreen === null || wasPassing.has(r.testId))).map((r) => r.testId);
 }
 function e2eRunsDirFor(projectRoot) {
-  return join59(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join60(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync23(join59(file, ".."), { recursive: true });
+  mkdirSync23(join60(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join59(e2eRunsDirFor(projectRoot), "index.json");
+  const file = join60(e2eRunsDirFor(projectRoot), "index.json");
   if (!existsSync36(file))
     return [];
   try {
@@ -96155,7 +96345,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join59(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join60(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -96163,11 +96353,11 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join59(dir, "index.json"), next);
+  writeJsonAtomic(join60(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join59(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  const file = join60(e2eRunsDirFor(projectRoot), `${runId}.json`);
   if (!existsSync36(file))
     return null;
   try {
@@ -96191,14 +96381,14 @@ var init_e2e_run = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join60 } from "node:path";
+import { join as join61 } from "node:path";
 import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 function requestsDir(projectRoot) {
-  return join60(e2eRunsDirFor(projectRoot), "requests");
+  return join61(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join60(requestsDir(projectRoot), `${runId}.json`);
+  return join61(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
@@ -96377,7 +96567,7 @@ async function runE2eSuiteCore(args, deps = {}) {
   const verdict = computeVerdict(results);
   const prevGreenId = lastGreenRunId(projectRoot);
   const prevGreen = prevGreenId ? loadRunRecord(projectRoot, prevGreenId) : null;
-  const record2 = {
+  const record3 = {
     runId,
     startedAt,
     finishedAt: now().toISOString(),
@@ -96397,13 +96587,13 @@ async function runE2eSuiteCore(args, deps = {}) {
     results,
     previousGreenRunId: prevGreenId
   };
-  writeRunRecord(projectRoot, record2);
+  writeRunRecord(projectRoot, record3);
   return okResult({
     runId,
     verdict,
-    totals: record2.totals,
+    totals: record3.totals,
     results,
-    newlyFailing: diffNewlyFailing(record2, prevGreen),
+    newlyFailing: diffNewlyFailing(record3, prevGreen),
     metroReloaded
   });
 }
@@ -97498,7 +97688,7 @@ import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
-import { dirname as dirname33, join as join61 } from "node:path";
+import { dirname as dirname33, join as join62 } from "node:path";
 function trackedTool(name, desc, schema, handler, afterAuthority) {
   registeredToolNames.push(name);
   const gated = authorityGate.wrap(name, arbiterWrap(name, handler));
@@ -98121,7 +98311,7 @@ var init_index = __esm({
     init_managed_metro();
     init_process_cleanup();
     init_runtime_connection_recovery();
-    pkgPath = join61(dirname33(fileURLToPath7(import.meta.url)), "..", "package.json");
+    pkgPath = join62(dirname33(fileURLToPath7(import.meta.url)), "..", "package.json");
     pkgVersion = JSON.parse(readFileSync42(pkgPath, "utf8")).version;
     lockfile = null;
     diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
@@ -98535,7 +98725,7 @@ var init_index = __esm({
         return null;
       if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
         return null;
-      const secretPath = sessionId ? join61(dirname33(dirname33(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+      const secretPath = sessionId ? join62(dirname33(dirname33(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
       return readJsonStateFile(secretPath)?.signerCapability ?? null;
     };
     spawningSupervisorPid = process.ppid;
@@ -99635,8 +99825,8 @@ var init_index = __esm({
 // packages/rn-dev-agent-core/dist/supervisor.js
 import { randomUUID as randomUUID14 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
-import { lstatSync as lstatSync20, readFileSync as readFileSync43 } from "node:fs";
-import { dirname as dirname34, join as join62, resolve as resolve21 } from "node:path";
+import { lstatSync as lstatSync21, readFileSync as readFileSync43 } from "node:fs";
+import { dirname as dirname34, join as join63, resolve as resolve21 } from "node:path";
 import { fileURLToPath as fileURLToPath8 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/lifecycle/child-error-or-exit.js
@@ -100025,7 +100215,7 @@ function supervisorRelaunchArgs(supervisorPath, sqliteWarningFilterPath2, versio
 
 // packages/rn-dev-agent-core/dist/supervisor.js
 var here = dirname34(fileURLToPath8(import.meta.url));
-var sqliteWarningFilterPath = join62(here, "sqlite-warning-filter.js");
+var sqliteWarningFilterPath = join63(here, "sqlite-warning-filter.js");
 var unsupportedNode = unsupportedNodeVersionMessage();
 if (unsupportedNode) {
   process.stderr.write(`${unsupportedNode}
@@ -100042,12 +100232,12 @@ if (supervisorFlag.length > 0 && !process.execArgv.includes("--experimental-sqli
 }
 function legacyRepairArtifactPresent(cwd) {
   try {
-    if (lstatSync20(join62(cwd, ".rn-agent")).isSymbolicLink())
+    if (lstatSync21(join63(cwd, ".rn-agent")).isSymbolicLink())
       return true;
   } catch {
   }
   try {
-    lstatSync20(join62(cwd, ".rn-agent.bak"));
+    lstatSync21(join63(cwd, ".rn-agent.bak"));
     return true;
   } catch {
     return false;
@@ -100104,7 +100294,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     const workerEnvironment = {
       ...process.env,
       RN_BRIDGE_SUPERVISED: "1",
-      RN_DEV_AGENT_SESSION_CLI: join62(here, "rn-session.js"),
+      RN_DEV_AGENT_SESSION_CLI: join63(here, "rn-session.js"),
       RN_BRIDGE_RESTARTS: String(core.restartCount),
       ...core.lastExit ? { RN_BRIDGE_LAST_EXIT: core.lastExit } : {},
       ...authority && spawnAuthorityError === null ? authority.workerEnvironment(workerInstance) : {
@@ -100176,12 +100366,12 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     force.unref();
   };
   apply = apply2, resolveAuthorityForSpawn = resolveAuthorityForSpawn2, spawnWorker = spawnWorker2, closeAuthorityAndExit = closeAuthorityAndExit2, beginShutdown = beginShutdown2;
-  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ? resolve21(process.env.RN_BRIDGE_WORKER_PATH) : join62(here, "index.js");
+  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ? resolve21(process.env.RN_BRIDGE_WORKER_PATH) : join63(here, "index.js");
   const noLock2 = process.argv.includes("--no-lock");
   const diagnosticContractProbe2 = process.argv.includes("--diagnostic-contract-probe");
   let lockfile2 = null;
   if (!noLock2) {
-    const pkg = JSON.parse(readFileSync43(join62(here, "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync43(join63(here, "..", "package.json"), "utf8"));
     lockfile2 = new Lockfile({ version: pkg.version });
     const lockResult = lockfile2.acquire();
     if (lockResult.status === "conflict") {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/workflow-check.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/workflow-check.js
@@ -10449,13 +10449,16 @@ function fail2(code, message) {
 `);
   process.exit(code);
 }
-function readTextIfFile(filePath) {
+function readTextIfFile(filePath, reportReadError = false) {
   try {
     const stat = fs.lstatSync(filePath);
     if (!stat.isFile())
       return null;
     return fs.readFileSync(filePath, "utf8");
-  } catch {
+  } catch (error) {
+    if (reportReadError && error.code !== "ENOENT") {
+      fail2(2, `workflow-check: cannot read ${path.basename(filePath)}`);
+    }
     return null;
   }
 }
@@ -10559,8 +10562,7 @@ function preflight(projectRoot) {
   const lockManagers = new Set(locks.map((lock) => lock.manager));
   const inferredLock = declaration.kind === "absent" && lockManagers.size === 1 ? locks[0] : null;
   const matchingLock = field === null ? inferredLock : locks.find((lock) => lock.manager === field) ?? null;
-  const claudeMd = readTextIfFile(path.join(projectRoot, "CLAUDE.md"));
-  const claudeMdBlock = claudeMd !== null && claudeMd.includes(TEMPLATE_HEADING) ? "present" : "absent";
+  const claudeMdBlocks = ["CLAUDE.md", "CLAUDE.local.md"].map((file) => readTextIfFile(path.join(projectRoot, file), true)).filter((text) => text !== null && text.includes(TEMPLATE_HEADING));
   const resolvedManager = field ?? inferredLock?.manager ?? null;
   const relativeWorkspaceRoot = redactedWorkspaceRoot(projectRoot, workspaceRoot);
   const modulesPresent = nodeModulesPresent(workspaceRoot);
@@ -10575,8 +10577,8 @@ function preflight(projectRoot) {
     nodeModulesPresent: modulesPresent,
     yarnPnpPresent: pnpPresent,
     dependenciesReady: modulesPresent || resolvedManager === "yarn" && pnpPresent,
-    claudeMdBlock,
-    claudeMdSentinel: claudeMd !== null && claudeMd.includes(TEMPLATE_SENTINEL),
+    claudeMdBlock: claudeMdBlocks.length > 0 ? "present" : "absent",
+    claudeMdSentinel: claudeMdBlocks.some((text) => text.includes(TEMPLATE_SENTINEL)),
     stateRoot: stateRootFacts()
   };
   const where = locationPhrase(relativeWorkspaceRoot);

--- a/packages/claude-plugin/skills/rn-workflow/SKILL.md
+++ b/packages/claude-plugin/skills/rn-workflow/SKILL.md
@@ -61,8 +61,15 @@ node <plugin-root>/rn-dev-agent-core/dist/workflow-check.js preflight --project 
 (`<plugin-root>` = `${CLAUDE_PLUGIN_ROOT}` on Claude, the Codex package root on
 Codex.) It reports `packageManager` (the `packageManager` field wins, lockfile
 inference is the fallback), the exact `installCommand`, `nodeModulesPresent`,
-the Claude instruction block, and the private-state-root kind and existence, with at
-most ONE actionable `stop`.
+`claudeMdBlock`, `claudeMdSentinel`, and the private-state-root kind and
+existence, with at most ONE actionable `stop`.
+
+The Claude facts are read-only: the exact heading in either instruction file
+from Step 0 marks the block present, including legacy heading-only blocks.
+The sentinel fact is true only when a heading and sentinel occur in the same
+file. These facts do not replace Step 0's onboarding decision.
+An instruction-file read error other than a missing file exits 2 with a
+stderr diagnostic and no JSON result; surface it and stop.
 
 In a monorepo the checker resolves the package-manager facts from the nearest
 ancestor that declares `packageManager` or holds a lockfile (bounded by the git

--- a/packages/claude-plugin/skills/rn-workflow/SKILL.md
+++ b/packages/claude-plugin/skills/rn-workflow/SKILL.md
@@ -42,9 +42,11 @@ There is no internal state to track — the only state ever consulted is a fresh
 
 ### Step 0 — Read the authoritative local instructions
 
-Read the project's injected CLAUDE.md block (from
+Read the project's injected block in `CLAUDE.md` or `CLAUDE.local.md` (from
 `## React Native Development (rn-dev-agent)` through
 `<!-- rn-dev-agent:template-end -->`) and `.rn-agent/local/troubleshooting.md`.
+Either instruction file can supply the block; keep shared instructions untouched
+when the block lives in `CLAUDE.local.md`.
 If the block is absent → stop: "project not onboarded — run
 `/rn-dev-agent:setup`". Never start device work on an un-onboarded project.
 
@@ -59,7 +61,7 @@ node <plugin-root>/rn-dev-agent-core/dist/workflow-check.js preflight --project 
 (`<plugin-root>` = `${CLAUDE_PLUGIN_ROOT}` on Claude, the Codex package root on
 Codex.) It reports `packageManager` (the `packageManager` field wins, lockfile
 inference is the fallback), the exact `installCommand`, `nodeModulesPresent`,
-the CLAUDE.md block, and the private-state-root kind and existence, with at
+the Claude instruction block, and the private-state-root kind and existence, with at
 most ONE actionable `stop`.
 
 In a monorepo the checker resolves the package-manager facts from the nearest

--- a/packages/codex-plugin/commands/run-action.md
+++ b/packages/codex-plugin/commands/run-action.md
@@ -169,6 +169,13 @@ $rn-dev-agent:run-action mark-all-done --no-auto-repair    # surface the raw fai
    temporary artifact that is deleted after every run — no report path is
    returned, and none should be looked for.
 
+   A failed replay may also carry `meta.runnerFailureEvidence`, persisted on
+   the RunRecord: a bounded closed-vocabulary projection of each runner
+   failure (exit code, timeout/signal flags, report state, per-command
+   status) marked `incomplete: true`, with text, screenshots, and terminal
+   output withheld. It is diagnostic context only and never changes the
+   outcome, refusal, or auto-repair decision.
+
    When `meta.trailingVerification.trailingVerificationOnly === true`, the
    result remains failed and the goal state remains unproven, but the ledger
    proved every authored mutation completed and only trailing verification

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -424,11 +424,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants10);
+          this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -445,10 +445,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants10);
+        this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -509,8 +509,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants10) {
-        this.code = optimizeExpr(this.code, names, constants10);
+      optimizeNames(names, constants11) {
+        this.code = optimizeExpr(this.code, names, constants11);
         return this;
       }
       get names() {
@@ -539,12 +539,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants10))
+          if (n.optimizeNames(names, constants11))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -597,12 +597,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        if (!(super.optimizeNames(names, constants10) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        if (!(super.optimizeNames(names, constants11) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants10);
+        this.condition = optimizeExpr(this.condition, names, constants11);
         return this;
       }
       get names() {
@@ -625,10 +625,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants10);
+        this.iteration = optimizeExpr(this.iteration, names, constants11);
         return this;
       }
       get names() {
@@ -664,10 +664,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants10);
+        this.iterable = optimizeExpr(this.iterable, names, constants11);
         return this;
       }
       get names() {
@@ -709,11 +709,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a, _b;
-        super.optimizeNames(names, constants10);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants10);
+        super.optimizeNames(names, constants11);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants11);
         return this;
       }
       get names() {
@@ -1014,7 +1014,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants10) {
+    function optimizeExpr(expr, names, constants11) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -1029,14 +1029,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants10[n.str];
+        const c = constants11[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants10[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants11[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -2683,18 +2683,18 @@ var require_validate = __commonJS({
         const { schemaCode } = this;
         this.fail((0, codegen_1._)`${schemaCode} !== undefined && (${(0, codegen_1.or)(this.invalid$data(), condition)})`);
       }
-      error(append, errorParams, errorPaths) {
+      error(append2, errorParams, errorPaths) {
         if (errorParams) {
           this.setParams(errorParams);
-          this._error(append, errorPaths);
+          this._error(append2, errorPaths);
           this.setParams({});
           return;
         }
-        this._error(append, errorPaths);
+        this._error(append2, errorPaths);
       }
-      _error(append, errorPaths) {
+      _error(append2, errorPaths) {
         ;
-        (append ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
+        (append2 ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
       }
       $dataError() {
         (0, errors_1.reportError)(this, this.def.$dataError || errors_1.keyword$DataError);
@@ -11012,17 +11012,17 @@ function getFreshRefTarget(ref, opts = {}) {
     return null;
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
   const rect = refMap.get(key);
-  const record2 = metadataMap.get(key);
-  if (!rect || !record2 || record2.snapshotGeneration !== snapshotGeneration || record2.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
+  const record3 = metadataMap.get(key);
+  if (!rect || !record3 || record3.snapshotGeneration !== snapshotGeneration || record3.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
     return null;
   return {
     rect,
-    snapshotGeneration: record2.snapshotGeneration,
-    snapshotNodeIndex: record2.snapshotNodeIndex,
-    snapshotElementType: record2.type,
-    ...record2.label !== void 0 ? { snapshotLabel: record2.label } : {},
-    ...record2.identifier !== void 0 ? { snapshotIdentifier: record2.identifier } : {},
-    keyboardStateAtSnapshot: record2.keyboardStateAtSnapshot
+    snapshotGeneration: record3.snapshotGeneration,
+    snapshotNodeIndex: record3.snapshotNodeIndex,
+    snapshotElementType: record3.type,
+    ...record3.label !== void 0 ? { snapshotLabel: record3.label } : {},
+    ...record3.identifier !== void 0 ? { snapshotIdentifier: record3.identifier } : {},
+    keyboardStateAtSnapshot: record3.keyboardStateAtSnapshot
   };
 }
 function getCachedMetadata(ref) {
@@ -19530,10 +19530,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -19547,7 +19547,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep11) {
+          if (!keyProps.anchor && !keyProps.tag && !sep12) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -19571,7 +19571,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+        const valueProps = resolveProps.resolveProps(sep12 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -19587,7 +19587,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep11, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep12, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -19678,7 +19678,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep11 = "";
+        let sep12 = "";
         for (const token2 of end) {
           const { source, type } = token2;
           switch (type) {
@@ -19692,13 +19692,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep11 + cb;
-              sep11 = "";
+                comment += sep12 + cb;
+              sep12 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep11 += source;
+                sep12 += source;
               hasSpace = true;
               break;
             default:
@@ -19741,18 +19741,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep11 && !value) {
+          if (!props.anchor && !props.tag && !sep12 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -19806,8 +19806,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep11 && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep11, null, props, onError);
+        if (!isMap && !sep12 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep12, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -19819,7 +19819,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+          const valueProps = resolveProps.resolveProps(sep12 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -19830,8 +19830,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep11)
-                for (const st of sep11) {
+              if (sep12)
+                for (const st of sep12) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -19848,7 +19848,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep11, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep12, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -20028,7 +20028,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep11 = "";
+      let sep12 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -20045,24 +20045,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep11 === " ")
-            sep11 = "\n";
-          else if (!prevMoreIndented && sep11 === "\n")
-            sep11 = "\n\n";
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          if (sep12 === " ")
+            sep12 = "\n";
+          else if (!prevMoreIndented && sep12 === "\n")
+            sep12 = "\n\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep11 === "\n")
+          if (sep12 === "\n")
             value += "\n";
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          value += sep11 + content;
-          sep11 = " ";
+          value += sep12 + content;
+          sep12 = " ";
           prevMoreIndented = false;
         }
       }
@@ -20244,25 +20244,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep11 = " ";
+      let sep12 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep11 === "\n")
-            res += sep11;
+          if (sep12 === "\n")
+            res += sep12;
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          res += sep11 + match[1];
-          sep11 = " ";
+          res += sep12 + match[1];
+          sep12 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep11 + (match?.[1] ?? "");
+      return res + sep12 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -21072,14 +21072,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep: sep11, value }) {
+    function stringifyItem({ start, key, sep: sep12, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep11)
-        for (const st of sep11)
+      if (sep12)
+        for (const st of sep12)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -22246,18 +22246,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep11;
+          let sep12;
           if (scalar.end) {
-            sep11 = scalar.end;
-            sep11.push(this.sourceToken);
+            sep12 = scalar.end;
+            sep12.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep11 = [this.sourceToken];
+            sep12 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep: sep11 }]
+            items: [{ start, key: scalar, sep: sep12 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -22410,15 +22410,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep11 = it.sep;
-                  sep11.push(this.sourceToken);
+                  const sep12 = it.sep;
+                  sep12.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep: sep11 }]
+                    items: [{ start: start2, key, sep: sep12 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -22612,13 +22612,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep11 = fc.end.splice(1, fc.end.length);
-            sep11.push(this.sourceToken);
+            const sep12 = fc.end.splice(1, fc.end.length);
+            sep12.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep: sep11 }]
+              items: [{ start, key: fc, sep: sep12 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -23332,7 +23332,7 @@ function recordNavigation(projectRoot, input) {
   if (!targetScreen)
     return null;
   const now = (/* @__PURE__ */ new Date()).toISOString();
-  const record2 = {
+  const record3 = {
     method: input.method,
     success: input.success,
     latency_ms: input.latency_ms ?? 0,
@@ -23340,7 +23340,7 @@ function recordNavigation(projectRoot, input) {
   };
   if (!targetScreen.action_records)
     targetScreen.action_records = [];
-  targetScreen.action_records.push(record2);
+  targetScreen.action_records.push(record3);
   if (targetScreen.action_records.length > MAX_ACTION_RECORDS) {
     targetScreen.action_records = targetScreen.action_records.slice(-MAX_ACTION_RECORDS);
   }
@@ -25277,10 +25277,10 @@ function referencesMetroEvidenceSocket(value, path) {
   }
   if (!value || typeof value !== "object")
     return false;
-  const record2 = value;
-  if (record2.runtimeEvidenceSocket === path)
+  const record3 = value;
+  if (record3.runtimeEvidenceSocket === path)
     return true;
-  return Object.values(record2).some((entry) => referencesMetroEvidenceSocket(entry, path));
+  return Object.values(record3).some((entry) => referencesMetroEvidenceSocket(entry, path));
 }
 function authorityRemedyNextAction(code) {
   return errorNextActions[code];
@@ -25350,14 +25350,14 @@ function readStartupCleanupBlocker(bindingsJson) {
   const refusal = journal.refusal;
   if (!refusal || typeof refusal !== "object")
     return void 0;
-  const record2 = refusal;
-  if (typeof record2.code !== "string" || typeof record2.reason !== "string")
+  const record3 = refusal;
+  if (typeof record3.code !== "string" || typeof record3.reason !== "string")
     return void 0;
   return {
-    code: record2.code,
-    reason: record2.reason,
-    ...record2.cause === "managed-metro-stop-proof-missing" ? { cause: record2.cause } : {},
-    ...typeof record2.nextAction === "string" ? { nextAction: record2.nextAction } : {}
+    code: record3.code,
+    reason: record3.reason,
+    ...record3.cause === "managed-metro-stop-proof-missing" ? { cause: record3.cause } : {},
+    ...typeof record3.nextAction === "string" ? { nextAction: record3.nextAction } : {}
   };
 }
 function bindingsRunnerPresent(bindingsJson) {
@@ -26297,21 +26297,21 @@ var init_registry = __esm({
               integration: existing.integration ?? null
             };
           }
-          const record2 = (value) => value && typeof value === "object" ? { ...value } : null;
+          const record3 = (value) => value && typeof value === "object" ? { ...value } : null;
           const obligation = (source, claimKey) => source ? {
             ...source,
             claimKey: String(source.claimKey ?? claimKey ?? ""),
             stopRequestedAt: typeof source.stopRequestedAt === "number" ? source.stopRequestedAt : now,
             completedAt: typeof source.completedAt === "number" ? source.completedAt : null
           } : void 0;
-          const handoffCleanup = record2(bindings.handoffCleanup);
-          const staleDevice = record2(bindings.staleDeviceCleanup);
-          const androidMetroReverseSource = record2(bindings.androidMetroReverse) ?? record2(staleDevice?.androidMetroReverse);
-          const recorderSource = record2(bindings.recorder) ?? record2(staleDevice?.recorder) ?? record2(handoffCleanup?.recorder);
-          const runnerSource = record2(bindings.runner) ?? record2(staleDevice?.runner) ?? record2(handoffCleanup?.runner);
-          const observeSource = record2(bindings.observe) ?? record2(handoffCleanup?.observe);
-          const liveMetro = record2(bindings.metroCleanup) ?? record2(bindings.metro);
-          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record2(handoffCleanup?.metro);
+          const handoffCleanup = record3(bindings.handoffCleanup);
+          const staleDevice = record3(bindings.staleDeviceCleanup);
+          const androidMetroReverseSource = record3(bindings.androidMetroReverse) ?? record3(staleDevice?.androidMetroReverse);
+          const recorderSource = record3(bindings.recorder) ?? record3(staleDevice?.recorder) ?? record3(handoffCleanup?.recorder);
+          const runnerSource = record3(bindings.runner) ?? record3(staleDevice?.runner) ?? record3(handoffCleanup?.runner);
+          const observeSource = record3(bindings.observe) ?? record3(handoffCleanup?.observe);
+          const liveMetro = record3(bindings.metroCleanup) ?? record3(bindings.metro);
+          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record3(handoffCleanup?.metro);
           const obligations = {};
           const androidMetroReverseEntry = obligation(androidMetroReverseSource, androidMetroReverseSource ? `android:${String(androidMetroReverseSource.deviceId)}` : null);
           if (androidMetroReverseEntry) {
@@ -26329,7 +26329,7 @@ var init_registry = __esm({
           const metroEntry = obligation(metroSource, metroSource ? String(metroSource.port) : null);
           if (metroEntry)
             obligations.metro = metroEntry;
-          const integrationBinding = record2(bindings.packageIntegration);
+          const integrationBinding = record3(bindings.packageIntegration);
           const integration = integrationBinding ? {
             installedBySessionId: integrationBinding.installedBySessionId ?? null,
             manifestSha256: integrationBinding.manifestSha256 ?? null,
@@ -26584,8 +26584,8 @@ var init_registry = __esm({
       #bindingMatchesDevice(binding, target) {
         if (!binding || typeof binding !== "object")
           return false;
-        const record2 = binding;
-        return record2.platform === target.platform && record2.deviceId === target.deviceId;
+        const record3 = binding;
+        return record3.platform === target.platform && record3.deviceId === target.deviceId;
       }
       #requireProvenDeadOwner(sessionId, claimEpoch) {
         const prior = asSession(this.#database.prepare(`SELECT session_id, claim_epoch, state, supervisor_pid, supervisor_birth, bindings_json
@@ -36358,7 +36358,7 @@ import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
-import { dirname as dirname31, join as join60 } from "node:path";
+import { dirname as dirname31, join as join61 } from "node:path";
 
 // node_modules/zod/v3/external.js
 var external_exports = {};
@@ -58943,10 +58943,10 @@ function openActionDb(projectRoot, opts = {}) {
     const handle = {
       db,
       close: () => db.close(),
-      insertRunRecord(actionId, record2) {
+      insertRunRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
@@ -58955,7 +58955,7 @@ function openActionDb(projectRoot, opts = {}) {
                (action_id, ts, trigger, status, failure_code, failure_detail,
                 transport, auto_repair_json, duration_ms, device_id, blind_probe_json,
                 trailing_verification_json)
-             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.trigger, record2.status, record2.failureCode ?? null, record2.failureDetail ?? null, record2.transport ?? null, record2.autoRepair ? JSON.stringify(record2.autoRepair) : null, record2.durationMs, record2.deviceId ?? null, record2.blindProbe ? JSON.stringify(record2.blindProbe) : null, record2.trailingVerification ? JSON.stringify(record2.trailingVerification) : null);
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.trigger, record3.status, record3.failureCode ?? null, record3.failureDetail ?? null, record3.transport ?? null, record3.autoRepair ? JSON.stringify(record3.autoRepair) : null, record3.durationMs, record3.deviceId ?? null, record3.blindProbe ? JSON.stringify(record3.blindProbe) : null, record3.trailingVerification ? JSON.stringify(record3.trailingVerification) : null);
           db.prepare(`DELETE FROM run_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -58970,17 +58970,17 @@ function openActionDb(projectRoot, opts = {}) {
           throw e;
         }
       },
-      insertRepairRecord(actionId, record2) {
+      insertRepairRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
           }
           db.prepare(`INSERT INTO repair_records
                (action_id, ts, failure_code, diff_json, duration_ms, agent_reasoning)
-             VALUES (?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.failureCode, JSON.stringify(record2.diff ?? {}), record2.durationMs, record2.agentReasoning ?? null);
+             VALUES (?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.failureCode, JSON.stringify(record3.diff ?? {}), record3.durationMs, record3.agentReasoning ?? null);
           db.prepare(`DELETE FROM repair_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -59151,36 +59151,36 @@ function freshRuntimeState(now = () => /* @__PURE__ */ new Date(), mtimeMs = 0) 
     }
   };
 }
-function appendRunRecord(state, record2) {
-  const newHistory = [...state.runHistory, record2];
+function appendRunRecord(state, record3) {
+  const newHistory = [...state.runHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.RUN_HISTORY_MAX)
     newHistory.shift();
   const totalRuns = state.stats.totalRuns + 1;
-  const successCount = state.stats.successCount + (record2.status === "pass" ? 1 : 0);
-  const failureCount = state.stats.failureCount + (record2.status === "fail" ? 1 : 0);
+  const successCount = state.stats.successCount + (record3.status === "pass" ? 1 : 0);
+  const failureCount = state.stats.failureCount + (record3.status === "fail" ? 1 : 0);
   const successDurations = newHistory.filter((r) => r.status === "pass").map((r) => r.durationMs);
   const avgDurationMs = successDurations.length ? Math.round(successDurations.reduce((s, n) => s + n, 0) / successDurations.length) : state.stats.avgDurationMs;
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     runHistory: newHistory,
     stats: {
       totalRuns,
       successCount,
       failureCount,
       avgDurationMs,
-      lastSuccessAt: record2.status === "pass" ? record2.timestamp : state.stats.lastSuccessAt,
-      lastFailureAt: record2.status === "fail" ? record2.timestamp : state.stats.lastFailureAt
+      lastSuccessAt: record3.status === "pass" ? record3.timestamp : state.stats.lastSuccessAt,
+      lastFailureAt: record3.status === "fail" ? record3.timestamp : state.stats.lastFailureAt
     }
   };
 }
-function appendRepairRecord(state, record2) {
-  const newHistory = [...state.repairHistory, record2];
+function appendRepairRecord(state, record3) {
+  const newHistory = [...state.repairHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.REPAIR_HISTORY_MAX)
     newHistory.shift();
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     revision: state.revision + 1,
     repairHistory: newHistory
   };
@@ -73853,11 +73853,11 @@ function redactBatchFillSteps(args) {
   const redactedSteps = steps.map((step) => {
     if (!step || typeof step !== "object" || Array.isArray(step))
       return step;
-    const record2 = step;
-    if (record2.action !== "fill")
+    const record3 = step;
+    if (record3.action !== "fill")
       return step;
-    const redacted = redactTypedValue(record2, "text");
-    if (redacted !== record2)
+    const redacted = redactTypedValue(record3, "text");
+    if (redacted !== record3)
       changed = true;
     return redacted;
   });
@@ -77140,8 +77140,8 @@ function acknowledgeExternalEdit(action) {
 function canonicalRuntimeJson(state) {
   return JSON.stringify(state, (_key, value) => {
     if (value && typeof value === "object" && !Array.isArray(value)) {
-      const record2 = value;
-      return Object.fromEntries(Object.keys(record2).sort().map((k) => [k, record2[k]]));
+      const record3 = value;
+      return Object.fromEntries(Object.keys(record3).sort().map((k) => [k, record3[k]]));
     }
     return value;
   });
@@ -78744,6 +78744,359 @@ function createSaveAsActionHandler() {
 }
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
+init_agent_device_wrapper();
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+import { closeSync as closeSync11, constants as constants10, fstatSync as fstatSync9, lstatSync as lstatSync17, openSync as openSync11, readSync as readSync5, realpathSync as realpathSync15 } from "node:fs";
+import { join as join42, sep as sep10 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
+import { existsSync as existsSync28, readFileSync as readFileSync28, readdirSync as readdirSync11, realpathSync as realpathSync14, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash14 } from "node:crypto";
+import { tmpdir as tmpdir8 } from "node:os";
+import { isAbsolute as isAbsolute14, join as join41, sep as sep9 } from "node:path";
+var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
+var WEAK_DEVICE_ID_KEYS = ["id"];
+var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
+function idsFrom(value, keys) {
+  if (!value || typeof value !== "object")
+    return [];
+  const record3 = value;
+  for (const key of keys) {
+    const id = record3[key];
+    if (typeof id === "string")
+      return [id];
+  }
+  return [];
+}
+function deviceIdsFrom(value) {
+  return idsFrom(value, DEVICE_ID_KEYS);
+}
+function weakDeviceIdsFrom(value) {
+  if (typeof value === "string")
+    return [value];
+  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
+}
+function containerDeviceIdsFrom(value) {
+  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
+}
+function reportDeviceIds(reportDir) {
+  const reportPath = join41(reportDir, "report.json");
+  if (!existsSync28(reportPath))
+    return { ids: [], strength: "none" };
+  try {
+    const report = JSON.parse(readFileSync28(reportPath, "utf8"));
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    const devices = [report.device, ...flows.map((flow) => flow?.device)];
+    const strong = [
+      ...devices.flatMap((device) => deviceIdsFrom(device)),
+      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
+    ];
+    const usingStrong = strong.length > 0;
+    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
+    const accepted = [
+      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
+    ];
+    return {
+      ids: accepted,
+      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
+    };
+  } catch {
+    return { ids: [], strength: "none" };
+  }
+}
+function createRunnerReportDir(runner, prefix) {
+  if (runner !== "maestro-runner")
+    return null;
+  return join41(tmpdir8(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+}
+function runnerReportArgs(reportDir) {
+  return reportDir ? ["--output", reportDir, "--flatten"] : [];
+}
+function collectDirectRunnerEvidence(reportDir, output) {
+  if (!reportDir)
+    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
+  const report = reportDeviceIds(reportDir);
+  const evidence = {
+    output,
+    reportDeviceIds: report.ids,
+    reportDeviceIdStrength: report.strength
+  };
+  const logPath = join41(reportDir, "maestro-runner.log");
+  if (!existsSync28(logPath))
+    return evidence;
+  try {
+    evidence.output = `${output}
+${readFileSync28(logPath, "utf8")}`;
+  } catch {
+  }
+  return evidence;
+}
+var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
+  "passed",
+  "failed",
+  "skipped",
+  "running",
+  "pending"
+]);
+function observationStatus(value) {
+  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
+}
+var FINGERPRINT_INCONCLUSIVE = "unreadable";
+function contentHash(path) {
+  try {
+    return createHash14("sha256").update(readFileSync28(path)).digest("hex");
+  } catch (error2) {
+    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
+  }
+}
+function runnerReportFingerprint(reportDir) {
+  const fingerprint = {};
+  if (!reportDir)
+    return fingerprint;
+  const reportHash = contentHash(join41(reportDir, "report.json"));
+  if (reportHash)
+    fingerprint["report.json"] = reportHash;
+  let flowEntries = [];
+  try {
+    flowEntries = readdirSync11(join41(reportDir, "flows"));
+  } catch (error2) {
+    if (error2?.code !== "ENOENT") {
+      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
+    }
+    return fingerprint;
+  }
+  for (const entry of flowEntries.sort()) {
+    const flowHash = contentHash(join41(reportDir, "flows", entry));
+    if (flowHash)
+      fingerprint[`flows/${entry}`] = flowHash;
+  }
+  return fingerprint;
+}
+function readStructuredFlowArtifact(reportDir, previous, readText = (path) => readFileSync28(path, "utf8")) {
+  if (!reportDir)
+    return null;
+  const reportPath = join41(reportDir, "report.json");
+  if (!existsSync28(reportPath))
+    return null;
+  const unfinalized = {
+    finalized: false,
+    flowStatus: "unknown",
+    commands: []
+  };
+  try {
+    const reportText = readText(reportPath);
+    if (previous) {
+      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
+        return unfinalized;
+      const reportHash = createHash14("sha256").update(reportText).digest("hex");
+      if (previous["report.json"] === reportHash)
+        return null;
+    }
+    const report = JSON.parse(reportText);
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    if (flows.length !== 1)
+      return unfinalized;
+    const flow = flows[0];
+    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
+    if (flowStatus === "unknown")
+      return unfinalized;
+    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
+      return unfinalized;
+    const normalizedDataFile = flow.dataFile;
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+      return unfinalized;
+    }
+    const realDataFile = realpathSync14(join41(reportDir, normalizedDataFile));
+    if (!realDataFile.startsWith(realpathSync14(reportDir) + sep9))
+      return unfinalized;
+    const dataText = readText(realDataFile);
+    if (previous) {
+      const dataHash = createHash14("sha256").update(dataText).digest("hex");
+      if (previous[normalizedDataFile] === dataHash)
+        return unfinalized;
+    }
+    const data = JSON.parse(dataText);
+    if (!Array.isArray(data.commands))
+      return unfinalized;
+    let malformedRow = false;
+    const seenIndices = /* @__PURE__ */ new Set();
+    const commands = data.commands.map((entry) => {
+      const record3 = entry ?? {};
+      const error2 = record3.error ?? void 0;
+      const status = observationStatus(record3.status);
+      const producerIndex = typeof record3.index === "number" && Number.isInteger(record3.index) && record3.index >= 0 ? record3.index : null;
+      if (producerIndex === null || seenIndices.has(producerIndex)) {
+        malformedRow = true;
+      } else {
+        seenIndices.add(producerIndex);
+      }
+      if (typeof record3.type !== "string" || record3.type.length === 0 || status === "unknown") {
+        malformedRow = true;
+      }
+      return {
+        index: producerIndex ?? -1,
+        type: typeof record3.type === "string" ? record3.type : "unknown",
+        status,
+        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
+      };
+    });
+    if (malformedRow)
+      return { finalized: false, flowStatus, commands: [] };
+    const counts = flow.commands ?? {};
+    const statusCount = (status) => commands.filter((command) => command.status === status).length;
+    const countExact = (key, actual) => counts[key] === actual;
+    const anyFailedRow = commands.some((command) => command.status === "failed");
+    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
+    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
+    return { finalized, flowStatus, commands };
+  } catch {
+    return unfinalized;
+  }
+}
+function disposeRunnerReportDir(reportDir) {
+  if (!reportDir)
+    return;
+  try {
+    rmSync11(reportDir, { recursive: true, force: true });
+  } catch {
+  }
+}
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+var MAX_CAPTURES = 8;
+var MAX_ROWS = 64;
+var MAX_REPORT_BYTES = 256 * 1024;
+var STATUSES = ["passed", "failed", "skipped", "running", "pending", "unknown"];
+var REPORT_STATES = ["missing", "unavailable", "oversized", "unfinalized", "finalized"];
+function createRunnerFailureEvidence() {
+  return {
+    version: 1,
+    incomplete: true,
+    withheld: "text-images-terminal-output-and-original-artifacts",
+    capturesTruncated: false,
+    captures: []
+  };
+}
+function append(evidence, capture) {
+  evidence.captures.push(capture);
+  if (evidence.captures.length > MAX_CAPTURES) {
+    evidence.captures.splice(1, 1);
+    evidence.capturesTruncated = true;
+  }
+}
+function captureRunnerFailure(evidence, reportDir, previous, stage, invocation, termination, attempt = 1) {
+  const capture = {
+    attempt,
+    stage,
+    invocation,
+    exitCode: Number.isSafeInteger(termination.exitCode) ? termination.exitCode : null,
+    signalPresent: termination.signal !== null,
+    timedOut: termination.timedOut,
+    outputTruncated: termination.outputTruncated,
+    bootstrapFailure: termination.bootstrapFailure,
+    transportFailure: termination.transportFailure,
+    report: "missing",
+    rowsTruncated: false,
+    commands: []
+  };
+  try {
+    if (reportDir) {
+      if (!lstatSync17(reportDir).isDirectory())
+        throw new Error();
+      const root = realpathSync15(reportDir);
+      const reportPath = join42(root, "report.json");
+      lstatSync17(reportPath);
+      let readFailure;
+      let remaining = MAX_REPORT_BYTES;
+      const artifact = readStructuredFlowArtifact(root, previous, (path) => {
+        let fd;
+        try {
+          if (!realpathSync15(path).startsWith(root + sep10))
+            throw new Error();
+          fd = openSync11(path, constants10.O_RDONLY | constants10.O_NOFOLLOW);
+          const stat2 = fstatSync9(fd);
+          if (!stat2.isFile())
+            throw new Error();
+          if (stat2.size > remaining) {
+            readFailure = "oversized";
+            throw new Error();
+          }
+          const bytes = Buffer.alloc(stat2.size + 1);
+          const size = readSync5(fd, bytes, 0, bytes.length, 0);
+          if (size !== stat2.size || fstatSync9(fd).size !== size)
+            throw new Error();
+          remaining -= size;
+          return bytes.subarray(0, size).toString("utf8");
+        } catch (error2) {
+          readFailure ??= "unavailable";
+          throw error2;
+        } finally {
+          if (fd !== void 0)
+            closeSync11(fd);
+        }
+      });
+      capture.report = readFailure ?? (artifact ? artifact.finalized ? "finalized" : "unfinalized" : "missing");
+      if (artifact?.finalized && !readFailure) {
+        capture.rowsTruncated = artifact.commands.length > MAX_ROWS;
+        const rows = [...artifact.commands].sort((a, b) => Number(b.status === "failed") - Number(a.status === "failed"));
+        capture.commands = rows.slice(0, MAX_ROWS).map((row) => ({
+          index: row.index,
+          status: row.status,
+          errorPresent: row.error !== void 0
+        }));
+      }
+    }
+  } catch (error2) {
+    capture.report = error2.code === "ENOENT" ? "missing" : "unavailable";
+  }
+  append(evidence, capture);
+}
+function record2(value) {
+  return value !== null && typeof value === "object" ? value : {};
+}
+function collectRunnerFailureEvidence(evidence, value) {
+  const input = record2(value);
+  if (input.version !== 1 || !Array.isArray(input.captures))
+    return;
+  evidence.capturesTruncated ||= input.capturesTruncated === true || input.captures.length > MAX_CAPTURES;
+  const captures = input.captures.length > MAX_CAPTURES ? [input.captures[0], ...input.captures.slice(-(MAX_CAPTURES - 1))] : input.captures;
+  for (const item of captures) {
+    const row = record2(item);
+    if (!Number.isSafeInteger(row.stage) || !Number.isSafeInteger(row.invocation))
+      continue;
+    const state = REPORT_STATES.find((state2) => state2 === row.report) ?? "unavailable";
+    const commands = Array.isArray(row.commands) ? row.commands : [];
+    append(evidence, {
+      attempt: Number.isSafeInteger(row.attempt) ? Number(row.attempt) : 1,
+      stage: Number(row.stage),
+      invocation: Number(row.invocation),
+      exitCode: Number.isSafeInteger(row.exitCode) ? Number(row.exitCode) : null,
+      signalPresent: row.signalPresent === true,
+      timedOut: row.timedOut === true,
+      outputTruncated: row.outputTruncated === true,
+      bootstrapFailure: row.bootstrapFailure === true,
+      transportFailure: row.transportFailure === true,
+      report: state,
+      rowsTruncated: row.rowsTruncated === true || commands.length > MAX_ROWS,
+      commands: commands.slice(0, MAX_ROWS).flatMap((item2) => {
+        const command = record2(item2);
+        if (!Number.isSafeInteger(command.index))
+          return [];
+        return [
+          {
+            index: Number(command.index),
+            status: STATUSES.find((status) => status === command.status) ?? "unknown",
+            errorPresent: command.errorPresent === true
+          }
+        ];
+      })
+    });
+  }
+}
+
+// packages/rn-dev-agent-core/dist/tools/run-action.js
 init_utils();
 import { randomUUID as randomUUID9 } from "node:crypto";
 
@@ -78924,7 +79277,7 @@ import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
 import { existsSync as existsSync29, readFileSync as readFileSync29, writeFileSync as writeFileSync13 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
-import { basename as basename10, join as join42, dirname as dirname21 } from "node:path";
+import { basename as basename10, join as join43, dirname as dirname21 } from "node:path";
 init_agent_device_wrapper();
 init_project_config();
 
@@ -79250,220 +79603,6 @@ function maestroAuthorityRefusal(authority, underlyingError) {
     return null;
   const headline = `Maestro device authority refused: requested ${authority.requestedDeviceId}, direct runner/WDA evidence was ${authority.reportedDeviceId ?? "missing"} (${authority.reason}).`;
   return underlyingError ? `${headline} Underlying failure: ${underlyingError}` : headline;
-}
-
-// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
-import { existsSync as existsSync28, readFileSync as readFileSync28, readdirSync as readdirSync11, realpathSync as realpathSync14, rmSync as rmSync11 } from "node:fs";
-import { createHash as createHash14 } from "node:crypto";
-import { tmpdir as tmpdir8 } from "node:os";
-import { isAbsolute as isAbsolute14, join as join41, sep as sep9 } from "node:path";
-var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
-var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
-var WEAK_DEVICE_ID_KEYS = ["id"];
-var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
-function idsFrom(value, keys) {
-  if (!value || typeof value !== "object")
-    return [];
-  const record2 = value;
-  for (const key of keys) {
-    const id = record2[key];
-    if (typeof id === "string")
-      return [id];
-  }
-  return [];
-}
-function deviceIdsFrom(value) {
-  return idsFrom(value, DEVICE_ID_KEYS);
-}
-function weakDeviceIdsFrom(value) {
-  if (typeof value === "string")
-    return [value];
-  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
-}
-function containerDeviceIdsFrom(value) {
-  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
-}
-function reportDeviceIds(reportDir) {
-  const reportPath = join41(reportDir, "report.json");
-  if (!existsSync28(reportPath))
-    return { ids: [], strength: "none" };
-  try {
-    const report = JSON.parse(readFileSync28(reportPath, "utf8"));
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    const devices = [report.device, ...flows.map((flow) => flow?.device)];
-    const strong = [
-      ...devices.flatMap((device) => deviceIdsFrom(device)),
-      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
-    ];
-    const usingStrong = strong.length > 0;
-    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
-    const accepted = [
-      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
-    ];
-    return {
-      ids: accepted,
-      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
-    };
-  } catch {
-    return { ids: [], strength: "none" };
-  }
-}
-function createRunnerReportDir(runner, prefix) {
-  if (runner !== "maestro-runner")
-    return null;
-  return join41(tmpdir8(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-}
-function runnerReportArgs(reportDir) {
-  return reportDir ? ["--output", reportDir, "--flatten"] : [];
-}
-function collectDirectRunnerEvidence(reportDir, output) {
-  if (!reportDir)
-    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
-  const report = reportDeviceIds(reportDir);
-  const evidence = {
-    output,
-    reportDeviceIds: report.ids,
-    reportDeviceIdStrength: report.strength
-  };
-  const logPath = join41(reportDir, "maestro-runner.log");
-  if (!existsSync28(logPath))
-    return evidence;
-  try {
-    evidence.output = `${output}
-${readFileSync28(logPath, "utf8")}`;
-  } catch {
-  }
-  return evidence;
-}
-var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
-  "passed",
-  "failed",
-  "skipped",
-  "running",
-  "pending"
-]);
-function observationStatus(value) {
-  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
-}
-var FINGERPRINT_INCONCLUSIVE = "unreadable";
-function contentHash(path) {
-  try {
-    return createHash14("sha256").update(readFileSync28(path)).digest("hex");
-  } catch (error2) {
-    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
-  }
-}
-function runnerReportFingerprint(reportDir) {
-  const fingerprint = {};
-  if (!reportDir)
-    return fingerprint;
-  const reportHash = contentHash(join41(reportDir, "report.json"));
-  if (reportHash)
-    fingerprint["report.json"] = reportHash;
-  let flowEntries = [];
-  try {
-    flowEntries = readdirSync11(join41(reportDir, "flows"));
-  } catch (error2) {
-    if (error2?.code !== "ENOENT") {
-      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
-    }
-    return fingerprint;
-  }
-  for (const entry of flowEntries.sort()) {
-    const flowHash = contentHash(join41(reportDir, "flows", entry));
-    if (flowHash)
-      fingerprint[`flows/${entry}`] = flowHash;
-  }
-  return fingerprint;
-}
-function readStructuredFlowArtifact(reportDir, previous) {
-  if (!reportDir)
-    return null;
-  const reportPath = join41(reportDir, "report.json");
-  if (!existsSync28(reportPath))
-    return null;
-  const unfinalized = {
-    finalized: false,
-    flowStatus: "unknown",
-    commands: []
-  };
-  try {
-    const reportText = readFileSync28(reportPath, "utf8");
-    if (previous) {
-      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
-        return unfinalized;
-      const reportHash = createHash14("sha256").update(reportText).digest("hex");
-      if (previous["report.json"] === reportHash)
-        return null;
-    }
-    const report = JSON.parse(reportText);
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    if (flows.length !== 1)
-      return unfinalized;
-    const flow = flows[0];
-    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
-    if (flowStatus === "unknown")
-      return unfinalized;
-    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
-      return unfinalized;
-    const normalizedDataFile = flow.dataFile;
-    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
-      return unfinalized;
-    }
-    const realDataFile = realpathSync14(join41(reportDir, normalizedDataFile));
-    if (!realDataFile.startsWith(realpathSync14(reportDir) + sep9))
-      return unfinalized;
-    const dataText = readFileSync28(realDataFile, "utf8");
-    if (previous) {
-      const dataHash = createHash14("sha256").update(dataText).digest("hex");
-      if (previous[normalizedDataFile] === dataHash)
-        return unfinalized;
-    }
-    const data = JSON.parse(dataText);
-    if (!Array.isArray(data.commands))
-      return unfinalized;
-    let malformedRow = false;
-    const seenIndices = /* @__PURE__ */ new Set();
-    const commands = data.commands.map((entry) => {
-      const record2 = entry ?? {};
-      const error2 = record2.error ?? void 0;
-      const status = observationStatus(record2.status);
-      const producerIndex = typeof record2.index === "number" && Number.isInteger(record2.index) && record2.index >= 0 ? record2.index : null;
-      if (producerIndex === null || seenIndices.has(producerIndex)) {
-        malformedRow = true;
-      } else {
-        seenIndices.add(producerIndex);
-      }
-      if (typeof record2.type !== "string" || record2.type.length === 0 || status === "unknown") {
-        malformedRow = true;
-      }
-      return {
-        index: producerIndex ?? -1,
-        type: typeof record2.type === "string" ? record2.type : "unknown",
-        status,
-        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
-      };
-    });
-    if (malformedRow)
-      return { finalized: false, flowStatus, commands: [] };
-    const counts = flow.commands ?? {};
-    const statusCount = (status) => commands.filter((command) => command.status === status).length;
-    const countExact = (key, actual) => counts[key] === actual;
-    const anyFailedRow = commands.some((command) => command.status === "failed");
-    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
-    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
-    return { finalized, flowStatus, commands };
-  } catch {
-    return unfinalized;
-  }
-}
-function disposeRunnerReportDir(reportDir) {
-  if (!reportDir)
-    return;
-  try {
-    rmSync11(reportDir, { recursive: true, force: true });
-  } catch {
-  }
 }
 
 // packages/rn-dev-agent-core/dist/domain/maestro-run-ledger.js
@@ -80927,7 +81066,7 @@ function createMaestroRunHandler(deps = {}) {
   const resolveEngineStatus = deps.resolveEngineStatus ?? (() => getEngineStatus().catch(() => null));
   const replayFactory = deps.replayDeps;
   const nativeOnlyHandler = replayFactory ? createMaestroRunHandler({ ...deps, replayDeps: void 0 }) : null;
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (args.params) {
       for (const [key, value] of Object.entries(args.params)) {
         if (!PARAM_KEY_RE.test(key)) {
@@ -81005,7 +81144,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join42(tmpdir9(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join43(tmpdir9(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -81235,15 +81374,15 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of result.replay.steps) {
               if (!step || typeof step !== "object")
                 continue;
-              const record2 = step;
+              const record3 = step;
               combinedSteps.push({
-                index: sourceIndices[record2.sourceIndex ?? -1] ?? record2.sourceIndex ?? combinedSteps.length,
-                name: String(record2.t ?? "unknown"),
-                verb: String(record2.t ?? "unknown"),
-                ...record2.target !== void 0 ? { target: String(record2.target) } : {},
-                ...record2.focusOnly === true ? { focusOnly: true } : {},
-                status: record2.ok === false ? "fail" : "pass",
-                durationMs: Number(record2.durationMs ?? 0)
+                index: sourceIndices[record3.sourceIndex ?? -1] ?? record3.sourceIndex ?? combinedSteps.length,
+                name: String(record3.t ?? "unknown"),
+                verb: String(record3.t ?? "unknown"),
+                ...record3.target !== void 0 ? { target: String(record3.target) } : {},
+                ...record3.focusOnly === true ? { focusOnly: true } : {},
+                status: record3.ok === false ? "fail" : "pass",
+                durationMs: Number(record3.durationMs ?? 0)
               });
             }
           }
@@ -81408,6 +81547,7 @@ function createMaestroRunHandler(deps = {}) {
     })();
     const stageCaptures = [];
     let ledgerStageCursor = 0;
+    let invocationOrdinal = 0;
     const stageTerminationFromError = (error2) => {
       const errorClass = classifyExecError(error2);
       const raw = error2;
@@ -81475,7 +81615,8 @@ function createMaestroRunHandler(deps = {}) {
                 Object.assign(error2, { code: "ETIMEDOUT" });
                 throw error2;
               }
-              const executeRunner = (runnerPath, prefixArgs = []) => {
+              const executeRunner = async (runnerPath, prefixArgs = []) => {
+                const fingerprint = runnerReportFingerprint(runnerReportDir);
                 beforeDispatch?.();
                 const remainingTimeout = flowDeadline - now();
                 if (remainingTimeout <= 0) {
@@ -81483,12 +81624,29 @@ function createMaestroRunHandler(deps = {}) {
                   Object.assign(error2, { code: "ETIMEDOUT" });
                   throw error2;
                 }
-                return execute2(runnerPath, [...prefixArgs, ...finalArgs], {
-                  timeout: remainingTimeout,
-                  encoding: "utf8",
-                  maxBuffer: 10 * 1024 * 1024,
-                  signal: flowAbort.signal
-                });
+                const invocation = ++invocationOrdinal;
+                try {
+                  const result = await execute2(runnerPath, [...prefixArgs, ...finalArgs], {
+                    timeout: remainingTimeout,
+                    encoding: "utf8",
+                    maxBuffer: 10 * 1024 * 1024,
+                    signal: flowAbort.signal
+                  });
+                  if (outputIndicatesFlowFailure(combineRunnerOutput(result.stdout, result.stderr))) {
+                    captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, {
+                      exitCode: 0,
+                      signal: null,
+                      timedOut: false,
+                      outputTruncated: false,
+                      bootstrapFailure: false,
+                      transportFailure: false
+                    }, ledgerAttempt.ordinal);
+                  }
+                  return result;
+                } catch (error2) {
+                  captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, stageTerminationFromError(error2), ledgerAttempt.ordinal);
+                  throw error2;
+                }
               };
               if (deps.execFile) {
                 const immediateStatus = await resolveEngineStatus();
@@ -81886,6 +82044,18 @@ function createMaestroRunHandler(deps = {}) {
       }
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 
 // packages/rn-dev-agent-core/dist/nav-graph/route-sequence.js
@@ -82275,7 +82445,7 @@ function createRunActionHandler(deps = {}) {
   const installReceipt = deps.installReceipt ?? boundInstallReceipt;
   const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   const resolveEngineStatus = deps.engineStatus ?? (() => getEngineStatus().catch(() => null));
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
     }
@@ -82363,10 +82533,10 @@ function createRunActionHandler(deps = {}) {
     const startedAt = new Date(t0).toISOString();
     const runId = randomUUID9();
     const timingSteps = [];
-    const measureStep = async (name, run) => {
+    const measureStep = async (name, run2) => {
       const stepStartedMs = Date.now();
       try {
-        return await run();
+        return await run2();
       } finally {
         const stepEndedMs = Date.now();
         timingSteps.push({
@@ -82389,14 +82559,15 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => {
+    const persistRunWithDevice = (record3) => {
       assertReadableActionLoadContextStable(loadContext);
       if (proofReplay) {
         return Promise.resolve({ promoted: false, promotionRefused: false });
       }
       const endedMs = Date.now();
       const timedRecord = {
-        ...record2,
+        ...record3,
+        ...evidence.captures.length ? { runnerFailureEvidence: structuredClone(evidence) } : {},
         runId,
         timing: {
           startedAt,
@@ -82436,6 +82607,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, firstEnv.meta?.runnerFailureEvidence);
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
@@ -82768,6 +82940,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, retryEnv.meta?.runnerFailureEvidence);
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
@@ -82905,34 +83078,46 @@ function createRunActionHandler(deps = {}) {
       });
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 function promotionDisclosure(outcome) {
   if (outcome.promoted)
     return "lifecycle-promotion";
   return outcome.promotionRefused ? "lifecycle-promotion-refused" : "none";
 }
-async function persistRun(actionId, projectRoot, record2) {
+async function persistRun(actionId, projectRoot, record3) {
   const MAX_ATTEMPTS = 5;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const fresh = loadAction(projectRoot, actionId);
     if (!fresh) {
-      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record2.status}, autoRepair.outcome=${record2.autoRepair?.outcome ?? "n/a"})`);
+      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record3.status}, autoRepair.outcome=${record3.autoRepair?.outcome ?? "n/a"})`);
       return { promoted: false, promotionRefused: false };
     }
-    const nextState = appendRunRecord(fresh.state, record2);
-    const promotes = shouldAutoPromoteToActive(fresh.metadata, record2);
+    const nextState = appendRunRecord(fresh.state, record3);
+    const promotes = shouldAutoPromoteToActive(fresh.metadata, record3);
     const commit = (runtimeStatePath, promoted, promotionRefused2) => {
       mirrorToDb({
         yamlFilePath: fresh.filePath,
         state: fresh.state,
-        newRunRecord: record2,
+        newRunRecord: record3,
         meta: {
           appId: fresh.metadata.appId,
           status: promoted ? "active" : fresh.metadata.status,
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record2.runId };
+      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record3.runId };
     };
     const promotion = promotes ? promoteActionRuntimeWithCAS(fresh, nextState) : null;
     const promotionRefused = promotion?.ok === false;
@@ -82942,7 +83127,7 @@ async function persistRun(actionId, projectRoot, record2) {
     if (runtimeWrite.ok)
       return commit(runtimeWrite.sidecarPath, false, promotionRefused);
     if (attempt === MAX_ATTEMPTS) {
-      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record2.status}).`);
+      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record3.status}).`);
       return { promoted: false, promotionRefused, runtimeStateRefused: true };
     }
   }
@@ -83089,7 +83274,7 @@ function createLoginPrologueHandler(deps) {
     try {
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record3) => record3.runId === strictRunRecordId) : void 0;
       });
     } catch (error2) {
       return unresolved(`could not verify the exact ${LOGIN_PROLOGUE_ALIAS} learned action: ${error2 instanceof Error ? error2.message : String(error2)}`, replayWrites);
@@ -83575,13 +83760,13 @@ import { promisify as promisify19 } from "node:util";
 import { createHash as createHash16, randomBytes as randomBytes7, randomUUID as randomUUID10 } from "node:crypto";
 import { chmodSync as chmodSync7, existsSync as existsSync30, mkdirSync as mkdirSync19, readFileSync as readFileSync30, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync14, unlinkSync as unlinkSync13, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname22, join as join43 } from "node:path";
+import { dirname as dirname22, join as join44 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 var UNKNOWN_CLASSIFICATION = "UNKNOWN";
 var DEFAULT_MAX_RECORDS = 500;
 var DEFAULT_RETENTION_DAYS = 14;
 var MAX_EVIDENCE_POINTERS = 3;
-var EXPERIENCE_DIRECTORY = join43(homedir9(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_DIRECTORY = join44(homedir9(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var MAX_SYMPTOM_LENGTH = 2048;
 var RUNNER_DIAGNOSTICS_MAX_BYTES = 256 * 1024;
@@ -83670,7 +83855,7 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join43(root, "app.json");
+  const manifest = join44(root, "app.json");
   try {
     if (!existsSync30(manifest))
       return { name: null, slug: null };
@@ -83697,7 +83882,7 @@ var ExperienceRecorder = class {
   previousFailure = null;
   constructor(options) {
     this.directory = options.directory ?? configuredExperienceDirectory();
-    this.path = join43(this.directory, EXPERIENCE_STORE_NAME);
+    this.path = join44(this.directory, EXPERIENCE_STORE_NAME);
     this.candidate = {
       pluginVersion: options.pluginVersion ?? null,
       coreVersion: options.coreVersion
@@ -83743,9 +83928,9 @@ var ExperienceRecorder = class {
       return;
     }
     this.persistRunnerDiagnostics(event);
-    const record2 = this.buildFailureRecord(event);
-    this.persistFailure(record2);
-    this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+    const record3 = this.buildFailureRecord(event);
+    this.persistFailure(record3);
+    this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record3.signature } : null;
   }
   persistRunnerDiagnostics(event) {
     const trace = event.runnerDiagnostics;
@@ -83825,7 +84010,7 @@ var ExperienceRecorder = class {
   }
   persistFailure(incoming) {
     const records = readExperienceStore(this.path);
-    const existing = records.find((record2) => record2.signature === incoming.signature);
+    const existing = records.find((record3) => record3.signature === incoming.signature);
     if (existing) {
       existing.count += 1;
       existing.lastSeen = incoming.lastSeen;
@@ -83846,7 +84031,7 @@ var ExperienceRecorder = class {
   }
   persistRecovery(signature, tool) {
     const records = readExperienceStore(this.path);
-    const existing = records.find((record2) => record2.signature === signature);
+    const existing = records.find((record3) => record3.signature === signature);
     if (!existing)
       return;
     const now = this.now().toISOString();
@@ -83861,13 +84046,13 @@ var ExperienceRecorder = class {
   }
   write(records) {
     mkdirSync19(this.directory, { recursive: true, mode: 448 });
-    const temp = join43(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
+    const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
     try {
-      const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
-        ...sanitizeForEvidence(record2),
+      const sanitized = records.map((record3) => record3.redactionVersion === REDACTION_RULES_VERSION ? record3 : {
+        ...sanitizeForEvidence(record3),
         redactionVersion: REDACTION_RULES_VERSION
       });
-      const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+      const contents = sanitized.map((record3) => JSON.stringify(record3)).join("\n");
       writeFileSync14(temp, contents.length > 0 ? `${contents}
 ` : "", {
         encoding: "utf8",
@@ -83890,10 +84075,10 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
   const start = dirname22(fileURLToPath3(fromUrl));
   const candidates = [
-    join43(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join43(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join43(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join43(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join44(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
@@ -83927,8 +84112,8 @@ function readExperienceStore(path) {
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
-  return records.filter((record2) => {
-    const lastSeen = Date.parse(record2.lastSeen);
+  return records.filter((record3) => {
+    const lastSeen = Date.parse(record3.lastSeen);
     return Number.isFinite(lastSeen) && lastSeen >= cutoff;
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
@@ -84158,7 +84343,7 @@ function stableDeviceHash(directory, deviceId) {
   return createHash16("sha256").update(readOrCreateRunnerDiagnosticsSalt(directory)).update("\0").update(deviceId).digest("hex");
 }
 function readOrCreateRunnerDiagnosticsSalt(directory) {
-  const path = join43(directory, ".runner-diagnostics-salt");
+  const path = join44(directory, ".runner-diagnostics-salt");
   mkdirSync19(directory, { recursive: true, mode: 448 });
   try {
     const existing = readFileSync30(path);
@@ -84183,7 +84368,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   const files = runnerDiagnosticsFiles(directory);
   const nextSequence = files.reduce((maximum, file) => Math.max(maximum, runnerDiagnosticsSequence(file)), 0) + 1;
   const sessionKey = (bundle.context.sessionId ?? "unknown").slice(0, 64).replace(/[^A-Za-z0-9_-]/g, "-");
-  const outputPath = join43(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
+  const outputPath = join44(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
   const bounded = boundRunnerDiagnosticsBundle(bundle);
   let serialized = `${JSON.stringify(bounded, null, 2)}
 `;
@@ -84201,17 +84386,17 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   if (Buffer.byteLength(serialized) > RUNNER_DIAGNOSTICS_MAX_BYTES) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
-  const temporary = join43(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
+  const temporary = join44(directory, `.runner-diagnostics.${process.pid}.${randomUUID10()}`);
   writeFileSync14(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync14(join43(directory, file)).mtimeMs,
+    mtimeMs: statSync14(join44(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => left.mtimeMs - right.mtimeMs || left.sequence - right.sequence || left.file.localeCompare(right.file));
   for (const stale of retained.slice(0, Math.max(0, retained.length - RUNNER_DIAGNOSTICS_RETENTION))) {
-    unlinkSync13(join43(directory, stale.file));
+    unlinkSync13(join44(directory, stale.file));
   }
   return outputPath;
 }
@@ -84281,11 +84466,11 @@ function latestRunnerDiagnosticsPath(sessionId, directory = configuredExperience
     return null;
   const files = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync14(join43(directory, file)).mtimeMs,
+    mtimeMs: statSync14(join44(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => right.mtimeMs - left.mtimeMs || right.sequence - left.sequence || right.file.localeCompare(left.file));
   for (const file of files) {
-    const path = join43(directory, file.file);
+    const path = join44(directory, file.file);
     try {
       const contents = readFileSync30(path);
       if (contents.byteLength > RUNNER_DIAGNOSTICS_MAX_BYTES)
@@ -85707,7 +85892,7 @@ init_utils();
 init_project_config();
 init_maestro_validator();
 import { writeFileSync as writeFileSync15 } from "node:fs";
-import { join as join44 } from "node:path";
+import { join as join45 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
 init_agent_device_wrapper();
 
@@ -85968,7 +86153,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join44(tmpdir10(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join45(tmpdir10(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -86507,7 +86692,7 @@ import { createHash as createHash17 } from "node:crypto";
 import { existsSync as existsSync31 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
-import { dirname as dirname23, join as join45 } from "node:path";
+import { dirname as dirname23, join as join46 } from "node:path";
 init_process_birth();
 var execFileAsync5 = promisify23(execFile22);
 var START_TIMEOUT_MS = 1e4;
@@ -86596,15 +86781,15 @@ function candidateRecordScripts(baseDir = dirname23(fileURLToPath4(import.meta.u
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join45(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join45(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join45(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join46(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join46(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join46(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join45(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join46(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join45(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join46(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join45(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join46(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
 function resolveRecordScript(baseDir = dirname23(fileURLToPath4(import.meta.url))) {
@@ -86927,8 +87112,8 @@ function createDeviceRecordHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash19, randomUUID as randomUUID11 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync11, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync15, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute15, join as join46, relative as relative9, resolve as resolve17, sep as sep10 } from "node:path";
+import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync18, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync32, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
+import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute15, join as join47, relative as relative9, resolve as resolve17, sep as sep11 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
@@ -87062,12 +87247,12 @@ function observedAssertionPassed(event) {
   const data = resultEnvelopeData(event.result);
   if (!data || typeof data !== "object")
     return !tool.endsWith("proof_step");
-  const record2 = data;
-  if (tool.endsWith("proof_step") && record2.verified !== true)
+  const record3 = data;
+  if (tool.endsWith("proof_step") && record3.verified !== true)
     return false;
-  if (record2.verified === false || record2.ok === false)
+  if (record3.verified === false || record3.ok === false)
     return false;
-  return !Array.isArray(record2.errors) || record2.errors.length === 0;
+  return !Array.isArray(record3.errors) || record3.errors.length === 0;
 }
 var readOnlyTools = /* @__PURE__ */ new Set([
   "cdp_status",
@@ -87583,14 +87768,14 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let coreBundleSha256 = null;
   try {
     if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
-      executedEntrypointPath = realpathSync15(argv[1]);
+      executedEntrypointPath = realpathSync16(argv[1]);
     }
   } catch {
     executedEntrypointPath = null;
   }
   if (attestation) {
     try {
-      loadedCoreBundlePath = realpathSync15(fileURLToPath5(attestation.entrypointUrl));
+      loadedCoreBundlePath = realpathSync16(fileURLToPath5(attestation.entrypointUrl));
       coreBundleSha256 = attestation.coreBundleSha256;
     } catch {
       loadedCoreBundlePath = null;
@@ -87607,7 +87792,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
 var proofWorkerStartup = captureProofWorkerStartup();
 function realpathOrSelf(path) {
   try {
-    return realpathSync15(path);
+    return realpathSync16(path);
   } catch {
     return path;
   }
@@ -87615,7 +87800,7 @@ function realpathOrSelf(path) {
 function resolveProofCandidateEntrypoint(candidateRoot, argv) {
   let root;
   try {
-    root = realpathSync15(candidateRoot);
+    root = realpathSync16(candidateRoot);
   } catch {
     return null;
   }
@@ -87624,14 +87809,14 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   let arg;
   try {
-    arg = realpathSync15(authorityArg);
+    arg = realpathSync16(authorityArg);
   } catch {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join46(root, "packages", host);
-    const coreIndex = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join47(root, "packages", host);
+    const coreIndex = realpathOrSelf(join47(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join47(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -87650,7 +87835,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join46(hostRoot, "bin", "cdp-supervisor.js"))) {
+    if (host === "codex-plugin" && arg === realpathOrSelf(join47(hostRoot, "bin", "cdp-supervisor.js"))) {
       if (!existsSync32(coreIndex) || !existsSync32(coreSupervisor))
         return null;
       return {
@@ -87672,7 +87857,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
     if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
-      return realpathSync15(value);
+      return realpathSync16(value);
     } catch {
       return null;
     }
@@ -87685,7 +87870,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join46(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join47(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -87694,7 +87879,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
 }
 function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   try {
-    const root = realpathSync15(candidateRoot);
+    const root = realpathSync16(candidateRoot);
     const statusArgs = [
       "-C",
       root,
@@ -87707,8 +87892,8 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       return null;
     const verifiedBytes = [];
     for (const artifactPath of artifactPaths) {
-      const resolvedArtifactPath = realpathSync15(artifactPath);
-      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep10).join("/");
+      const resolvedArtifactPath = realpathSync16(artifactPath);
+      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep11).join("/");
       if (!artifactRelativePath || artifactRelativePath === ".." || artifactRelativePath.startsWith("../")) {
         return null;
       }
@@ -87727,7 +87912,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   }
 }
 function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) {
-  const root = realpathSync15(resolve17(candidateRoot));
+  const root = realpathSync16(resolve17(candidateRoot));
   const sha = execFileSync15("git", ["-C", root, "rev-parse", "HEAD"], {
     encoding: "utf8"
   }).trim();
@@ -87743,7 +87928,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join46(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join47(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -87812,14 +87997,14 @@ function isNormalizedDescendant(root, path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep11}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
-  const parts = relative9(root, path).split(sep10);
+  const parts = relative9(root, path).split(sep11);
   for (let length = 0; length <= parts.length; length += 1) {
     const candidate = resolve17(root, ...parts.slice(0, length));
     try {
-      if (lstatSync17(candidate).isSymbolicLink())
+      if (lstatSync18(candidate).isSymbolicLink())
         return true;
     } catch {
     }
@@ -87838,7 +88023,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join46(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join47(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -87852,9 +88037,9 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join47(args.projectRoot, "docs", "proof", args.runId);
   try {
-    lstatSync17(proofRoot);
+    lstatSync18(proofRoot);
     return true;
   } catch (error2) {
     return error2.code !== "ENOENT";
@@ -87878,15 +88063,15 @@ function parseProofGitChanges(porcelain) {
   const records = porcelain.split("\0");
   const changes = [];
   for (let index = 0; index < records.length; index += 1) {
-    const record2 = records[index];
-    if (!record2 || record2.length < 4)
+    const record3 = records[index];
+    if (!record3 || record3.length < 4)
       continue;
     const change = {
-      path: record2.slice(3).replaceAll("\\", "/"),
-      indexStatus: record2[0],
-      worktreeStatus: record2[1]
+      path: record3.slice(3).replaceAll("\\", "/"),
+      indexStatus: record3[0],
+      worktreeStatus: record3[1]
     };
-    if (/[RC]/.test(record2.slice(0, 2))) {
+    if (/[RC]/.test(record3.slice(0, 2))) {
       const sourcePath = records[index + 1];
       if (sourcePath)
         change.sourcePath = sourcePath.replaceAll("\\", "/");
@@ -87908,7 +88093,7 @@ function readProofGitInfo(root) {
 function proofRootHasTrackedEntries(root, proofRoot) {
   if (!isNormalizedDescendant(root, proofRoot))
     throw new Error("INVALID_PROOF_ROOT");
-  const path = relative9(root, proofRoot).replaceAll(sep10, "/");
+  const path = relative9(root, proofRoot).replaceAll(sep11, "/");
   return execFileSync15("git", ["ls-files", "-z", "--", path], {
     cwd: root,
     encoding: "utf8"
@@ -88005,17 +88190,17 @@ function writeProofReceiptAtomic(path, receipt2) {
   const temporary = resolve17(directory, `.${randomUUID11()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
-    descriptor = openSync11(temporary, "wx", 384);
+    descriptor = openSync12(temporary, "wx", 384);
     writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
-    closeSync11(descriptor);
+    closeSync12(descriptor);
     descriptor = null;
     renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
-      closeSync11(descriptor);
+      closeSync12(descriptor);
     try {
       unlinkSync15(temporary);
     } catch {
@@ -88177,7 +88362,7 @@ function createProofCaptureHandler(deps) {
       return current.reasons;
     return sameProofAction(current.value, active.actionIdentity) ? [] : ["PROOF_ACTION_IDENTITY_CHANGED"];
   };
-  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep10, "/");
+  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep11, "/");
   const observedSetupScreenshots = (active) => {
     const owned = /* @__PURE__ */ new Set();
     for (const observation of deps.monitor.observations()) {
@@ -88337,7 +88522,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join47(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -88807,7 +88992,7 @@ import { createHash as createHash20 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir11 } from "node:os";
-import { dirname as dirname25, join as join47 } from "node:path";
+import { dirname as dirname25, join as join48 } from "node:path";
 var MediaFailure = class extends Error {
   reason;
   constructor(reason) {
@@ -88944,7 +89129,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join47(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join48(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -88969,7 +89154,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join47(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join48(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -89093,7 +89278,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir11();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join47(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join48(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -90280,8 +90465,8 @@ init_agent_device_wrapper();
 init_storage();
 init_project_config();
 init_maestro_validator();
-import { lstatSync as lstatSync18, readFileSync as readFileSync33, readdirSync as readdirSync14, realpathSync as realpathSync16 } from "node:fs";
-import { dirname as dirname26, join as join48, resolve as resolve18 } from "node:path";
+import { lstatSync as lstatSync19, readFileSync as readFileSync33, readdirSync as readdirSync14, realpathSync as realpathSync17 } from "node:fs";
+import { dirname as dirname26, join as join49, resolve as resolve18 } from "node:path";
 var AUTH_ROUTE_PATTERNS = [
   "login",
   "signin",
@@ -90341,13 +90526,13 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join48(projectRoot, ".maestro");
-  const searchDirs = [join48(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join49(projectRoot, ".maestro");
+  const searchDirs = [join49(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
-      const maestroStat = lstatSync18(maestroDir);
-      const dirStat = lstatSync18(dir);
+      const maestroStat = lstatSync19(maestroDir);
+      const dirStat = lstatSync19(dir);
       if (maestroStat.isSymbolicLink() || dirStat.isSymbolicLink()) {
         throw new Error(`Refusing legacy login directory symlink at ${dir}.`);
       }
@@ -90361,17 +90546,17 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join48(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join49(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join48(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join49(dir, authFile));
   }
   return null;
 }
 function assertLegacyLoginFlow(projectRoot, flowPath) {
-  const stat2 = lstatSync18(flowPath);
+  const stat2 = lstatSync19(flowPath);
   if (!stat2.isFile() || stat2.isSymbolicLink()) {
     throw new Error(`Refusing legacy login flow symlink at ${flowPath}.`);
   }
@@ -90397,7 +90582,7 @@ function boundSessionProjectRoot() {
 }
 function canonicalRoot(path) {
   try {
-    return realpathSync16(path);
+    return realpathSync17(path);
   } catch {
     return null;
   }
@@ -90482,7 +90667,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   try {
     const parsed = parseAndValidateFlow(originalContent, {
       flowDir: dirname26(flowPath),
-      flowRoot: join48(projectRoot, ".maestro")
+      flowRoot: join49(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -90997,9 +91182,9 @@ function buildGracefulShutdown(deps) {
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
 import { createHash as createHash21 } from "node:crypto";
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { closeSync as closeSync12, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17, writeSync as writeSync3 } from "node:fs";
+import { closeSync as closeSync13, existsSync as existsSync33, mkdirSync as mkdirSync21, openSync as openSync13, readFileSync as readFileSync34, statSync as statSync15, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
-import { join as join49, resolve as resolve19 } from "node:path";
+import { join as join50, resolve as resolve19 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var DEFAULT_PROCESS_NAME_NEEDLE = "cdp-bridge";
 var PROCESS_IDENTITY_MARKERS = ["cdp-bridge", "rn-dev-agent", "supervisor.js"];
@@ -91075,7 +91260,7 @@ var Lockfile = class {
       processIdentity: opts.processIdentity ?? defaultProcessIdentity(),
       staleMs: opts.staleMs ?? DEFAULT_STALE_MS
     };
-    this.lockPath = join49(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
+    this.lockPath = join50(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
   }
   // GH#251: acquire via atomic exclusive-create (same pattern as DeviceLock).
   // The previous read-then-writeFileSync let two bridges starting in the same
@@ -91242,11 +91427,11 @@ var Lockfile = class {
     if (!existsSync33(dir)) {
       mkdirSync21(dir, { recursive: true });
     }
-    const fd = openSync12(this.lockPath, "wx");
+    const fd = openSync13(this.lockPath, "wx");
     try {
       writeSync3(fd, JSON.stringify(body, null, 2));
     } finally {
-      closeSync12(fd);
+      closeSync13(fd);
     }
   }
 };
@@ -91314,7 +91499,7 @@ init_agent_device_wrapper();
 init_utils();
 init_storage();
 init_maestro_validator();
-import { basename as basename12, dirname as dirname27, join as join50 } from "node:path";
+import { basename as basename12, dirname as dirname27, join as join51 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -91373,7 +91558,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join50(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join51(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -91446,7 +91631,7 @@ init_storage();
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
-import { basename as basename13, dirname as dirname28, join as join51, resolve as resolve20 } from "node:path";
+import { basename as basename13, dirname as dirname28, join as join52, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 init_maestro_validator();
 init_registry();
@@ -91475,7 +91660,7 @@ function filterFlows(yamls, pattern) {
 function discoverFlows(dir, pattern) {
   if (!existsSync34(dir))
     return [];
-  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join51(dir, f)).sort();
+  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join52(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -91500,12 +91685,12 @@ function createMaestroTestAllHandler(deps = {}) {
     const requestedDeviceId = args.deviceId ?? matchingSessionDeviceId;
     const engineStatus = await resolveEngineStatus();
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join51(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join52(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve20(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join51(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join52(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
@@ -91538,7 +91723,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if ("error" in dispatch) {
       return failResult(dispatch.error);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join51(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join52(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -91697,7 +91882,7 @@ function createMaestroTestAllHandler(deps = {}) {
           break;
         continue;
       }
-      const safeFlowFile = join51(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      const safeFlowFile = join52(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
@@ -91868,8 +92053,8 @@ function createMaestroTestAllHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/tools/cross-platform-verify.js
 init_agent_device_wrapper();
 init_utils();
-import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync19 } from "node:fs";
-import { join as join52, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync20 } from "node:fs";
+import { join as join53, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -91894,9 +92079,9 @@ function discoverTestIDs(dir) {
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join52(d, entry);
+      const full = join53(d, entry);
       try {
-        const st = lstatSync19(full);
+        const st = lstatSync20(full);
         if (st.isSymbolicLink())
           continue;
         if (st.isDirectory()) {
@@ -92242,7 +92427,7 @@ function instrumentTool(toolName, handler) {
 }
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join53 } from "node:path";
+import { join as join54 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -92430,7 +92615,7 @@ function buildLiveDeps(input) {
     readShotFile: input.readShotFile,
     // Preserve Recorder.pushLive's `this` binding.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join53(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join54(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive,
     reportBlocked: input.reportBlocked
   };
@@ -92448,7 +92633,7 @@ import { createServer as createServer3 } from "node:http";
 import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync37 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname29, join as join54 } from "node:path";
+import { dirname as dirname29, join as join55 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
 import { randomBytes as randomBytes8, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
@@ -92778,7 +92963,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync37(join54(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync37(join55(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -92981,10 +93166,10 @@ init_project_config();
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
 init_secure_state_file();
 init_storage();
-import { join as join55 } from "node:path";
+import { join as join56 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join55(getStateDir(), "observe", `${safe}.json`);
+  return join56(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -93666,17 +93851,17 @@ function buildMirrorTargetResolver(deps) {
 init_sources();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname30, join as join56 } from "node:path";
+import { dirname as dirname30, join as join57 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash22 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
-  return join56(projectRoot, ".rn-agent", "e2e");
+  return join57(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join56(dir, `${id}.yaml`);
+  const file = join57(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -93785,9 +93970,9 @@ function parseLockedTest(text, filePath) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
-import { join as join57 } from "node:path";
+import { join as join58 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join57(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join58(projectRoot, ".rn-agent", "e2e.config.json");
   try {
     const raw = readFileSync39(filePath, "utf8");
     return JSON.parse(raw);
@@ -93921,7 +94106,7 @@ function createLockE2eTestHandler(deps = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
-import { join as join58 } from "node:path";
+import { join as join59 } from "node:path";
 import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
@@ -93977,16 +94162,16 @@ function diffNewlyFailing(current, previousGreen) {
 }
 var INDEX_MAX = 100;
 function e2eRunsDirFor(projectRoot) {
-  return join58(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join59(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync23(join58(file, ".."), { recursive: true });
+  mkdirSync23(join59(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join58(e2eRunsDirFor(projectRoot), "index.json");
+  const file = join59(e2eRunsDirFor(projectRoot), "index.json");
   if (!existsSync36(file))
     return [];
   try {
@@ -93999,7 +94184,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join58(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join59(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -94007,11 +94192,11 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join58(dir, "index.json"), next);
+  writeJsonAtomic(join59(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join58(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  const file = join59(e2eRunsDirFor(projectRoot), `${runId}.json`);
   if (!existsSync36(file))
     return null;
   try {
@@ -94030,7 +94215,7 @@ init_storage();
 init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join59 } from "node:path";
+import { join as join60 } from "node:path";
 import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
@@ -94039,11 +94224,11 @@ var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "interrupted"
 ]);
 function requestsDir(projectRoot) {
-  return join59(e2eRunsDirFor(projectRoot), "requests");
+  return join60(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join59(requestsDir(projectRoot), `${runId}.json`);
+  return join60(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
@@ -94208,7 +94393,7 @@ async function runE2eSuiteCore(args, deps = {}) {
   const verdict = computeVerdict(results);
   const prevGreenId = lastGreenRunId(projectRoot);
   const prevGreen = prevGreenId ? loadRunRecord(projectRoot, prevGreenId) : null;
-  const record2 = {
+  const record3 = {
     runId,
     startedAt,
     finishedAt: now().toISOString(),
@@ -94228,13 +94413,13 @@ async function runE2eSuiteCore(args, deps = {}) {
     results,
     previousGreenRunId: prevGreenId
   };
-  writeRunRecord(projectRoot, record2);
+  writeRunRecord(projectRoot, record3);
   return okResult({
     runId,
     verdict,
-    totals: record2.totals,
+    totals: record3.totals,
     results,
-    newlyFailing: diffNewlyFailing(record2, prevGreen),
+    newlyFailing: diffNewlyFailing(record3, prevGreen),
     metroReloaded
   });
 }
@@ -95275,7 +95460,7 @@ async function withRecoveredAuthoritativeRuntime(status, connectedClient, operat
 }
 
 // packages/rn-dev-agent-core/dist/index.js
-var pkgPath = join60(dirname31(fileURLToPath7(import.meta.url)), "..", "package.json");
+var pkgPath = join61(dirname31(fileURLToPath7(import.meta.url)), "..", "package.json");
 var pkgVersion = JSON.parse(readFileSync42(pkgPath, "utf8")).version;
 var lockfile = null;
 var diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
@@ -96030,7 +96215,7 @@ var getSessionSignerCapability = (sessionId) => {
     return null;
   if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
     return null;
-  const secretPath = sessionId ? join60(dirname31(dirname31(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+  const secretPath = sessionId ? join61(dirname31(dirname31(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
   return readJsonStateFile(secretPath)?.signerCapability ?? null;
 };
 var spawningSupervisorPid = process.ppid;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -4517,10 +4517,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep: sep8, value } = collItem;
+        const { start, key, sep: sep9, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep8?.[0],
+          next: key ?? sep9?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -4534,7 +4534,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep8) {
+          if (!keyProps.anchor && !keyProps.tag && !sep9) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -4558,7 +4558,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep8 ?? [], {
+        const valueProps = resolveProps.resolveProps(sep9 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -4574,7 +4574,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep8, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep9, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -4665,7 +4665,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep8 = "";
+        let sep9 = "";
         for (const token2 of end) {
           const { source, type } = token2;
           switch (type) {
@@ -4679,13 +4679,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep8 + cb;
-              sep8 = "";
+                comment += sep9 + cb;
+              sep9 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep8 += source;
+                sep9 += source;
               hasSpace = true;
               break;
             default:
@@ -4728,18 +4728,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep: sep8, value } = collItem;
+        const { start, key, sep: sep9, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep8?.[0],
+          next: key ?? sep9?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep8 && !value) {
+          if (!props.anchor && !props.tag && !sep9 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -4793,8 +4793,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep8 && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep8, null, props, onError);
+        if (!isMap && !sep9 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep9, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -4806,7 +4806,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep8 ?? [], {
+          const valueProps = resolveProps.resolveProps(sep9 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -4817,8 +4817,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep8)
-                for (const st of sep8) {
+              if (sep9)
+                for (const st of sep9) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -4835,7 +4835,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep8, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep9, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -5015,7 +5015,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep8 = "";
+      let sep9 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -5032,24 +5032,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep8 + indent.slice(trimIndent) + content;
-          sep8 = "\n";
+          value += sep9 + indent.slice(trimIndent) + content;
+          sep9 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep8 === " ")
-            sep8 = "\n";
-          else if (!prevMoreIndented && sep8 === "\n")
-            sep8 = "\n\n";
-          value += sep8 + indent.slice(trimIndent) + content;
-          sep8 = "\n";
+          if (sep9 === " ")
+            sep9 = "\n";
+          else if (!prevMoreIndented && sep9 === "\n")
+            sep9 = "\n\n";
+          value += sep9 + indent.slice(trimIndent) + content;
+          sep9 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep8 === "\n")
+          if (sep9 === "\n")
             value += "\n";
           else
-            sep8 = "\n";
+            sep9 = "\n";
         } else {
-          value += sep8 + content;
-          sep8 = " ";
+          value += sep9 + content;
+          sep9 = " ";
           prevMoreIndented = false;
         }
       }
@@ -5231,25 +5231,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep8 = " ";
+      let sep9 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep8 === "\n")
-            res += sep8;
+          if (sep9 === "\n")
+            res += sep9;
           else
-            sep8 = "\n";
+            sep9 = "\n";
         } else {
-          res += sep8 + match[1];
-          sep8 = " ";
+          res += sep9 + match[1];
+          sep9 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep8 + (match?.[1] ?? "");
+      return res + sep9 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -6059,14 +6059,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep: sep8, value }) {
+    function stringifyItem({ start, key, sep: sep9, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep8)
-        for (const st of sep8)
+      if (sep9)
+        for (const st of sep9)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -7233,18 +7233,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep8;
+          let sep9;
           if (scalar.end) {
-            sep8 = scalar.end;
-            sep8.push(this.sourceToken);
+            sep9 = scalar.end;
+            sep9.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep8 = [this.sourceToken];
+            sep9 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep: sep8 }]
+            items: [{ start, key: scalar, sep: sep9 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -7397,15 +7397,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep8 = it.sep;
-                  sep8.push(this.sourceToken);
+                  const sep9 = it.sep;
+                  sep9.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep: sep8 }]
+                    items: [{ start: start2, key, sep: sep9 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -7599,13 +7599,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep8 = fc.end.splice(1, fc.end.length);
-            sep8.push(this.sourceToken);
+            const sep9 = fc.end.splice(1, fc.end.length);
+            sep9.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep: sep8 }]
+              items: [{ start, key: fc, sep: sep9 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -8354,28 +8354,28 @@ var init_keyboard_guard = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/util/secure-state-file.js
-import { readFileSync as readFileSync10, writeFileSync as writeFileSync4, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync9 } from "node:fs";
-import { join as join12, dirname as dirname12 } from "node:path";
+import { readFileSync as readFileSync11, writeFileSync as writeFileSync4, unlinkSync as unlinkSync6, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync10 } from "node:fs";
+import { join as join14, dirname as dirname12 } from "node:path";
 import { homedir as homedir3 } from "node:os";
 function getStateDir() {
   if (process.env.XDG_STATE_HOME) {
-    return join12(process.env.XDG_STATE_HOME, "rn-dev-agent");
+    return join14(process.env.XDG_STATE_HOME, "rn-dev-agent");
   }
   if (process.platform === "darwin") {
-    return join12(homedir3(), "Library", "Application Support", "rn-dev-agent");
+    return join14(homedir3(), "Library", "Application Support", "rn-dev-agent");
   }
-  return join12(homedir3(), ".rn-dev-agent");
+  return join14(homedir3(), ".rn-dev-agent");
 }
 function runnerStatePath(key) {
   const safe = key.replace(/[^A-Za-z0-9._:-]/g, "_");
-  return join12(getStateDir(), "runner-state", `${safe}.json`);
+  return join14(getStateDir(), "runner-state", `${safe}.json`);
 }
 function readJsonStateFile(path) {
   try {
-    const stat = lstatSync9(path);
+    const stat = lstatSync10(path);
     if (stat.isSymbolicLink())
       return null;
-    return JSON.parse(readFileSync10(path, "utf8"));
+    return JSON.parse(readFileSync11(path, "utf8"));
   } catch {
     return null;
   }
@@ -8411,8 +8411,8 @@ var init_secure_state_file = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/runtime-paths.js
-import { existsSync as existsSync11, statSync as statSync5 } from "node:fs";
-import { join as join13 } from "node:path";
+import { existsSync as existsSync12, statSync as statSync5 } from "node:fs";
+import { join as join15 } from "node:path";
 function compactUnique(paths) {
   const out = [];
   for (const path of paths) {
@@ -8435,21 +8435,21 @@ function candidateNativeRunnerDirs(runnerName, baseDir = import.meta.dirname) {
   const codexPluginRoot = process.env.RN_DEV_AGENT_CODEX_PLUGIN_ROOT;
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique([
-    runnerRoot ? join13(runnerRoot, runnerName) : void 0,
-    repoRoot ? join13(repoRoot, "packages", runnerName) : void 0,
-    repoRoot ? join13(repoRoot, "scripts", runnerName) : void 0,
-    codexPluginRoot ? join13(codexPluginRoot, "scripts", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "..", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "..", "..", "packages", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "..", "..", "scripts", runnerName) : void 0,
-    claudePluginRoot ? join13(claudePluginRoot, "scripts", runnerName) : void 0,
+    runnerRoot ? join15(runnerRoot, runnerName) : void 0,
+    repoRoot ? join15(repoRoot, "packages", runnerName) : void 0,
+    repoRoot ? join15(repoRoot, "scripts", runnerName) : void 0,
+    codexPluginRoot ? join15(codexPluginRoot, "scripts", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "..", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "..", "..", "packages", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "..", "..", "scripts", runnerName) : void 0,
+    claudePluginRoot ? join15(claudePluginRoot, "scripts", runnerName) : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join13(baseDir, "..", "..", "scripts", runnerName),
+    join15(baseDir, "..", "..", "scripts", runnerName),
     // Source checkout: packages/rn-dev-agent-core/dist/runners.
     // Also covers the legacy scripts/cdp-bridge/dist/runners layout.
-    join13(baseDir, "..", "..", "..", runnerName),
+    join15(baseDir, "..", "..", "..", runnerName),
     // Legacy source checkout: packages/rn-dev-agent-core/dist/runners before runner package split.
-    join13(baseDir, "..", "..", "..", "..", "scripts", runnerName)
+    join15(baseDir, "..", "..", "..", "..", "scripts", runnerName)
   ]);
 }
 function resolveNativeRunnerDir(runnerName, baseDir = import.meta.dirname) {
@@ -8493,7 +8493,7 @@ var init_transport_recovery = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
-import { join as join14 } from "node:path";
+import { join as join16 } from "node:path";
 function resolveReadyTimeoutMs() {
   const raw = Number(process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : 3e4;
@@ -8783,9 +8783,9 @@ var init_rn_fast_runner_client = __esm({
     runnerState = null;
     lastKnownCapabilities = [];
     quiescenceAnnouncementPending = false;
-    REBUILD_LOCK_DIR = join14(FAST_RUNNER_PROJECT, "build", ".rebuild-lock");
+    REBUILD_LOCK_DIR = join16(FAST_RUNNER_PROJECT, "build", ".rebuild-lock");
     REBUILD_LOCK_STALE_MS = 15 * 6e4;
-    REBUILD_BUDGET_FILE = join14(FAST_RUNNER_PROJECT, "build", "commands-rebuild.json");
+    REBUILD_BUDGET_FILE = join16(FAST_RUNNER_PROJECT, "build", "commands-rebuild.json");
     fetchImpl = globalThis.fetch;
   }
 });
@@ -8820,14 +8820,14 @@ var init_declared_source_contract = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/nav-graph/storage.js
-import { readFileSync as readFileSync11, writeFileSync as writeFileSync5, existsSync as existsSync12, renameSync as renameSync5, readdirSync as readdirSync5, lstatSync as lstatSync10, mkdirSync as mkdirSync9, realpathSync as realpathSync6 } from "node:fs";
-import { join as join15, dirname as dirname13 } from "node:path";
+import { readFileSync as readFileSync12, writeFileSync as writeFileSync5, existsSync as existsSync13, renameSync as renameSync5, readdirSync as readdirSync6, lstatSync as lstatSync11, mkdirSync as mkdirSync9, realpathSync as realpathSync8 } from "node:fs";
+import { join as join17, dirname as dirname13 } from "node:path";
 function isRnProject(dir) {
-  const pkgPath = join15(dir, "package.json");
-  if (!existsSync12(pkgPath))
+  const pkgPath = join17(dir, "package.json");
+  if (!existsSync13(pkgPath))
     return false;
   try {
-    const pkg = JSON.parse(readFileSync11(pkgPath, "utf-8"));
+    const pkg = JSON.parse(readFileSync12(pkgPath, "utf-8"));
     const deps = { ...pkg.dependencies, ...pkg.devDependencies };
     return !!(deps["react-native"] || deps["expo"]);
   } catch {
@@ -8839,7 +8839,7 @@ function scanForRnProject(rootDir, maxDepth) {
     return null;
   let entries;
   try {
-    entries = readdirSync5(rootDir);
+    entries = readdirSync6(rootDir);
   } catch {
     return null;
   }
@@ -8848,9 +8848,9 @@ function scanForRnProject(rootDir, maxDepth) {
   for (const name of entries) {
     if (name.startsWith(".") || name === "node_modules")
       continue;
-    const full = join15(rootDir, name);
+    const full = join17(rootDir, name);
     try {
-      const stat = lstatSync10(full);
+      const stat = lstatSync11(full);
       if (!(stat.isDirectory() || stat.isSymbolicLink()))
         continue;
     } catch {
@@ -8874,7 +8874,7 @@ function collectRnProjects(rootDir, maxDepth, out) {
     return;
   let entries;
   try {
-    entries = readdirSync5(rootDir);
+    entries = readdirSync6(rootDir);
   } catch {
     return;
   }
@@ -8883,9 +8883,9 @@ function collectRnProjects(rootDir, maxDepth, out) {
   for (const name of entries) {
     if (name.startsWith(".") || name === "node_modules")
       continue;
-    const full = join15(rootDir, name);
+    const full = join17(rootDir, name);
     try {
-      const stat = lstatSync10(full);
+      const stat = lstatSync11(full);
       if (!(stat.isDirectory() || stat.isSymbolicLink()))
         continue;
     } catch {
@@ -8903,11 +8903,11 @@ function collectRnProjects(rootDir, maxDepth, out) {
   }
 }
 function readProjectBundleId(projectRoot) {
-  const appJsonPath = join15(projectRoot, "app.json");
-  if (!existsSync12(appJsonPath))
+  const appJsonPath = join17(projectRoot, "app.json");
+  if (!existsSync13(appJsonPath))
     return null;
   try {
-    const raw = JSON.parse(readFileSync11(appJsonPath, "utf-8"));
+    const raw = JSON.parse(readFileSync12(appJsonPath, "utf-8"));
     const iosId = raw.expo?.ios?.bundleIdentifier ?? raw.ios?.bundleIdentifier;
     const androidId = raw.expo?.android?.package ?? raw.android?.package;
     if (typeof iosId === "string" && iosId.length > 0)
@@ -8941,7 +8941,7 @@ function findProjectRoot(opts = {}) {
         walkupHit = walkupHit ?? dir;
         break;
       }
-      const parent = join15(dir, "..");
+      const parent = join17(dir, "..");
       if (parent === dir)
         break;
       dir = parent;
@@ -8950,7 +8950,7 @@ function findProjectRoot(opts = {}) {
   if (!targetBundleId && walkupHit)
     return walkupHit;
   const cwd = process.cwd();
-  const parentOfCwd = join15(cwd, "..");
+  const parentOfCwd = join17(cwd, "..");
   if (targetBundleId) {
     const all = [];
     collectRnProjects(cwd, 0, all);
@@ -9101,15 +9101,15 @@ var init_sources = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/project-config.js
-import { existsSync as existsSync13, readFileSync as readFileSync12 } from "node:fs";
-import { join as join16 } from "node:path";
+import { existsSync as existsSync14, readFileSync as readFileSync13 } from "node:fs";
+import { join as join18 } from "node:path";
 function readAppId(projectRoot, platform) {
   for (const filename of ["app.json", "app.config.json"]) {
-    const p = join16(projectRoot, filename);
-    if (!existsSync13(p))
+    const p = join18(projectRoot, filename);
+    if (!existsSync14(p))
       continue;
     try {
-      const raw = JSON.parse(readFileSync12(p, "utf-8"));
+      const raw = JSON.parse(readFileSync13(p, "utf-8"));
       const expo = raw.expo ?? raw;
       const iosBundleId = expo?.ios?.bundleIdentifier;
       const androidPkg = expo?.android?.package;
@@ -9133,11 +9133,11 @@ function readExpoSlug() {
   if (!projectRoot)
     return null;
   for (const filename of ["app.json", "app.config.json"]) {
-    const p = join16(projectRoot, filename);
-    if (!existsSync13(p))
+    const p = join18(projectRoot, filename);
+    if (!existsSync14(p))
       continue;
     try {
-      const raw = JSON.parse(readFileSync12(p, "utf-8"));
+      const raw = JSON.parse(readFileSync13(p, "utf-8"));
       return raw.expo?.slug ?? null;
     } catch {
       continue;
@@ -9155,11 +9155,11 @@ var init_project_config = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/agent-device-wrapper.js
-import { join as join17 } from "node:path";
-import { createHash as createHash3 } from "node:crypto";
+import { join as join19 } from "node:path";
+import { createHash as createHash4 } from "node:crypto";
 function getSessionFilePath() {
-  const projectId = createHash3("sha256").update(process.cwd()).digest("hex").slice(0, 12);
-  return join17(getStateDir(), `session-${projectId}.json`);
+  const projectId = createHash4("sha256").update(process.cwd()).digest("hex").slice(0, 12);
+  return join19(getStateDir(), `session-${projectId}.json`);
 }
 function getActiveSession() {
   return activeSession;
@@ -9171,6 +9171,30 @@ function getAdbSerial() {
   if (process.env.ANDROID_SERIAL)
     return ["-s", process.env.ANDROID_SERIAL];
   return [];
+}
+function attachMeta(result, patch) {
+  try {
+    const first = result.content?.[0];
+    if (!first || first.type !== "text")
+      return result;
+    const envelope = JSON.parse(first.text);
+    const prevTimings = envelope.meta?.timings_ms ?? {};
+    const patchTimings = patch.timings_ms ?? {};
+    envelope.meta = {
+      ...envelope.meta,
+      ...patch,
+      ...Object.keys(prevTimings).length + Object.keys(patchTimings).length > 0 ? { timings_ms: { ...prevTimings, ...patchTimings } } : {}
+    };
+    return {
+      ...result,
+      content: [
+        { type: "text", text: JSON.stringify(envelope) },
+        ...result.content.slice(1)
+      ]
+    };
+  } catch {
+    return result;
+  }
 }
 var SESSION_FILE, LEGACY_SESSION_FILE, activeSession;
 var init_agent_device_wrapper = __esm({
@@ -9223,7 +9247,7 @@ var init_free_port = __esm({
 // packages/rn-dev-agent-core/dist/runners/rn-android-runner-client.js
 import { spawn as spawn2, execFile as execFile3 } from "node:child_process";
 import { promisify as promisify3 } from "node:util";
-import { join as join18 } from "node:path";
+import { join as join20 } from "node:path";
 function androidStatePath(serial) {
   return runnerStatePath(`android-${serial}`);
 }
@@ -9346,11 +9370,11 @@ var init_rn_android_runner_client = __esm({
     init_authority_store();
     execFileAsync2 = promisify3(execFile3);
     RN_ANDROID_RUNNER_DIR = resolveNativeRunnerDir("rn-android-runner");
-    GRADLEW = join18(RN_ANDROID_RUNNER_DIR, "gradlew");
-    APK_APP = join18(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
-    APK_TEST = join18(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
-    ANDROID_REBUILD_ROOT = join18(RN_ANDROID_RUNNER_DIR, "app", "build");
-    ANDROID_REBUILD_LOCK_DATABASE = join18(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
+    GRADLEW = join20(RN_ANDROID_RUNNER_DIR, "gradlew");
+    APK_APP = join20(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
+    APK_TEST = join20(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
+    ANDROID_REBUILD_ROOT = join20(RN_ANDROID_RUNNER_DIR, "app", "build");
+    ANDROID_REBUILD_LOCK_DATABASE = join20(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
     ANDROID_REBUILD_LOCK_STALE_MS = 15 * 6e4;
     ADB_CLEANUP_TIMEOUT_MS = 5e3;
     runnerProcess2 = null;
@@ -9462,14 +9486,14 @@ var init_discovery = __esm({
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
 import { homedir as homedir4 } from "node:os";
-import { join as join19 } from "node:path";
+import { join as join21 } from "node:path";
 var DAEMON_JSON, DAEMON_LOCK;
 var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON = join19(homedir4(), ".agent-device", "daemon.json");
-    DAEMON_LOCK = join19(homedir4(), ".agent-device", "daemon.lock");
+    DAEMON_JSON = join21(homedir4(), ".agent-device", "daemon.json");
+    DAEMON_LOCK = join21(homedir4(), ".agent-device", "daemon.lock");
   }
 });
 
@@ -10234,9 +10258,9 @@ var init_utils = __esm({
 // packages/rn-dev-agent-core/dist/runners/release-android-slot.js
 import { execFile as execFileCb9 } from "node:child_process";
 import { promisify as promisify12 } from "node:util";
-import { existsSync as existsSync15, readFileSync as readFileSync13, unlinkSync as unlinkSync7 } from "node:fs";
+import { existsSync as existsSync16, readFileSync as readFileSync14, unlinkSync as unlinkSync7 } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { join as join21 } from "node:path";
+import { join as join23 } from "node:path";
 function isProtectedPid(pid, selfPid, parentPid) {
   return pid === selfPid || pid === parentPid;
 }
@@ -10253,7 +10277,7 @@ function defaultDeps() {
     resolveSerial: (deviceId) => deviceId ? ["-s", deviceId] : getAdbSerial(),
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync13(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync14(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -10269,7 +10293,7 @@ function defaultDeps() {
     },
     protectedPids: () => ({ selfPid: process.pid, parentPid: process.ppid }),
     kill: (pid, sig) => process.kill(pid, sig),
-    fileExists: (p) => existsSync15(p),
+    fileExists: (p) => existsSync16(p),
     removeFile: (p) => unlinkSync7(p),
     delay: (ms) => new Promise((resolve9) => setTimeout(resolve9, ms)),
     killLegacy: () => process.env.RN_DEVICE_KILL_LEGACY !== "0",
@@ -10383,8 +10407,8 @@ var init_release_android_slot = __esm({
     init_rn_android_runner_client();
     init_agent_device_wrapper();
     execFile12 = promisify12(execFileCb9);
-    DAEMON_JSON2 = join21(homedir5(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join21(homedir5(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join23(homedir5(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join23(homedir5(), ".agent-device", "daemon.lock");
     DAEMON_FILES = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS = 500;
     ADB_TIMEOUT_MS = 5e3;
@@ -10405,7 +10429,7 @@ var init_release_android_slot = __esm({
 // packages/rn-dev-agent-core/dist/maestro-runner-pin.js
 import { spawnSync as spawnSync3 } from "node:child_process";
 import { existsSync as existsSync18 } from "node:fs";
-import { dirname as dirname15, join as join24, resolve as resolve8 } from "node:path";
+import { dirname as dirname15, join as join25, resolve as resolve8 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/domain/engine-pin.js
@@ -14361,13 +14385,319 @@ function filterWithBoundedRegex(candidates, pattern, timeoutMs = 500) {
   });
 }
 
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+import { closeSync as closeSync4, constants as constants5, fstatSync as fstatSync4, lstatSync as lstatSync9, openSync as openSync4, readSync as readSync2, realpathSync as realpathSync7 } from "node:fs";
+import { join as join13, sep as sep8 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
+import { existsSync as existsSync11, readFileSync as readFileSync10, readdirSync as readdirSync5, realpathSync as realpathSync6, rmSync as rmSync2 } from "node:fs";
+import { createHash as createHash3 } from "node:crypto";
+import { tmpdir as tmpdir2 } from "node:os";
+import { isAbsolute as isAbsolute6, join as join12, sep as sep7 } from "node:path";
+var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
+var WEAK_DEVICE_ID_KEYS = ["id"];
+var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
+function idsFrom(value, keys) {
+  if (!value || typeof value !== "object")
+    return [];
+  const record = value;
+  for (const key of keys) {
+    const id = record[key];
+    if (typeof id === "string")
+      return [id];
+  }
+  return [];
+}
+function deviceIdsFrom(value) {
+  return idsFrom(value, DEVICE_ID_KEYS);
+}
+function weakDeviceIdsFrom(value) {
+  if (typeof value === "string")
+    return [value];
+  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
+}
+function containerDeviceIdsFrom(value) {
+  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
+}
+function reportDeviceIds(reportDir) {
+  const reportPath = join12(reportDir, "report.json");
+  if (!existsSync11(reportPath))
+    return { ids: [], strength: "none" };
+  try {
+    const report = JSON.parse(readFileSync10(reportPath, "utf8"));
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    const devices = [report.device, ...flows.map((flow) => flow?.device)];
+    const strong = [
+      ...devices.flatMap((device) => deviceIdsFrom(device)),
+      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
+    ];
+    const usingStrong = strong.length > 0;
+    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
+    const accepted = [
+      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
+    ];
+    return {
+      ids: accepted,
+      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
+    };
+  } catch {
+    return { ids: [], strength: "none" };
+  }
+}
+function createRunnerReportDir(runner, prefix) {
+  if (runner !== "maestro-runner")
+    return null;
+  return join12(tmpdir2(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+}
+function runnerReportArgs(reportDir) {
+  return reportDir ? ["--output", reportDir, "--flatten"] : [];
+}
+function collectDirectRunnerEvidence(reportDir, output) {
+  if (!reportDir)
+    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
+  const report = reportDeviceIds(reportDir);
+  const evidence = {
+    output,
+    reportDeviceIds: report.ids,
+    reportDeviceIdStrength: report.strength
+  };
+  const logPath = join12(reportDir, "maestro-runner.log");
+  if (!existsSync11(logPath))
+    return evidence;
+  try {
+    evidence.output = `${output}
+${readFileSync10(logPath, "utf8")}`;
+  } catch {
+  }
+  return evidence;
+}
+var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
+  "passed",
+  "failed",
+  "skipped",
+  "running",
+  "pending"
+]);
+function observationStatus(value) {
+  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
+}
+var FINGERPRINT_INCONCLUSIVE = "unreadable";
+function contentHash(path) {
+  try {
+    return createHash3("sha256").update(readFileSync10(path)).digest("hex");
+  } catch (error) {
+    return error?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
+  }
+}
+function runnerReportFingerprint(reportDir) {
+  const fingerprint = {};
+  if (!reportDir)
+    return fingerprint;
+  const reportHash = contentHash(join12(reportDir, "report.json"));
+  if (reportHash)
+    fingerprint["report.json"] = reportHash;
+  let flowEntries = [];
+  try {
+    flowEntries = readdirSync5(join12(reportDir, "flows"));
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
+    }
+    return fingerprint;
+  }
+  for (const entry of flowEntries.sort()) {
+    const flowHash = contentHash(join12(reportDir, "flows", entry));
+    if (flowHash)
+      fingerprint[`flows/${entry}`] = flowHash;
+  }
+  return fingerprint;
+}
+function readStructuredFlowArtifact(reportDir, previous, readText = (path) => readFileSync10(path, "utf8")) {
+  if (!reportDir)
+    return null;
+  const reportPath = join12(reportDir, "report.json");
+  if (!existsSync11(reportPath))
+    return null;
+  const unfinalized = {
+    finalized: false,
+    flowStatus: "unknown",
+    commands: []
+  };
+  try {
+    const reportText = readText(reportPath);
+    if (previous) {
+      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
+        return unfinalized;
+      const reportHash = createHash3("sha256").update(reportText).digest("hex");
+      if (previous["report.json"] === reportHash)
+        return null;
+    }
+    const report = JSON.parse(reportText);
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    if (flows.length !== 1)
+      return unfinalized;
+    const flow = flows[0];
+    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
+    if (flowStatus === "unknown")
+      return unfinalized;
+    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
+      return unfinalized;
+    const normalizedDataFile = flow.dataFile;
+    if (isAbsolute6(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+      return unfinalized;
+    }
+    const realDataFile = realpathSync6(join12(reportDir, normalizedDataFile));
+    if (!realDataFile.startsWith(realpathSync6(reportDir) + sep7))
+      return unfinalized;
+    const dataText = readText(realDataFile);
+    if (previous) {
+      const dataHash = createHash3("sha256").update(dataText).digest("hex");
+      if (previous[normalizedDataFile] === dataHash)
+        return unfinalized;
+    }
+    const data = JSON.parse(dataText);
+    if (!Array.isArray(data.commands))
+      return unfinalized;
+    let malformedRow = false;
+    const seenIndices = /* @__PURE__ */ new Set();
+    const commands = data.commands.map((entry) => {
+      const record = entry ?? {};
+      const error = record.error ?? void 0;
+      const status = observationStatus(record.status);
+      const producerIndex = typeof record.index === "number" && Number.isInteger(record.index) && record.index >= 0 ? record.index : null;
+      if (producerIndex === null || seenIndices.has(producerIndex)) {
+        malformedRow = true;
+      } else {
+        seenIndices.add(producerIndex);
+      }
+      if (typeof record.type !== "string" || record.type.length === 0 || status === "unknown") {
+        malformedRow = true;
+      }
+      return {
+        index: producerIndex ?? -1,
+        type: typeof record.type === "string" ? record.type : "unknown",
+        status,
+        ...error && typeof error.message === "string" ? { error: error.message.slice(0, 500) } : {}
+      };
+    });
+    if (malformedRow)
+      return { finalized: false, flowStatus, commands: [] };
+    const counts = flow.commands ?? {};
+    const statusCount = (status) => commands.filter((command) => command.status === status).length;
+    const countExact = (key, actual) => counts[key] === actual;
+    const anyFailedRow = commands.some((command) => command.status === "failed");
+    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
+    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
+    return { finalized, flowStatus, commands };
+  } catch {
+    return unfinalized;
+  }
+}
+function disposeRunnerReportDir(reportDir) {
+  if (!reportDir)
+    return;
+  try {
+    rmSync2(reportDir, { recursive: true, force: true });
+  } catch {
+  }
+}
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+var MAX_CAPTURES = 8;
+var MAX_ROWS = 64;
+var MAX_REPORT_BYTES = 256 * 1024;
+function createRunnerFailureEvidence() {
+  return {
+    version: 1,
+    incomplete: true,
+    withheld: "text-images-terminal-output-and-original-artifacts",
+    capturesTruncated: false,
+    captures: []
+  };
+}
+function append(evidence, capture) {
+  evidence.captures.push(capture);
+  if (evidence.captures.length > MAX_CAPTURES) {
+    evidence.captures.splice(1, 1);
+    evidence.capturesTruncated = true;
+  }
+}
+function captureRunnerFailure(evidence, reportDir, previous, stage, invocation, termination, attempt = 1) {
+  const capture = {
+    attempt,
+    stage,
+    invocation,
+    exitCode: Number.isSafeInteger(termination.exitCode) ? termination.exitCode : null,
+    signalPresent: termination.signal !== null,
+    timedOut: termination.timedOut,
+    outputTruncated: termination.outputTruncated,
+    bootstrapFailure: termination.bootstrapFailure,
+    transportFailure: termination.transportFailure,
+    report: "missing",
+    rowsTruncated: false,
+    commands: []
+  };
+  try {
+    if (reportDir) {
+      if (!lstatSync9(reportDir).isDirectory())
+        throw new Error();
+      const root2 = realpathSync7(reportDir);
+      const reportPath = join13(root2, "report.json");
+      lstatSync9(reportPath);
+      let readFailure;
+      let remaining = MAX_REPORT_BYTES;
+      const artifact = readStructuredFlowArtifact(root2, previous, (path) => {
+        let fd;
+        try {
+          if (!realpathSync7(path).startsWith(root2 + sep8))
+            throw new Error();
+          fd = openSync4(path, constants5.O_RDONLY | constants5.O_NOFOLLOW);
+          const stat = fstatSync4(fd);
+          if (!stat.isFile())
+            throw new Error();
+          if (stat.size > remaining) {
+            readFailure = "oversized";
+            throw new Error();
+          }
+          const bytes = Buffer.alloc(stat.size + 1);
+          const size = readSync2(fd, bytes, 0, bytes.length, 0);
+          if (size !== stat.size || fstatSync4(fd).size !== size)
+            throw new Error();
+          remaining -= size;
+          return bytes.subarray(0, size).toString("utf8");
+        } catch (error) {
+          readFailure ??= "unavailable";
+          throw error;
+        } finally {
+          if (fd !== void 0)
+            closeSync4(fd);
+        }
+      });
+      capture.report = readFailure ?? (artifact ? artifact.finalized ? "finalized" : "unfinalized" : "missing");
+      if (artifact?.finalized && !readFailure) {
+        capture.rowsTruncated = artifact.commands.length > MAX_ROWS;
+        const rows = [...artifact.commands].sort((a, b) => Number(b.status === "failed") - Number(a.status === "failed"));
+        capture.commands = rows.slice(0, MAX_ROWS).map((row) => ({
+          index: row.index,
+          status: row.status,
+          errorPresent: row.error !== void 0
+        }));
+      }
+    }
+  } catch (error) {
+    capture.report = error.code === "ENOENT" ? "missing" : "unavailable";
+  }
+  append(evidence, capture);
+}
+
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 init_utils();
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
 import { existsSync as existsSync17, readFileSync as readFileSync15, writeFileSync as writeFileSync6 } from "node:fs";
 import { tmpdir as tmpdir4 } from "node:os";
-import { basename as basename8, join as join23, dirname as dirname14 } from "node:path";
+import { basename as basename8, join as join24, dirname as dirname14 } from "node:path";
 init_agent_device_wrapper();
 init_project_config();
 
@@ -14406,17 +14736,17 @@ function chooseMaestroDispatch(inputs) {
 
 // packages/rn-dev-agent-core/dist/tools/resolve-ios-app-file.js
 import { execFileSync as execFileSync3 } from "node:child_process";
-import { existsSync as existsSync14, cpSync as cpSync2, rmSync as rmSync2, mkdirSync as mkdirSync10, readdirSync as readdirSync6, statSync as statSync6 } from "node:fs";
-import { tmpdir as tmpdir2 } from "node:os";
-import { join as join20, basename as basename7 } from "node:path";
+import { existsSync as existsSync15, cpSync as cpSync2, rmSync as rmSync3, mkdirSync as mkdirSync10, readdirSync as readdirSync7, statSync as statSync6 } from "node:fs";
+import { tmpdir as tmpdir3 } from "node:os";
+import { join as join22, basename as basename7 } from "node:path";
 function flowUsesClearState(flowText) {
   return /clearState:\s*true\b/.test(flowText) || /^[ \t]*-[ \t]*clearState[ \t]*$/m.test(flowText);
 }
 function defaultSnapshotApp(appPath) {
   try {
-    const destDir = join20(tmpdir2(), "rn-appfile-snapshots");
-    const dest = join20(destDir, basename7(appPath));
-    rmSync2(dest, { recursive: true, force: true });
+    const destDir = join22(tmpdir3(), "rn-appfile-snapshots");
+    const dest = join22(destDir, basename7(appPath));
+    rmSync3(dest, { recursive: true, force: true });
     mkdirSync10(destDir, { recursive: true });
     try {
       execFileSync3("cp", ["-Rc", appPath, dest], { timeout: 3e4, stdio: "ignore" });
@@ -14429,7 +14759,7 @@ function defaultSnapshotApp(appPath) {
   }
 }
 function resolveIosAppFile(bundleId, deps = {}) {
-  const exists = deps.exists ?? existsSync14;
+  const exists = deps.exists ?? existsSync15;
   const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
   const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
   const fromContainer = getAppContainer(bundleId, deps.deviceId);
@@ -14933,220 +15263,6 @@ function maestroAuthorityRefusal(authority, underlyingError) {
     return null;
   const headline = `Maestro device authority refused: requested ${authority.requestedDeviceId}, direct runner/WDA evidence was ${authority.reportedDeviceId ?? "missing"} (${authority.reason}).`;
   return underlyingError ? `${headline} Underlying failure: ${underlyingError}` : headline;
-}
-
-// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
-import { existsSync as existsSync16, readFileSync as readFileSync14, readdirSync as readdirSync7, realpathSync as realpathSync7, rmSync as rmSync3 } from "node:fs";
-import { createHash as createHash4 } from "node:crypto";
-import { tmpdir as tmpdir3 } from "node:os";
-import { isAbsolute as isAbsolute6, join as join22, sep as sep7 } from "node:path";
-var DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
-var DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
-var WEAK_DEVICE_ID_KEYS = ["id"];
-var CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
-function idsFrom(value, keys) {
-  if (!value || typeof value !== "object")
-    return [];
-  const record = value;
-  for (const key of keys) {
-    const id = record[key];
-    if (typeof id === "string")
-      return [id];
-  }
-  return [];
-}
-function deviceIdsFrom(value) {
-  return idsFrom(value, DEVICE_ID_KEYS);
-}
-function weakDeviceIdsFrom(value) {
-  if (typeof value === "string")
-    return [value];
-  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
-}
-function containerDeviceIdsFrom(value) {
-  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
-}
-function reportDeviceIds(reportDir) {
-  const reportPath = join22(reportDir, "report.json");
-  if (!existsSync16(reportPath))
-    return { ids: [], strength: "none" };
-  try {
-    const report = JSON.parse(readFileSync14(reportPath, "utf8"));
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    const devices = [report.device, ...flows.map((flow) => flow?.device)];
-    const strong = [
-      ...devices.flatMap((device) => deviceIdsFrom(device)),
-      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
-    ];
-    const usingStrong = strong.length > 0;
-    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
-    const accepted = [
-      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
-    ];
-    return {
-      ids: accepted,
-      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
-    };
-  } catch {
-    return { ids: [], strength: "none" };
-  }
-}
-function createRunnerReportDir(runner, prefix) {
-  if (runner !== "maestro-runner")
-    return null;
-  return join22(tmpdir3(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-}
-function runnerReportArgs(reportDir) {
-  return reportDir ? ["--output", reportDir, "--flatten"] : [];
-}
-function collectDirectRunnerEvidence(reportDir, output) {
-  if (!reportDir)
-    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
-  const report = reportDeviceIds(reportDir);
-  const evidence = {
-    output,
-    reportDeviceIds: report.ids,
-    reportDeviceIdStrength: report.strength
-  };
-  const logPath = join22(reportDir, "maestro-runner.log");
-  if (!existsSync16(logPath))
-    return evidence;
-  try {
-    evidence.output = `${output}
-${readFileSync14(logPath, "utf8")}`;
-  } catch {
-  }
-  return evidence;
-}
-var OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
-  "passed",
-  "failed",
-  "skipped",
-  "running",
-  "pending"
-]);
-function observationStatus(value) {
-  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
-}
-var FINGERPRINT_INCONCLUSIVE = "unreadable";
-function contentHash(path) {
-  try {
-    return createHash4("sha256").update(readFileSync14(path)).digest("hex");
-  } catch (error) {
-    return error?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
-  }
-}
-function runnerReportFingerprint(reportDir) {
-  const fingerprint = {};
-  if (!reportDir)
-    return fingerprint;
-  const reportHash = contentHash(join22(reportDir, "report.json"));
-  if (reportHash)
-    fingerprint["report.json"] = reportHash;
-  let flowEntries = [];
-  try {
-    flowEntries = readdirSync7(join22(reportDir, "flows"));
-  } catch (error) {
-    if (error?.code !== "ENOENT") {
-      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
-    }
-    return fingerprint;
-  }
-  for (const entry of flowEntries.sort()) {
-    const flowHash = contentHash(join22(reportDir, "flows", entry));
-    if (flowHash)
-      fingerprint[`flows/${entry}`] = flowHash;
-  }
-  return fingerprint;
-}
-function readStructuredFlowArtifact(reportDir, previous) {
-  if (!reportDir)
-    return null;
-  const reportPath = join22(reportDir, "report.json");
-  if (!existsSync16(reportPath))
-    return null;
-  const unfinalized = {
-    finalized: false,
-    flowStatus: "unknown",
-    commands: []
-  };
-  try {
-    const reportText = readFileSync14(reportPath, "utf8");
-    if (previous) {
-      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
-        return unfinalized;
-      const reportHash = createHash4("sha256").update(reportText).digest("hex");
-      if (previous["report.json"] === reportHash)
-        return null;
-    }
-    const report = JSON.parse(reportText);
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    if (flows.length !== 1)
-      return unfinalized;
-    const flow = flows[0];
-    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
-    if (flowStatus === "unknown")
-      return unfinalized;
-    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
-      return unfinalized;
-    const normalizedDataFile = flow.dataFile;
-    if (isAbsolute6(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
-      return unfinalized;
-    }
-    const realDataFile = realpathSync7(join22(reportDir, normalizedDataFile));
-    if (!realDataFile.startsWith(realpathSync7(reportDir) + sep7))
-      return unfinalized;
-    const dataText = readFileSync14(realDataFile, "utf8");
-    if (previous) {
-      const dataHash = createHash4("sha256").update(dataText).digest("hex");
-      if (previous[normalizedDataFile] === dataHash)
-        return unfinalized;
-    }
-    const data = JSON.parse(dataText);
-    if (!Array.isArray(data.commands))
-      return unfinalized;
-    let malformedRow = false;
-    const seenIndices = /* @__PURE__ */ new Set();
-    const commands = data.commands.map((entry) => {
-      const record = entry ?? {};
-      const error = record.error ?? void 0;
-      const status = observationStatus(record.status);
-      const producerIndex = typeof record.index === "number" && Number.isInteger(record.index) && record.index >= 0 ? record.index : null;
-      if (producerIndex === null || seenIndices.has(producerIndex)) {
-        malformedRow = true;
-      } else {
-        seenIndices.add(producerIndex);
-      }
-      if (typeof record.type !== "string" || record.type.length === 0 || status === "unknown") {
-        malformedRow = true;
-      }
-      return {
-        index: producerIndex ?? -1,
-        type: typeof record.type === "string" ? record.type : "unknown",
-        status,
-        ...error && typeof error.message === "string" ? { error: error.message.slice(0, 500) } : {}
-      };
-    });
-    if (malformedRow)
-      return { finalized: false, flowStatus, commands: [] };
-    const counts = flow.commands ?? {};
-    const statusCount = (status) => commands.filter((command) => command.status === status).length;
-    const countExact = (key, actual) => counts[key] === actual;
-    const anyFailedRow = commands.some((command) => command.status === "failed");
-    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
-    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
-    return { finalized, flowStatus, commands };
-  } catch {
-    return unfinalized;
-  }
-}
-function disposeRunnerReportDir(reportDir) {
-  if (!reportDir)
-    return;
-  try {
-    rmSync3(reportDir, { recursive: true, force: true });
-  } catch {
-  }
 }
 
 // packages/rn-dev-agent-core/dist/domain/maestro-run-ledger.js
@@ -16525,7 +16641,7 @@ function createMaestroRunHandler(deps = {}) {
   const resolveEngineStatus = deps.resolveEngineStatus ?? (() => getEngineStatus().catch(() => null));
   const replayFactory = deps.replayDeps;
   const nativeOnlyHandler = replayFactory ? createMaestroRunHandler({ ...deps, replayDeps: void 0 }) : null;
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (args.params) {
       for (const [key, value] of Object.entries(args.params)) {
         if (!PARAM_KEY_RE.test(key)) {
@@ -16603,7 +16719,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join23(tmpdir4(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join24(tmpdir4(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -17006,6 +17122,7 @@ function createMaestroRunHandler(deps = {}) {
     })();
     const stageCaptures = [];
     let ledgerStageCursor = 0;
+    let invocationOrdinal = 0;
     const stageTerminationFromError = (error) => {
       const errorClass = classifyExecError(error);
       const raw = error;
@@ -17073,7 +17190,8 @@ function createMaestroRunHandler(deps = {}) {
                 Object.assign(error, { code: "ETIMEDOUT" });
                 throw error;
               }
-              const executeRunner = (runnerPath, prefixArgs = []) => {
+              const executeRunner = async (runnerPath, prefixArgs = []) => {
+                const fingerprint = runnerReportFingerprint(runnerReportDir);
                 beforeDispatch?.();
                 const remainingTimeout = flowDeadline - now();
                 if (remainingTimeout <= 0) {
@@ -17081,12 +17199,29 @@ function createMaestroRunHandler(deps = {}) {
                   Object.assign(error, { code: "ETIMEDOUT" });
                   throw error;
                 }
-                return execute(runnerPath, [...prefixArgs, ...finalArgs], {
-                  timeout: remainingTimeout,
-                  encoding: "utf8",
-                  maxBuffer: 10 * 1024 * 1024,
-                  signal: flowAbort.signal
-                });
+                const invocation = ++invocationOrdinal;
+                try {
+                  const result = await execute(runnerPath, [...prefixArgs, ...finalArgs], {
+                    timeout: remainingTimeout,
+                    encoding: "utf8",
+                    maxBuffer: 10 * 1024 * 1024,
+                    signal: flowAbort.signal
+                  });
+                  if (outputIndicatesFlowFailure(combineRunnerOutput(result.stdout, result.stderr))) {
+                    captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, {
+                      exitCode: 0,
+                      signal: null,
+                      timedOut: false,
+                      outputTruncated: false,
+                      bootstrapFailure: false,
+                      transportFailure: false
+                    }, ledgerAttempt.ordinal);
+                  }
+                  return result;
+                } catch (error) {
+                  captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, stageTerminationFromError(error), ledgerAttempt.ordinal);
+                  throw error;
+                }
               };
               if (deps.execFile) {
                 const immediateStatus = await resolveEngineStatus();
@@ -17484,6 +17619,18 @@ function createMaestroRunHandler(deps = {}) {
       }
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error) {
+      if (error instanceof SessionAuthorityError && evidence.captures.length) {
+        error.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error;
+    }
+  };
 }
 
 // packages/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -17491,9 +17638,9 @@ var USAGE = "usage: maestro-runner-pin [diagnose|install|migrate-actions|verify-
 function ensureScriptPath() {
   const here = dirname15(fileURLToPath2(import.meta.url));
   const candidates = [
-    join24(here, "..", "..", "..", "scripts", "ensure-maestro-runner.sh"),
-    join24(here, "..", "scripts", "ensure-maestro-runner.sh"),
-    join24(here, "..", "..", "scripts", "ensure-maestro-runner.sh")
+    join25(here, "..", "..", "..", "scripts", "ensure-maestro-runner.sh"),
+    join25(here, "..", "scripts", "ensure-maestro-runner.sh"),
+    join25(here, "..", "..", "scripts", "ensure-maestro-runner.sh")
   ];
   return candidates.find((path) => existsSync18(path)) ?? candidates[0];
 }
@@ -17571,7 +17718,7 @@ async function verifyActions(argv) {
     }
   }
   const flowDir = resolve8(flowDirArg);
-  const flowDirClassification = classifyLearnedActionPath(join24(flowDir, "__action__.yaml"));
+  const flowDirClassification = classifyLearnedActionPath(join25(flowDir, "__action__.yaml"));
   if (flowDirClassification !== "action") {
     console.error(`Refusing to execute flows outside an owned .rn-agent/actions corpus: ${flowDir}.`);
     return 2;
@@ -17598,7 +17745,7 @@ async function verifyActions(argv) {
       console.error(`verify-actions pattern is ${filtered.reason}: ${filtered.message}`);
       return 2;
     }
-    files = filtered.matches.map((file) => join24(flowDir, file)).sort();
+    files = filtered.matches.map((file) => join25(flowDir, file)).sort();
   } catch (err) {
     console.error(`verify-actions could not read ${flowDir}: ${String(err)}`);
     return 2;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -5203,10 +5203,10 @@ var require_resolve_block_map = __commonJS({
       let offset = bm.offset;
       let commentEnd = null;
       for (const collItem of bm.items) {
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const keyProps = resolveProps.resolveProps(start, {
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: bm.indent,
@@ -5220,7 +5220,7 @@ var require_resolve_block_map = __commonJS({
             else if ("indent" in key && key.indent !== bm.indent)
               onError(offset, "BAD_INDENT", startColMsg);
           }
-          if (!keyProps.anchor && !keyProps.tag && !sep11) {
+          if (!keyProps.anchor && !keyProps.tag && !sep12) {
             commentEnd = keyProps.end;
             if (keyProps.comment) {
               if (map.comment)
@@ -5244,7 +5244,7 @@ var require_resolve_block_map = __commonJS({
         ctx.atKey = false;
         if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
           onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-        const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+        const valueProps = resolveProps.resolveProps(sep12 ?? [], {
           indicator: "map-value-ind",
           next: value,
           offset: keyNode.range[2],
@@ -5260,7 +5260,7 @@ var require_resolve_block_map = __commonJS({
             if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
               onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep11, null, valueProps, onError);
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep12, null, valueProps, onError);
           if (ctx.schema.compat)
             utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
           offset = valueNode.range[2];
@@ -5351,7 +5351,7 @@ var require_resolve_end = __commonJS({
       let comment = "";
       if (end) {
         let hasSpace = false;
-        let sep11 = "";
+        let sep12 = "";
         for (const token2 of end) {
           const { source, type } = token2;
           switch (type) {
@@ -5365,13 +5365,13 @@ var require_resolve_end = __commonJS({
               if (!comment)
                 comment = cb;
               else
-                comment += sep11 + cb;
-              sep11 = "";
+                comment += sep12 + cb;
+              sep12 = "";
               break;
             }
             case "newline":
               if (comment)
-                sep11 += source;
+                sep12 += source;
               hasSpace = true;
               break;
             default:
@@ -5414,18 +5414,18 @@ var require_resolve_flow_collection = __commonJS({
       let offset = fc.offset + fc.start.source.length;
       for (let i = 0; i < fc.items.length; ++i) {
         const collItem = fc.items[i];
-        const { start, key, sep: sep11, value } = collItem;
+        const { start, key, sep: sep12, value } = collItem;
         const props = resolveProps.resolveProps(start, {
           flow: fcName,
           indicator: "explicit-key-ind",
-          next: key ?? sep11?.[0],
+          next: key ?? sep12?.[0],
           offset,
           onError,
           parentIndent: fc.indent,
           startOnNewline: false
         });
         if (!props.found) {
-          if (!props.anchor && !props.tag && !sep11 && !value) {
+          if (!props.anchor && !props.tag && !sep12 && !value) {
             if (i === 0 && props.comma)
               onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
             else if (i < fc.items.length - 1)
@@ -5479,8 +5479,8 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap && !sep11 && !props.found) {
-          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep11, null, props, onError);
+        if (!isMap && !sep12 && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep12, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
           if (isBlock(value))
@@ -5492,7 +5492,7 @@ var require_resolve_flow_collection = __commonJS({
           if (isBlock(key))
             onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
           ctx.atKey = false;
-          const valueProps = resolveProps.resolveProps(sep11 ?? [], {
+          const valueProps = resolveProps.resolveProps(sep12 ?? [], {
             flow: fcName,
             indicator: "map-value-ind",
             next: value,
@@ -5503,8 +5503,8 @@ var require_resolve_flow_collection = __commonJS({
           });
           if (valueProps.found) {
             if (!isMap && !props.found && ctx.options.strict) {
-              if (sep11)
-                for (const st of sep11) {
+              if (sep12)
+                for (const st of sep12) {
                   if (st === valueProps.found)
                     break;
                   if (st.type === "newline") {
@@ -5521,7 +5521,7 @@ var require_resolve_flow_collection = __commonJS({
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
           }
-          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep11, null, valueProps, onError) : null;
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep12, null, valueProps, onError) : null;
           if (valueNode) {
             if (isBlock(value))
               onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -5701,7 +5701,7 @@ var require_resolve_block_scalar = __commonJS({
           chompStart = i + 1;
       }
       let value = "";
-      let sep11 = "";
+      let sep12 = "";
       let prevMoreIndented = false;
       for (let i = 0; i < contentStart; ++i)
         value += lines[i][0].slice(trimIndent) + "\n";
@@ -5718,24 +5718,24 @@ var require_resolve_block_scalar = __commonJS({
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
         } else if (indent.length > trimIndent || content[0] === "	") {
-          if (sep11 === " ")
-            sep11 = "\n";
-          else if (!prevMoreIndented && sep11 === "\n")
-            sep11 = "\n\n";
-          value += sep11 + indent.slice(trimIndent) + content;
-          sep11 = "\n";
+          if (sep12 === " ")
+            sep12 = "\n";
+          else if (!prevMoreIndented && sep12 === "\n")
+            sep12 = "\n\n";
+          value += sep12 + indent.slice(trimIndent) + content;
+          sep12 = "\n";
           prevMoreIndented = true;
         } else if (content === "") {
-          if (sep11 === "\n")
+          if (sep12 === "\n")
             value += "\n";
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          value += sep11 + content;
-          sep11 = " ";
+          value += sep12 + content;
+          sep12 = " ";
           prevMoreIndented = false;
         }
       }
@@ -5917,25 +5917,25 @@ var require_resolve_flow_scalar = __commonJS({
       if (!match)
         return source;
       let res = match[1];
-      let sep11 = " ";
+      let sep12 = " ";
       let pos = first.lastIndex;
       line.lastIndex = pos;
       while (match = line.exec(source)) {
         if (match[1] === "") {
-          if (sep11 === "\n")
-            res += sep11;
+          if (sep12 === "\n")
+            res += sep12;
           else
-            sep11 = "\n";
+            sep12 = "\n";
         } else {
-          res += sep11 + match[1];
-          sep11 = " ";
+          res += sep12 + match[1];
+          sep12 = " ";
         }
         pos = line.lastIndex;
       }
       const last = /[ \t]*(.*)/sy;
       last.lastIndex = pos;
       match = last.exec(source);
-      return res + sep11 + (match?.[1] ?? "");
+      return res + sep12 + (match?.[1] ?? "");
     }
     function doubleQuotedValue(source, onError) {
       let res = "";
@@ -6745,14 +6745,14 @@ var require_cst_stringify = __commonJS({
         }
       }
     }
-    function stringifyItem({ start, key, sep: sep11, value }) {
+    function stringifyItem({ start, key, sep: sep12, value }) {
       let res = "";
       for (const st of start)
         res += st.source;
       if (key)
         res += stringifyToken(key);
-      if (sep11)
-        for (const st of sep11)
+      if (sep12)
+        for (const st of sep12)
           res += st.source;
       if (value)
         res += stringifyToken(value);
@@ -7919,18 +7919,18 @@ var require_parser = __commonJS({
         if (this.type === "map-value-ind") {
           const prev = getPrevProps(this.peek(2));
           const start = getFirstKeyStartProps(prev);
-          let sep11;
+          let sep12;
           if (scalar.end) {
-            sep11 = scalar.end;
-            sep11.push(this.sourceToken);
+            sep12 = scalar.end;
+            sep12.push(this.sourceToken);
             delete scalar.end;
           } else
-            sep11 = [this.sourceToken];
+            sep12 = [this.sourceToken];
           const map = {
             type: "block-map",
             offset: scalar.offset,
             indent: scalar.indent,
-            items: [{ start, key: scalar, sep: sep11 }]
+            items: [{ start, key: scalar, sep: sep12 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -8083,15 +8083,15 @@ var require_parser = __commonJS({
                 } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                   const start2 = getFirstKeyStartProps(it.start);
                   const key = it.key;
-                  const sep11 = it.sep;
-                  sep11.push(this.sourceToken);
+                  const sep12 = it.sep;
+                  sep12.push(this.sourceToken);
                   delete it.key;
                   delete it.sep;
                   this.stack.push({
                     type: "block-map",
                     offset: this.offset,
                     indent: this.indent,
-                    items: [{ start: start2, key, sep: sep11 }]
+                    items: [{ start: start2, key, sep: sep12 }]
                   });
                 } else if (start.length > 0) {
                   it.sep = it.sep.concat(start, this.sourceToken);
@@ -8285,13 +8285,13 @@ var require_parser = __commonJS({
             const prev = getPrevProps(parent);
             const start = getFirstKeyStartProps(prev);
             fixFlowSeqItems(fc);
-            const sep11 = fc.end.splice(1, fc.end.length);
-            sep11.push(this.sourceToken);
+            const sep12 = fc.end.splice(1, fc.end.length);
+            sep12.push(this.sourceToken);
             const map = {
               type: "block-map",
               offset: fc.offset,
               indent: fc.indent,
-              items: [{ start, key: fc, sep: sep11 }]
+              items: [{ start, key: fc, sep: sep12 }]
             };
             this.onKeyLine = true;
             this.stack[this.stack.length - 1] = map;
@@ -9005,7 +9005,7 @@ function recordNavigation(projectRoot, input) {
   if (!targetScreen)
     return null;
   const now = (/* @__PURE__ */ new Date()).toISOString();
-  const record2 = {
+  const record3 = {
     method: input.method,
     success: input.success,
     latency_ms: input.latency_ms ?? 0,
@@ -9013,7 +9013,7 @@ function recordNavigation(projectRoot, input) {
   };
   if (!targetScreen.action_records)
     targetScreen.action_records = [];
-  targetScreen.action_records.push(record2);
+  targetScreen.action_records.push(record3);
   if (targetScreen.action_records.length > MAX_ACTION_RECORDS) {
     targetScreen.action_records = targetScreen.action_records.slice(-MAX_ACTION_RECORDS);
   }
@@ -20071,17 +20071,17 @@ function getFreshRefTarget(ref, opts = {}) {
     return null;
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
   const rect = refMap.get(key);
-  const record2 = metadataMap.get(key);
-  if (!rect || !record2 || record2.snapshotGeneration !== snapshotGeneration || record2.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
+  const record3 = metadataMap.get(key);
+  if (!rect || !record3 || record3.snapshotGeneration !== snapshotGeneration || record3.keyboardStateAtSnapshot === null && opts.allowUnknownKeyboardState !== true)
     return null;
   return {
     rect,
-    snapshotGeneration: record2.snapshotGeneration,
-    snapshotNodeIndex: record2.snapshotNodeIndex,
-    snapshotElementType: record2.type,
-    ...record2.label !== void 0 ? { snapshotLabel: record2.label } : {},
-    ...record2.identifier !== void 0 ? { snapshotIdentifier: record2.identifier } : {},
-    keyboardStateAtSnapshot: record2.keyboardStateAtSnapshot
+    snapshotGeneration: record3.snapshotGeneration,
+    snapshotNodeIndex: record3.snapshotNodeIndex,
+    snapshotElementType: record3.type,
+    ...record3.label !== void 0 ? { snapshotLabel: record3.label } : {},
+    ...record3.identifier !== void 0 ? { snapshotIdentifier: record3.identifier } : {},
+    keyboardStateAtSnapshot: record3.keyboardStateAtSnapshot
   };
 }
 function getCachedMetadata(ref) {
@@ -22573,10 +22573,10 @@ function referencesMetroEvidenceSocket(value, path) {
   }
   if (!value || typeof value !== "object")
     return false;
-  const record2 = value;
-  if (record2.runtimeEvidenceSocket === path)
+  const record3 = value;
+  if (record3.runtimeEvidenceSocket === path)
     return true;
-  return Object.values(record2).some((entry) => referencesMetroEvidenceSocket(entry, path));
+  return Object.values(record3).some((entry) => referencesMetroEvidenceSocket(entry, path));
 }
 function authorityRemedyNextAction(code) {
   return errorNextActions[code];
@@ -22646,14 +22646,14 @@ function readStartupCleanupBlocker(bindingsJson) {
   const refusal = journal.refusal;
   if (!refusal || typeof refusal !== "object")
     return void 0;
-  const record2 = refusal;
-  if (typeof record2.code !== "string" || typeof record2.reason !== "string")
+  const record3 = refusal;
+  if (typeof record3.code !== "string" || typeof record3.reason !== "string")
     return void 0;
   return {
-    code: record2.code,
-    reason: record2.reason,
-    ...record2.cause === "managed-metro-stop-proof-missing" ? { cause: record2.cause } : {},
-    ...typeof record2.nextAction === "string" ? { nextAction: record2.nextAction } : {}
+    code: record3.code,
+    reason: record3.reason,
+    ...record3.cause === "managed-metro-stop-proof-missing" ? { cause: record3.cause } : {},
+    ...typeof record3.nextAction === "string" ? { nextAction: record3.nextAction } : {}
   };
 }
 function bindingsRunnerPresent(bindingsJson) {
@@ -23593,21 +23593,21 @@ var init_registry = __esm({
               integration: existing.integration ?? null
             };
           }
-          const record2 = (value) => value && typeof value === "object" ? { ...value } : null;
+          const record3 = (value) => value && typeof value === "object" ? { ...value } : null;
           const obligation = (source, claimKey) => source ? {
             ...source,
             claimKey: String(source.claimKey ?? claimKey ?? ""),
             stopRequestedAt: typeof source.stopRequestedAt === "number" ? source.stopRequestedAt : now,
             completedAt: typeof source.completedAt === "number" ? source.completedAt : null
           } : void 0;
-          const handoffCleanup = record2(bindings.handoffCleanup);
-          const staleDevice = record2(bindings.staleDeviceCleanup);
-          const androidMetroReverseSource = record2(bindings.androidMetroReverse) ?? record2(staleDevice?.androidMetroReverse);
-          const recorderSource = record2(bindings.recorder) ?? record2(staleDevice?.recorder) ?? record2(handoffCleanup?.recorder);
-          const runnerSource = record2(bindings.runner) ?? record2(staleDevice?.runner) ?? record2(handoffCleanup?.runner);
-          const observeSource = record2(bindings.observe) ?? record2(handoffCleanup?.observe);
-          const liveMetro = record2(bindings.metroCleanup) ?? record2(bindings.metro);
-          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record2(handoffCleanup?.metro);
+          const handoffCleanup = record3(bindings.handoffCleanup);
+          const staleDevice = record3(bindings.staleDeviceCleanup);
+          const androidMetroReverseSource = record3(bindings.androidMetroReverse) ?? record3(staleDevice?.androidMetroReverse);
+          const recorderSource = record3(bindings.recorder) ?? record3(staleDevice?.recorder) ?? record3(handoffCleanup?.recorder);
+          const runnerSource = record3(bindings.runner) ?? record3(staleDevice?.runner) ?? record3(handoffCleanup?.runner);
+          const observeSource = record3(bindings.observe) ?? record3(handoffCleanup?.observe);
+          const liveMetro = record3(bindings.metroCleanup) ?? record3(bindings.metro);
+          const metroSource = liveMetro && liveMetro.mode === "managed" ? liveMetro : record3(handoffCleanup?.metro);
           const obligations = {};
           const androidMetroReverseEntry = obligation(androidMetroReverseSource, androidMetroReverseSource ? `android:${String(androidMetroReverseSource.deviceId)}` : null);
           if (androidMetroReverseEntry) {
@@ -23625,7 +23625,7 @@ var init_registry = __esm({
           const metroEntry = obligation(metroSource, metroSource ? String(metroSource.port) : null);
           if (metroEntry)
             obligations.metro = metroEntry;
-          const integrationBinding = record2(bindings.packageIntegration);
+          const integrationBinding = record3(bindings.packageIntegration);
           const integration = integrationBinding ? {
             installedBySessionId: integrationBinding.installedBySessionId ?? null,
             manifestSha256: integrationBinding.manifestSha256 ?? null,
@@ -23880,8 +23880,8 @@ var init_registry = __esm({
       #bindingMatchesDevice(binding, target) {
         if (!binding || typeof binding !== "object")
           return false;
-        const record2 = binding;
-        return record2.platform === target.platform && record2.deviceId === target.deviceId;
+        const record3 = binding;
+        return record3.platform === target.platform && record3.deviceId === target.deviceId;
       }
       #requireProvenDeadOwner(sessionId, claimEpoch) {
         const prior = asSession(this.#database.prepare(`SELECT session_id, claim_epoch, state, supervisor_pid, supervisor_birth, bindings_json
@@ -50931,11 +50931,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants10);
+          this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -50952,10 +50952,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants10);
+        this.rhs = optimizeExpr(this.rhs, names, constants11);
         return this;
       }
       get names() {
@@ -51016,8 +51016,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants10) {
-        this.code = optimizeExpr(this.code, names, constants10);
+      optimizeNames(names, constants11) {
+        this.code = optimizeExpr(this.code, names, constants11);
         return this;
       }
       get names() {
@@ -51046,12 +51046,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants10))
+          if (n.optimizeNames(names, constants11))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -51104,12 +51104,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        if (!(super.optimizeNames(names, constants10) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        if (!(super.optimizeNames(names, constants11) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants10);
+        this.condition = optimizeExpr(this.condition, names, constants11);
         return this;
       }
       get names() {
@@ -51132,10 +51132,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants10);
+        this.iteration = optimizeExpr(this.iteration, names, constants11);
         return this;
       }
       get names() {
@@ -51171,10 +51171,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants10) {
-        if (!super.optimizeNames(names, constants10))
+      optimizeNames(names, constants11) {
+        if (!super.optimizeNames(names, constants11))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants10);
+        this.iterable = optimizeExpr(this.iterable, names, constants11);
         return this;
       }
       get names() {
@@ -51216,11 +51216,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants10) {
+      optimizeNames(names, constants11) {
         var _a, _b;
-        super.optimizeNames(names, constants10);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants10);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants10);
+        super.optimizeNames(names, constants11);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants11);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants11);
         return this;
       }
       get names() {
@@ -51521,7 +51521,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants10) {
+    function optimizeExpr(expr, names, constants11) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -51536,14 +51536,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants10[n.str];
+        const c = constants11[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants10[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants11[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -53190,18 +53190,18 @@ var require_validate = __commonJS({
         const { schemaCode } = this;
         this.fail((0, codegen_1._)`${schemaCode} !== undefined && (${(0, codegen_1.or)(this.invalid$data(), condition)})`);
       }
-      error(append, errorParams, errorPaths) {
+      error(append2, errorParams, errorPaths) {
         if (errorParams) {
           this.setParams(errorParams);
-          this._error(append, errorPaths);
+          this._error(append2, errorPaths);
           this.setParams({});
           return;
         }
-        this._error(append, errorPaths);
+        this._error(append2, errorPaths);
       }
-      _error(append, errorPaths) {
+      _error(append2, errorPaths) {
         ;
-        (append ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
+        (append2 ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
       }
       $dataError() {
         (0, errors_1.reportError)(this, this.def.$dataError || errors_1.keyword$DataError);
@@ -71383,10 +71383,10 @@ function openActionDb(projectRoot, opts = {}) {
     const handle = {
       db,
       close: () => db.close(),
-      insertRunRecord(actionId, record2) {
+      insertRunRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM run_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
@@ -71395,7 +71395,7 @@ function openActionDb(projectRoot, opts = {}) {
                (action_id, ts, trigger, status, failure_code, failure_detail,
                 transport, auto_repair_json, duration_ms, device_id, blind_probe_json,
                 trailing_verification_json)
-             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.trigger, record2.status, record2.failureCode ?? null, record2.failureDetail ?? null, record2.transport ?? null, record2.autoRepair ? JSON.stringify(record2.autoRepair) : null, record2.durationMs, record2.deviceId ?? null, record2.blindProbe ? JSON.stringify(record2.blindProbe) : null, record2.trailingVerification ? JSON.stringify(record2.trailingVerification) : null);
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.trigger, record3.status, record3.failureCode ?? null, record3.failureDetail ?? null, record3.transport ?? null, record3.autoRepair ? JSON.stringify(record3.autoRepair) : null, record3.durationMs, record3.deviceId ?? null, record3.blindProbe ? JSON.stringify(record3.blindProbe) : null, record3.trailingVerification ? JSON.stringify(record3.trailingVerification) : null);
           db.prepare(`DELETE FROM run_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -71410,17 +71410,17 @@ function openActionDb(projectRoot, opts = {}) {
           throw e;
         }
       },
-      insertRepairRecord(actionId, record2) {
+      insertRepairRecord(actionId, record3) {
         db.exec("BEGIN IMMEDIATE");
         try {
-          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record2.timestamp);
+          const dup = db.prepare("SELECT 1 FROM repair_records WHERE action_id = ? AND ts = ? LIMIT 1").get(actionId, record3.timestamp);
           if (dup) {
             db.exec("COMMIT");
             return;
           }
           db.prepare(`INSERT INTO repair_records
                (action_id, ts, failure_code, diff_json, duration_ms, agent_reasoning)
-             VALUES (?,?,?,?,?,?)`).run(actionId, record2.timestamp, record2.failureCode, JSON.stringify(record2.diff ?? {}), record2.durationMs, record2.agentReasoning ?? null);
+             VALUES (?,?,?,?,?,?)`).run(actionId, record3.timestamp, record3.failureCode, JSON.stringify(record3.diff ?? {}), record3.durationMs, record3.agentReasoning ?? null);
           db.prepare(`DELETE FROM repair_records
              WHERE action_id = ?
                AND id NOT IN (
@@ -71630,36 +71630,36 @@ function freshRuntimeState(now = () => /* @__PURE__ */ new Date(), mtimeMs = 0) 
     }
   };
 }
-function appendRunRecord(state, record2) {
-  const newHistory = [...state.runHistory, record2];
+function appendRunRecord(state, record3) {
+  const newHistory = [...state.runHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.RUN_HISTORY_MAX)
     newHistory.shift();
   const totalRuns = state.stats.totalRuns + 1;
-  const successCount = state.stats.successCount + (record2.status === "pass" ? 1 : 0);
-  const failureCount = state.stats.failureCount + (record2.status === "fail" ? 1 : 0);
+  const successCount = state.stats.successCount + (record3.status === "pass" ? 1 : 0);
+  const failureCount = state.stats.failureCount + (record3.status === "fail" ? 1 : 0);
   const successDurations = newHistory.filter((r) => r.status === "pass").map((r) => r.durationMs);
   const avgDurationMs = successDurations.length ? Math.round(successDurations.reduce((s, n) => s + n, 0) / successDurations.length) : state.stats.avgDurationMs;
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     runHistory: newHistory,
     stats: {
       totalRuns,
       successCount,
       failureCount,
       avgDurationMs,
-      lastSuccessAt: record2.status === "pass" ? record2.timestamp : state.stats.lastSuccessAt,
-      lastFailureAt: record2.status === "fail" ? record2.timestamp : state.stats.lastFailureAt
+      lastSuccessAt: record3.status === "pass" ? record3.timestamp : state.stats.lastSuccessAt,
+      lastFailureAt: record3.status === "fail" ? record3.timestamp : state.stats.lastFailureAt
     }
   };
 }
-function appendRepairRecord(state, record2) {
-  const newHistory = [...state.repairHistory, record2];
+function appendRepairRecord(state, record3) {
+  const newHistory = [...state.repairHistory, record3];
   while (newHistory.length > HISTORY_LIMITS.REPAIR_HISTORY_MAX)
     newHistory.shift();
   return {
     ...state,
-    updatedAt: record2.timestamp,
+    updatedAt: record3.timestamp,
     revision: state.revision + 1,
     repairHistory: newHistory
   };
@@ -76425,11 +76425,11 @@ function redactBatchFillSteps(args) {
   const redactedSteps = steps.map((step) => {
     if (!step || typeof step !== "object" || Array.isArray(step))
       return step;
-    const record2 = step;
-    if (record2.action !== "fill")
+    const record3 = step;
+    if (record3.action !== "fill")
       return step;
-    const redacted = redactTypedValue(record2, "text");
-    if (redacted !== record2)
+    const redacted = redactTypedValue(record3, "text");
+    if (redacted !== record3)
       changed = true;
     return redacted;
   });
@@ -79080,8 +79080,8 @@ function acknowledgeExternalEdit(action) {
 function canonicalRuntimeJson(state) {
   return JSON.stringify(state, (_key, value) => {
     if (value && typeof value === "object" && !Array.isArray(value)) {
-      const record2 = value;
-      return Object.fromEntries(Object.keys(record2).sort().map((k) => [k, record2[k]]));
+      const record3 = value;
+      return Object.fromEntries(Object.keys(record3).sort().map((k) => [k, record3[k]]));
     }
     return value;
   });
@@ -80760,6 +80760,367 @@ var init_save_as_action = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
+import { existsSync as existsSync29, readFileSync as readFileSync29, readdirSync as readdirSync11, realpathSync as realpathSync15, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash16 } from "node:crypto";
+import { tmpdir as tmpdir9 } from "node:os";
+import { isAbsolute as isAbsolute14, join as join43, sep as sep9 } from "node:path";
+function idsFrom(value, keys) {
+  if (!value || typeof value !== "object")
+    return [];
+  const record3 = value;
+  for (const key of keys) {
+    const id = record3[key];
+    if (typeof id === "string")
+      return [id];
+  }
+  return [];
+}
+function deviceIdsFrom(value) {
+  return idsFrom(value, DEVICE_ID_KEYS);
+}
+function weakDeviceIdsFrom(value) {
+  if (typeof value === "string")
+    return [value];
+  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
+}
+function containerDeviceIdsFrom(value) {
+  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
+}
+function reportDeviceIds(reportDir) {
+  const reportPath = join43(reportDir, "report.json");
+  if (!existsSync29(reportPath))
+    return { ids: [], strength: "none" };
+  try {
+    const report = JSON.parse(readFileSync29(reportPath, "utf8"));
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    const devices = [report.device, ...flows.map((flow) => flow?.device)];
+    const strong = [
+      ...devices.flatMap((device) => deviceIdsFrom(device)),
+      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
+    ];
+    const usingStrong = strong.length > 0;
+    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
+    const accepted = [
+      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
+    ];
+    return {
+      ids: accepted,
+      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
+    };
+  } catch {
+    return { ids: [], strength: "none" };
+  }
+}
+function createRunnerReportDir(runner, prefix) {
+  if (runner !== "maestro-runner")
+    return null;
+  return join43(tmpdir9(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+}
+function runnerReportArgs(reportDir) {
+  return reportDir ? ["--output", reportDir, "--flatten"] : [];
+}
+function collectDirectRunnerEvidence(reportDir, output) {
+  if (!reportDir)
+    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
+  const report = reportDeviceIds(reportDir);
+  const evidence = {
+    output,
+    reportDeviceIds: report.ids,
+    reportDeviceIdStrength: report.strength
+  };
+  const logPath = join43(reportDir, "maestro-runner.log");
+  if (!existsSync29(logPath))
+    return evidence;
+  try {
+    evidence.output = `${output}
+${readFileSync29(logPath, "utf8")}`;
+  } catch {
+  }
+  return evidence;
+}
+function observationStatus(value) {
+  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
+}
+function contentHash(path) {
+  try {
+    return createHash16("sha256").update(readFileSync29(path)).digest("hex");
+  } catch (error2) {
+    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
+  }
+}
+function runnerReportFingerprint(reportDir) {
+  const fingerprint = {};
+  if (!reportDir)
+    return fingerprint;
+  const reportHash = contentHash(join43(reportDir, "report.json"));
+  if (reportHash)
+    fingerprint["report.json"] = reportHash;
+  let flowEntries = [];
+  try {
+    flowEntries = readdirSync11(join43(reportDir, "flows"));
+  } catch (error2) {
+    if (error2?.code !== "ENOENT") {
+      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
+    }
+    return fingerprint;
+  }
+  for (const entry of flowEntries.sort()) {
+    const flowHash = contentHash(join43(reportDir, "flows", entry));
+    if (flowHash)
+      fingerprint[`flows/${entry}`] = flowHash;
+  }
+  return fingerprint;
+}
+function readStructuredFlowArtifact(reportDir, previous, readText = (path) => readFileSync29(path, "utf8")) {
+  if (!reportDir)
+    return null;
+  const reportPath = join43(reportDir, "report.json");
+  if (!existsSync29(reportPath))
+    return null;
+  const unfinalized = {
+    finalized: false,
+    flowStatus: "unknown",
+    commands: []
+  };
+  try {
+    const reportText = readText(reportPath);
+    if (previous) {
+      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
+        return unfinalized;
+      const reportHash = createHash16("sha256").update(reportText).digest("hex");
+      if (previous["report.json"] === reportHash)
+        return null;
+    }
+    const report = JSON.parse(reportText);
+    const flows = Array.isArray(report.flows) ? report.flows : [];
+    if (flows.length !== 1)
+      return unfinalized;
+    const flow = flows[0];
+    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
+    if (flowStatus === "unknown")
+      return unfinalized;
+    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
+      return unfinalized;
+    const normalizedDataFile = flow.dataFile;
+    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
+      return unfinalized;
+    }
+    const realDataFile = realpathSync15(join43(reportDir, normalizedDataFile));
+    if (!realDataFile.startsWith(realpathSync15(reportDir) + sep9))
+      return unfinalized;
+    const dataText = readText(realDataFile);
+    if (previous) {
+      const dataHash = createHash16("sha256").update(dataText).digest("hex");
+      if (previous[normalizedDataFile] === dataHash)
+        return unfinalized;
+    }
+    const data = JSON.parse(dataText);
+    if (!Array.isArray(data.commands))
+      return unfinalized;
+    let malformedRow = false;
+    const seenIndices = /* @__PURE__ */ new Set();
+    const commands = data.commands.map((entry) => {
+      const record3 = entry ?? {};
+      const error2 = record3.error ?? void 0;
+      const status = observationStatus(record3.status);
+      const producerIndex = typeof record3.index === "number" && Number.isInteger(record3.index) && record3.index >= 0 ? record3.index : null;
+      if (producerIndex === null || seenIndices.has(producerIndex)) {
+        malformedRow = true;
+      } else {
+        seenIndices.add(producerIndex);
+      }
+      if (typeof record3.type !== "string" || record3.type.length === 0 || status === "unknown") {
+        malformedRow = true;
+      }
+      return {
+        index: producerIndex ?? -1,
+        type: typeof record3.type === "string" ? record3.type : "unknown",
+        status,
+        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
+      };
+    });
+    if (malformedRow)
+      return { finalized: false, flowStatus, commands: [] };
+    const counts = flow.commands ?? {};
+    const statusCount = (status) => commands.filter((command) => command.status === status).length;
+    const countExact = (key, actual) => counts[key] === actual;
+    const anyFailedRow = commands.some((command) => command.status === "failed");
+    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
+    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
+    return { finalized, flowStatus, commands };
+  } catch {
+    return unfinalized;
+  }
+}
+function disposeRunnerReportDir(reportDir) {
+  if (!reportDir)
+    return;
+  try {
+    rmSync11(reportDir, { recursive: true, force: true });
+  } catch {
+  }
+}
+var DIRECT_DEVICE_ID_RE, DEVICE_ID_KEYS, WEAK_DEVICE_ID_KEYS, CONTAINER_DEVICE_ID_KEYS, OBSERVATION_STATUSES, FINGERPRINT_INCONCLUSIVE;
+var init_maestro_runner_report = __esm({
+  "packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js"() {
+    "use strict";
+    DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+    DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
+    WEAK_DEVICE_ID_KEYS = ["id"];
+    CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
+    OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
+      "passed",
+      "failed",
+      "skipped",
+      "running",
+      "pending"
+    ]);
+    FINGERPRINT_INCONCLUSIVE = "unreadable";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js
+import { closeSync as closeSync12, constants as constants10, fstatSync as fstatSync9, lstatSync as lstatSync17, openSync as openSync12, readSync as readSync5, realpathSync as realpathSync16 } from "node:fs";
+import { join as join44, sep as sep10 } from "node:path";
+function createRunnerFailureEvidence() {
+  return {
+    version: 1,
+    incomplete: true,
+    withheld: "text-images-terminal-output-and-original-artifacts",
+    capturesTruncated: false,
+    captures: []
+  };
+}
+function append(evidence, capture) {
+  evidence.captures.push(capture);
+  if (evidence.captures.length > MAX_CAPTURES) {
+    evidence.captures.splice(1, 1);
+    evidence.capturesTruncated = true;
+  }
+}
+function captureRunnerFailure(evidence, reportDir, previous, stage, invocation, termination, attempt = 1) {
+  const capture = {
+    attempt,
+    stage,
+    invocation,
+    exitCode: Number.isSafeInteger(termination.exitCode) ? termination.exitCode : null,
+    signalPresent: termination.signal !== null,
+    timedOut: termination.timedOut,
+    outputTruncated: termination.outputTruncated,
+    bootstrapFailure: termination.bootstrapFailure,
+    transportFailure: termination.transportFailure,
+    report: "missing",
+    rowsTruncated: false,
+    commands: []
+  };
+  try {
+    if (reportDir) {
+      if (!lstatSync17(reportDir).isDirectory())
+        throw new Error();
+      const root = realpathSync16(reportDir);
+      const reportPath = join44(root, "report.json");
+      lstatSync17(reportPath);
+      let readFailure;
+      let remaining = MAX_REPORT_BYTES;
+      const artifact = readStructuredFlowArtifact(root, previous, (path) => {
+        let fd;
+        try {
+          if (!realpathSync16(path).startsWith(root + sep10))
+            throw new Error();
+          fd = openSync12(path, constants10.O_RDONLY | constants10.O_NOFOLLOW);
+          const stat2 = fstatSync9(fd);
+          if (!stat2.isFile())
+            throw new Error();
+          if (stat2.size > remaining) {
+            readFailure = "oversized";
+            throw new Error();
+          }
+          const bytes = Buffer.alloc(stat2.size + 1);
+          const size = readSync5(fd, bytes, 0, bytes.length, 0);
+          if (size !== stat2.size || fstatSync9(fd).size !== size)
+            throw new Error();
+          remaining -= size;
+          return bytes.subarray(0, size).toString("utf8");
+        } catch (error2) {
+          readFailure ??= "unavailable";
+          throw error2;
+        } finally {
+          if (fd !== void 0)
+            closeSync12(fd);
+        }
+      });
+      capture.report = readFailure ?? (artifact ? artifact.finalized ? "finalized" : "unfinalized" : "missing");
+      if (artifact?.finalized && !readFailure) {
+        capture.rowsTruncated = artifact.commands.length > MAX_ROWS;
+        const rows = [...artifact.commands].sort((a, b) => Number(b.status === "failed") - Number(a.status === "failed"));
+        capture.commands = rows.slice(0, MAX_ROWS).map((row) => ({
+          index: row.index,
+          status: row.status,
+          errorPresent: row.error !== void 0
+        }));
+      }
+    }
+  } catch (error2) {
+    capture.report = error2.code === "ENOENT" ? "missing" : "unavailable";
+  }
+  append(evidence, capture);
+}
+function record2(value) {
+  return value !== null && typeof value === "object" ? value : {};
+}
+function collectRunnerFailureEvidence(evidence, value) {
+  const input = record2(value);
+  if (input.version !== 1 || !Array.isArray(input.captures))
+    return;
+  evidence.capturesTruncated ||= input.capturesTruncated === true || input.captures.length > MAX_CAPTURES;
+  const captures = input.captures.length > MAX_CAPTURES ? [input.captures[0], ...input.captures.slice(-(MAX_CAPTURES - 1))] : input.captures;
+  for (const item of captures) {
+    const row = record2(item);
+    if (!Number.isSafeInteger(row.stage) || !Number.isSafeInteger(row.invocation))
+      continue;
+    const state = REPORT_STATES.find((state2) => state2 === row.report) ?? "unavailable";
+    const commands = Array.isArray(row.commands) ? row.commands : [];
+    append(evidence, {
+      attempt: Number.isSafeInteger(row.attempt) ? Number(row.attempt) : 1,
+      stage: Number(row.stage),
+      invocation: Number(row.invocation),
+      exitCode: Number.isSafeInteger(row.exitCode) ? Number(row.exitCode) : null,
+      signalPresent: row.signalPresent === true,
+      timedOut: row.timedOut === true,
+      outputTruncated: row.outputTruncated === true,
+      bootstrapFailure: row.bootstrapFailure === true,
+      transportFailure: row.transportFailure === true,
+      report: state,
+      rowsTruncated: row.rowsTruncated === true || commands.length > MAX_ROWS,
+      commands: commands.slice(0, MAX_ROWS).flatMap((item2) => {
+        const command = record2(item2);
+        if (!Number.isSafeInteger(command.index))
+          return [];
+        return [
+          {
+            index: Number(command.index),
+            status: STATUSES.find((status) => status === command.status) ?? "unknown",
+            errorPresent: command.errorPresent === true
+          }
+        ];
+      })
+    });
+  }
+}
+var MAX_CAPTURES, MAX_ROWS, MAX_REPORT_BYTES, STATUSES, REPORT_STATES;
+var init_runner_failure_evidence = __esm({
+  "packages/rn-dev-agent-core/dist/domain/runner-failure-evidence.js"() {
+    "use strict";
+    init_maestro_runner_report();
+    MAX_CAPTURES = 8;
+    MAX_ROWS = 64;
+    MAX_REPORT_BYTES = 256 * 1024;
+    STATUSES = ["passed", "failed", "skipped", "running", "pending", "unknown"];
+    REPORT_STATES = ["missing", "unavailable", "oversized", "unfinalized", "finalized"];
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/ansi.js
 function stripAnsi(value) {
   return value.replace(ANSI_RE, "");
@@ -81285,226 +81646,6 @@ function maestroAuthorityRefusal(authority, underlyingError) {
 var init_maestro_device_authority = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-device-authority.js"() {
     "use strict";
-  }
-});
-
-// packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js
-import { existsSync as existsSync29, readFileSync as readFileSync29, readdirSync as readdirSync11, realpathSync as realpathSync15, rmSync as rmSync11 } from "node:fs";
-import { createHash as createHash16 } from "node:crypto";
-import { tmpdir as tmpdir9 } from "node:os";
-import { isAbsolute as isAbsolute14, join as join43, sep as sep9 } from "node:path";
-function idsFrom(value, keys) {
-  if (!value || typeof value !== "object")
-    return [];
-  const record2 = value;
-  for (const key of keys) {
-    const id = record2[key];
-    if (typeof id === "string")
-      return [id];
-  }
-  return [];
-}
-function deviceIdsFrom(value) {
-  return idsFrom(value, DEVICE_ID_KEYS);
-}
-function weakDeviceIdsFrom(value) {
-  if (typeof value === "string")
-    return [value];
-  return idsFrom(value, WEAK_DEVICE_ID_KEYS);
-}
-function containerDeviceIdsFrom(value) {
-  return idsFrom(value, CONTAINER_DEVICE_ID_KEYS);
-}
-function reportDeviceIds(reportDir) {
-  const reportPath = join43(reportDir, "report.json");
-  if (!existsSync29(reportPath))
-    return { ids: [], strength: "none" };
-  try {
-    const report = JSON.parse(readFileSync29(reportPath, "utf8"));
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    const devices = [report.device, ...flows.map((flow) => flow?.device)];
-    const strong = [
-      ...devices.flatMap((device) => deviceIdsFrom(device)),
-      ...[report, ...flows].flatMap((container) => containerDeviceIdsFrom(container))
-    ];
-    const usingStrong = strong.length > 0;
-    const ids = usingStrong ? strong : devices.flatMap((device) => weakDeviceIdsFrom(device));
-    const accepted = [
-      ...new Set(ids.map((id) => id.trim()).filter((id) => DIRECT_DEVICE_ID_RE.test(id)))
-    ];
-    return {
-      ids: accepted,
-      strength: accepted.length === 0 ? "none" : usingStrong ? "strong" : "weak"
-    };
-  } catch {
-    return { ids: [], strength: "none" };
-  }
-}
-function createRunnerReportDir(runner, prefix) {
-  if (runner !== "maestro-runner")
-    return null;
-  return join43(tmpdir9(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-}
-function runnerReportArgs(reportDir) {
-  return reportDir ? ["--output", reportDir, "--flatten"] : [];
-}
-function collectDirectRunnerEvidence(reportDir, output) {
-  if (!reportDir)
-    return { output, reportDeviceIds: [], reportDeviceIdStrength: "none" };
-  const report = reportDeviceIds(reportDir);
-  const evidence = {
-    output,
-    reportDeviceIds: report.ids,
-    reportDeviceIdStrength: report.strength
-  };
-  const logPath = join43(reportDir, "maestro-runner.log");
-  if (!existsSync29(logPath))
-    return evidence;
-  try {
-    evidence.output = `${output}
-${readFileSync29(logPath, "utf8")}`;
-  } catch {
-  }
-  return evidence;
-}
-function observationStatus(value) {
-  return typeof value === "string" && OBSERVATION_STATUSES.has(value) ? value : "unknown";
-}
-function contentHash(path) {
-  try {
-    return createHash16("sha256").update(readFileSync29(path)).digest("hex");
-  } catch (error2) {
-    return error2?.code === "ENOENT" ? null : FINGERPRINT_INCONCLUSIVE;
-  }
-}
-function runnerReportFingerprint(reportDir) {
-  const fingerprint = {};
-  if (!reportDir)
-    return fingerprint;
-  const reportHash = contentHash(join43(reportDir, "report.json"));
-  if (reportHash)
-    fingerprint["report.json"] = reportHash;
-  let flowEntries = [];
-  try {
-    flowEntries = readdirSync11(join43(reportDir, "flows"));
-  } catch (error2) {
-    if (error2?.code !== "ENOENT") {
-      fingerprint["flows"] = FINGERPRINT_INCONCLUSIVE;
-    }
-    return fingerprint;
-  }
-  for (const entry of flowEntries.sort()) {
-    const flowHash = contentHash(join43(reportDir, "flows", entry));
-    if (flowHash)
-      fingerprint[`flows/${entry}`] = flowHash;
-  }
-  return fingerprint;
-}
-function readStructuredFlowArtifact(reportDir, previous) {
-  if (!reportDir)
-    return null;
-  const reportPath = join43(reportDir, "report.json");
-  if (!existsSync29(reportPath))
-    return null;
-  const unfinalized = {
-    finalized: false,
-    flowStatus: "unknown",
-    commands: []
-  };
-  try {
-    const reportText = readFileSync29(reportPath, "utf8");
-    if (previous) {
-      if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE))
-        return unfinalized;
-      const reportHash = createHash16("sha256").update(reportText).digest("hex");
-      if (previous["report.json"] === reportHash)
-        return null;
-    }
-    const report = JSON.parse(reportText);
-    const flows = Array.isArray(report.flows) ? report.flows : [];
-    if (flows.length !== 1)
-      return unfinalized;
-    const flow = flows[0];
-    const flowStatus = flow.status === "passed" || flow.status === "failed" ? flow.status : "unknown";
-    if (flowStatus === "unknown")
-      return unfinalized;
-    if (typeof flow.dataFile !== "string" || flow.dataFile.length === 0)
-      return unfinalized;
-    const normalizedDataFile = flow.dataFile;
-    if (isAbsolute14(normalizedDataFile) || !/^flows\/[^/\\]+$/.test(normalizedDataFile)) {
-      return unfinalized;
-    }
-    const realDataFile = realpathSync15(join43(reportDir, normalizedDataFile));
-    if (!realDataFile.startsWith(realpathSync15(reportDir) + sep9))
-      return unfinalized;
-    const dataText = readFileSync29(realDataFile, "utf8");
-    if (previous) {
-      const dataHash = createHash16("sha256").update(dataText).digest("hex");
-      if (previous[normalizedDataFile] === dataHash)
-        return unfinalized;
-    }
-    const data = JSON.parse(dataText);
-    if (!Array.isArray(data.commands))
-      return unfinalized;
-    let malformedRow = false;
-    const seenIndices = /* @__PURE__ */ new Set();
-    const commands = data.commands.map((entry) => {
-      const record2 = entry ?? {};
-      const error2 = record2.error ?? void 0;
-      const status = observationStatus(record2.status);
-      const producerIndex = typeof record2.index === "number" && Number.isInteger(record2.index) && record2.index >= 0 ? record2.index : null;
-      if (producerIndex === null || seenIndices.has(producerIndex)) {
-        malformedRow = true;
-      } else {
-        seenIndices.add(producerIndex);
-      }
-      if (typeof record2.type !== "string" || record2.type.length === 0 || status === "unknown") {
-        malformedRow = true;
-      }
-      return {
-        index: producerIndex ?? -1,
-        type: typeof record2.type === "string" ? record2.type : "unknown",
-        status,
-        ...error2 && typeof error2.message === "string" ? { error: error2.message.slice(0, 500) } : {}
-      };
-    });
-    if (malformedRow)
-      return { finalized: false, flowStatus, commands: [] };
-    const counts = flow.commands ?? {};
-    const statusCount = (status) => commands.filter((command) => command.status === status).length;
-    const countExact = (key, actual) => counts[key] === actual;
-    const anyFailedRow = commands.some((command) => command.status === "failed");
-    const contiguousIndices = Array.from({ length: commands.length }, (_, i) => i).every((i) => seenIndices.has(i));
-    const finalized = (report.status === "passed" || report.status === "failed") && report.status === flowStatus && flowStatus === "failed" === anyFailedRow && !malformedRow && contiguousIndices && commands.length > 0 && countExact("total", commands.length) && countExact("passed", statusCount("passed")) && countExact("failed", statusCount("failed")) && countExact("skipped", statusCount("skipped")) && countExact("running", 0) && countExact("pending", 0) && commands.every((command) => command.status !== "running" && command.status !== "pending");
-    return { finalized, flowStatus, commands };
-  } catch {
-    return unfinalized;
-  }
-}
-function disposeRunnerReportDir(reportDir) {
-  if (!reportDir)
-    return;
-  try {
-    rmSync11(reportDir, { recursive: true, force: true });
-  } catch {
-  }
-}
-var DIRECT_DEVICE_ID_RE, DEVICE_ID_KEYS, WEAK_DEVICE_ID_KEYS, CONTAINER_DEVICE_ID_KEYS, OBSERVATION_STATUSES, FINGERPRINT_INCONCLUSIVE;
-var init_maestro_runner_report = __esm({
-  "packages/rn-dev-agent-core/dist/domain/maestro-runner-report.js"() {
-    "use strict";
-    DIRECT_DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,256}$/;
-    DEVICE_ID_KEYS = ["udid", "deviceId", "serial"];
-    WEAK_DEVICE_ID_KEYS = ["id"];
-    CONTAINER_DEVICE_ID_KEYS = ["udid", "deviceId", "deviceSerial"];
-    OBSERVATION_STATUSES = /* @__PURE__ */ new Set([
-      "passed",
-      "failed",
-      "skipped",
-      "running",
-      "pending"
-    ]);
-    FINGERPRINT_INCONCLUSIVE = "unreadable";
   }
 });
 
@@ -82713,7 +82854,7 @@ import { execFile as execFileCb14 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
 import { existsSync as existsSync30, readFileSync as readFileSync30, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
-import { basename as basename10, join as join44, dirname as dirname23 } from "node:path";
+import { basename as basename10, join as join45, dirname as dirname23 } from "node:path";
 import { randomUUID as randomUUID9 } from "node:crypto";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
@@ -82969,7 +83110,7 @@ function createMaestroRunHandler(deps = {}) {
   const resolveEngineStatus = deps.resolveEngineStatus ?? (() => getEngineStatus().catch(() => null));
   const replayFactory = deps.replayDeps;
   const nativeOnlyHandler = replayFactory ? createMaestroRunHandler({ ...deps, replayDeps: void 0 }) : null;
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (args.params) {
       for (const [key, value] of Object.entries(args.params)) {
         if (!PARAM_KEY_RE.test(key)) {
@@ -83047,7 +83188,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join44(tmpdir10(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join45(tmpdir10(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -83277,15 +83418,15 @@ function createMaestroRunHandler(deps = {}) {
             for (const step of result.replay.steps) {
               if (!step || typeof step !== "object")
                 continue;
-              const record2 = step;
+              const record3 = step;
               combinedSteps.push({
-                index: sourceIndices[record2.sourceIndex ?? -1] ?? record2.sourceIndex ?? combinedSteps.length,
-                name: String(record2.t ?? "unknown"),
-                verb: String(record2.t ?? "unknown"),
-                ...record2.target !== void 0 ? { target: String(record2.target) } : {},
-                ...record2.focusOnly === true ? { focusOnly: true } : {},
-                status: record2.ok === false ? "fail" : "pass",
-                durationMs: Number(record2.durationMs ?? 0)
+                index: sourceIndices[record3.sourceIndex ?? -1] ?? record3.sourceIndex ?? combinedSteps.length,
+                name: String(record3.t ?? "unknown"),
+                verb: String(record3.t ?? "unknown"),
+                ...record3.target !== void 0 ? { target: String(record3.target) } : {},
+                ...record3.focusOnly === true ? { focusOnly: true } : {},
+                status: record3.ok === false ? "fail" : "pass",
+                durationMs: Number(record3.durationMs ?? 0)
               });
             }
           }
@@ -83450,6 +83591,7 @@ function createMaestroRunHandler(deps = {}) {
     })();
     const stageCaptures = [];
     let ledgerStageCursor = 0;
+    let invocationOrdinal = 0;
     const stageTerminationFromError = (error2) => {
       const errorClass = classifyExecError(error2);
       const raw = error2;
@@ -83517,7 +83659,8 @@ function createMaestroRunHandler(deps = {}) {
                 Object.assign(error2, { code: "ETIMEDOUT" });
                 throw error2;
               }
-              const executeRunner = (runnerPath, prefixArgs = []) => {
+              const executeRunner = async (runnerPath, prefixArgs = []) => {
+                const fingerprint = runnerReportFingerprint(runnerReportDir);
                 beforeDispatch?.();
                 const remainingTimeout = flowDeadline - now();
                 if (remainingTimeout <= 0) {
@@ -83525,12 +83668,29 @@ function createMaestroRunHandler(deps = {}) {
                   Object.assign(error2, { code: "ETIMEDOUT" });
                   throw error2;
                 }
-                return execute2(runnerPath, [...prefixArgs, ...finalArgs], {
-                  timeout: remainingTimeout,
-                  encoding: "utf8",
-                  maxBuffer: 10 * 1024 * 1024,
-                  signal: flowAbort.signal
-                });
+                const invocation = ++invocationOrdinal;
+                try {
+                  const result = await execute2(runnerPath, [...prefixArgs, ...finalArgs], {
+                    timeout: remainingTimeout,
+                    encoding: "utf8",
+                    maxBuffer: 10 * 1024 * 1024,
+                    signal: flowAbort.signal
+                  });
+                  if (outputIndicatesFlowFailure(combineRunnerOutput(result.stdout, result.stderr))) {
+                    captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, {
+                      exitCode: 0,
+                      signal: null,
+                      timedOut: false,
+                      outputTruncated: false,
+                      bootstrapFailure: false,
+                      transportFailure: false
+                    }, ledgerAttempt.ordinal);
+                  }
+                  return result;
+                } catch (error2) {
+                  captureRunnerFailure(evidence, runnerReportDir, fingerprint, ledgerStageIndex, invocation, stageTerminationFromError(error2), ledgerAttempt.ordinal);
+                  throw error2;
+                }
               };
               if (deps.execFile) {
                 const immediateStatus = await resolveEngineStatus();
@@ -83928,11 +84088,24 @@ function createMaestroRunHandler(deps = {}) {
       }
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 var defaultExecFile2, MaestroStageExecutionError, lifecycleCommands, PARAM_KEY_RE, ReactReplayFailure, UIAUTOMATION_SESSION_CREATION_FAILURE;
 var init_maestro_run = __esm({
   "packages/rn-dev-agent-core/dist/tools/maestro-run.js"() {
     "use strict";
+    init_runner_failure_evidence();
     init_utils();
     init_engine_pin();
     init_runner_diagnostics();
@@ -84379,7 +84552,7 @@ function createRunActionHandler(deps = {}) {
   const installReceipt = deps.installReceipt ?? boundInstallReceipt;
   const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   const resolveEngineStatus = deps.engineStatus ?? (() => getEngineStatus().catch(() => null));
-  return async (args) => {
+  const run = async (args, evidence) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
     }
@@ -84467,10 +84640,10 @@ function createRunActionHandler(deps = {}) {
     const startedAt = new Date(t0).toISOString();
     const runId = randomUUID10();
     const timingSteps = [];
-    const measureStep = async (name, run) => {
+    const measureStep = async (name, run2) => {
       const stepStartedMs = Date.now();
       try {
-        return await run();
+        return await run2();
       } finally {
         const stepEndedMs = Date.now();
         timingSteps.push({
@@ -84493,14 +84666,15 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => {
+    const persistRunWithDevice = (record3) => {
       assertReadableActionLoadContextStable(loadContext);
       if (proofReplay) {
         return Promise.resolve({ promoted: false, promotionRefused: false });
       }
       const endedMs = Date.now();
       const timedRecord = {
-        ...record2,
+        ...record3,
+        ...evidence.captures.length ? { runnerFailureEvidence: structuredClone(evidence) } : {},
         runId,
         timing: {
           startedAt,
@@ -84540,6 +84714,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, firstEnv.meta?.runnerFailureEvidence);
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
@@ -84872,6 +85047,7 @@ function createRunActionHandler(deps = {}) {
       }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
+      collectRunnerFailureEvidence(evidence, retryEnv.meta?.runnerFailureEvidence);
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
@@ -85009,34 +85185,46 @@ function createRunActionHandler(deps = {}) {
       });
     }
   };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length ? attachMeta(result, { runnerFailureEvidence: evidence }) : result;
+    } catch (error2) {
+      if (error2 instanceof SessionAuthorityError && evidence.captures.length) {
+        error2.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error2;
+    }
+  };
 }
 function promotionDisclosure(outcome) {
   if (outcome.promoted)
     return "lifecycle-promotion";
   return outcome.promotionRefused ? "lifecycle-promotion-refused" : "none";
 }
-async function persistRun(actionId, projectRoot, record2) {
+async function persistRun(actionId, projectRoot, record3) {
   const MAX_ATTEMPTS = 5;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const fresh = loadAction(projectRoot, actionId);
     if (!fresh) {
-      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record2.status}, autoRepair.outcome=${record2.autoRepair?.outcome ?? "n/a"})`);
+      console.error(`cdp_run_action: persistRun could not reload action "${actionId}" \u2014 RunRecord dropped (status=${record3.status}, autoRepair.outcome=${record3.autoRepair?.outcome ?? "n/a"})`);
       return { promoted: false, promotionRefused: false };
     }
-    const nextState = appendRunRecord(fresh.state, record2);
-    const promotes = shouldAutoPromoteToActive(fresh.metadata, record2);
+    const nextState = appendRunRecord(fresh.state, record3);
+    const promotes = shouldAutoPromoteToActive(fresh.metadata, record3);
     const commit = (runtimeStatePath, promoted, promotionRefused2) => {
       mirrorToDb({
         yamlFilePath: fresh.filePath,
         state: fresh.state,
-        newRunRecord: record2,
+        newRunRecord: record3,
         meta: {
           appId: fresh.metadata.appId,
           status: promoted ? "active" : fresh.metadata.status,
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record2.runId };
+      return { promoted, promotionRefused: promotionRefused2, runtimeStatePath, persistedRunId: record3.runId };
     };
     const promotion = promotes ? promoteActionRuntimeWithCAS(fresh, nextState) : null;
     const promotionRefused = promotion?.ok === false;
@@ -85046,7 +85234,7 @@ async function persistRun(actionId, projectRoot, record2) {
     if (runtimeWrite.ok)
       return commit(runtimeWrite.sidecarPath, false, promotionRefused);
     if (attempt === MAX_ATTEMPTS) {
-      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record2.status}).`);
+      console.error(`cdp_run_action: persistRun for "${actionId}" hit ${MAX_ATTEMPTS} sidecar CAS conflicts; runtime state was not written (status=${record3.status}).`);
       return { promoted: false, promotionRefused, runtimeStateRefused: true };
     }
   }
@@ -85056,6 +85244,8 @@ var strictRunActionPolicy, PROVEN_ENGINE_PIN_DIVERGENCE, OUTPUT_BUDGET, OUTPUT_E
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
+    init_agent_device_wrapper();
+    init_runner_failure_evidence();
     init_utils();
     init_action_store();
     init_action_state_store();
@@ -85233,7 +85423,7 @@ function createLoginPrologueHandler(deps) {
     try {
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record3) => record3.runId === strictRunRecordId) : void 0;
       });
     } catch (error2) {
       return unresolved(`could not verify the exact ${LOGIN_PROLOGUE_ALIAS} learned action: ${error2 instanceof Error ? error2.message : String(error2)}`, replayWrites);
@@ -85750,7 +85940,7 @@ var init_dev_settings = __esm({
 import { createHash as createHash18, randomBytes as randomBytes8, randomUUID as randomUUID11 } from "node:crypto";
 import { chmodSync as chmodSync7, existsSync as existsSync31, mkdirSync as mkdirSync20, readFileSync as readFileSync31, readdirSync as readdirSync12, renameSync as renameSync9, statSync as statSync15, unlinkSync as unlinkSync14, writeFileSync as writeFileSync15 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname24, join as join45 } from "node:path";
+import { dirname as dirname24, join as join46 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 function configuredExperienceDirectory() {
   return process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
@@ -85803,7 +85993,7 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join45(root, "app.json");
+  const manifest = join46(root, "app.json");
   try {
     if (!existsSync31(manifest))
       return { name: null, slug: null };
@@ -85822,10 +86012,10 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
   const start = dirname24(fileURLToPath3(fromUrl));
   const candidates = [
-    join45(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join45(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join45(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join45(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join46(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join46(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join46(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join46(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
@@ -85859,8 +86049,8 @@ function readExperienceStore(path) {
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
-  return records.filter((record2) => {
-    const lastSeen = Date.parse(record2.lastSeen);
+  return records.filter((record3) => {
+    const lastSeen = Date.parse(record3.lastSeen);
     return Number.isFinite(lastSeen) && lastSeen >= cutoff;
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
@@ -86044,7 +86234,7 @@ function stableDeviceHash(directory, deviceId) {
   return createHash18("sha256").update(readOrCreateRunnerDiagnosticsSalt(directory)).update("\0").update(deviceId).digest("hex");
 }
 function readOrCreateRunnerDiagnosticsSalt(directory) {
-  const path = join45(directory, ".runner-diagnostics-salt");
+  const path = join46(directory, ".runner-diagnostics-salt");
   mkdirSync20(directory, { recursive: true, mode: 448 });
   try {
     const existing = readFileSync31(path);
@@ -86069,7 +86259,7 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   const files = runnerDiagnosticsFiles(directory);
   const nextSequence = files.reduce((maximum, file) => Math.max(maximum, runnerDiagnosticsSequence(file)), 0) + 1;
   const sessionKey = (bundle.context.sessionId ?? "unknown").slice(0, 64).replace(/[^A-Za-z0-9_-]/g, "-");
-  const outputPath = join45(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
+  const outputPath = join46(directory, `runner-diagnostics-${sessionKey}-${nextSequence}.json`);
   const bounded = boundRunnerDiagnosticsBundle(bundle);
   let serialized = `${JSON.stringify(bounded, null, 2)}
 `;
@@ -86087,17 +86277,17 @@ function writeRunnerDiagnosticsBundle(directory, bundle) {
   if (Buffer.byteLength(serialized) > RUNNER_DIAGNOSTICS_MAX_BYTES) {
     throw new Error("Runner diagnostics bundle exceeds the 256 KB limit after truncation.");
   }
-  const temporary = join45(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
+  const temporary = join46(directory, `.runner-diagnostics.${process.pid}.${randomUUID11()}`);
   writeFileSync15(temporary, serialized, { encoding: "utf8", flag: "wx", mode: 384 });
   renameSync9(temporary, outputPath);
   chmodSync7(outputPath, 384);
   const retained = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync15(join45(directory, file)).mtimeMs,
+    mtimeMs: statSync15(join46(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => left.mtimeMs - right.mtimeMs || left.sequence - right.sequence || left.file.localeCompare(right.file));
   for (const stale of retained.slice(0, Math.max(0, retained.length - RUNNER_DIAGNOSTICS_RETENTION))) {
-    unlinkSync14(join45(directory, stale.file));
+    unlinkSync14(join46(directory, stale.file));
   }
   return outputPath;
 }
@@ -86167,11 +86357,11 @@ function latestRunnerDiagnosticsPath(sessionId, directory = configuredExperience
     return null;
   const files = runnerDiagnosticsFiles(directory).map((file) => ({
     file,
-    mtimeMs: statSync15(join45(directory, file)).mtimeMs,
+    mtimeMs: statSync15(join46(directory, file)).mtimeMs,
     sequence: runnerDiagnosticsSequence(file)
   })).sort((left, right) => right.mtimeMs - left.mtimeMs || right.sequence - left.sequence || right.file.localeCompare(left.file));
   for (const file of files) {
-    const path = join45(directory, file.file);
+    const path = join46(directory, file.file);
     try {
       const contents = readFileSync31(path);
       if (contents.byteLength > RUNNER_DIAGNOSTICS_MAX_BYTES)
@@ -86203,7 +86393,7 @@ var init_evidence = __esm({
     DEFAULT_MAX_RECORDS = 500;
     DEFAULT_RETENTION_DAYS = 14;
     MAX_EVIDENCE_POINTERS = 3;
-    EXPERIENCE_DIRECTORY = join45(homedir9(), ".claude", "rn-agent", "experience");
+    EXPERIENCE_DIRECTORY = join46(homedir9(), ".claude", "rn-agent", "experience");
     EXPERIENCE_STORE_NAME = "patterns.jsonl";
     MAX_SYMPTOM_LENGTH = 2048;
     RUNNER_DIAGNOSTICS_MAX_BYTES = 256 * 1024;
@@ -86254,7 +86444,7 @@ var init_evidence = __esm({
       previousFailure = null;
       constructor(options) {
         this.directory = options.directory ?? configuredExperienceDirectory();
-        this.path = join45(this.directory, EXPERIENCE_STORE_NAME);
+        this.path = join46(this.directory, EXPERIENCE_STORE_NAME);
         this.candidate = {
           pluginVersion: options.pluginVersion ?? null,
           coreVersion: options.coreVersion
@@ -86300,9 +86490,9 @@ var init_evidence = __esm({
           return;
         }
         this.persistRunnerDiagnostics(event);
-        const record2 = this.buildFailureRecord(event);
-        this.persistFailure(record2);
-        this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+        const record3 = this.buildFailureRecord(event);
+        this.persistFailure(record3);
+        this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record3.signature } : null;
       }
       persistRunnerDiagnostics(event) {
         const trace = event.runnerDiagnostics;
@@ -86382,7 +86572,7 @@ var init_evidence = __esm({
       }
       persistFailure(incoming) {
         const records = readExperienceStore(this.path);
-        const existing = records.find((record2) => record2.signature === incoming.signature);
+        const existing = records.find((record3) => record3.signature === incoming.signature);
         if (existing) {
           existing.count += 1;
           existing.lastSeen = incoming.lastSeen;
@@ -86403,7 +86593,7 @@ var init_evidence = __esm({
       }
       persistRecovery(signature, tool) {
         const records = readExperienceStore(this.path);
-        const existing = records.find((record2) => record2.signature === signature);
+        const existing = records.find((record3) => record3.signature === signature);
         if (!existing)
           return;
         const now = this.now().toISOString();
@@ -86418,13 +86608,13 @@ var init_evidence = __esm({
       }
       write(records) {
         mkdirSync20(this.directory, { recursive: true, mode: 448 });
-        const temp = join45(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
+        const temp = join46(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
         try {
-          const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
-            ...sanitizeForEvidence(record2),
+          const sanitized = records.map((record3) => record3.redactionVersion === REDACTION_RULES_VERSION ? record3 : {
+            ...sanitizeForEvidence(record3),
             redactionVersion: REDACTION_RULES_VERSION
           });
-          const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+          const contents = sanitized.map((record3) => JSON.stringify(record3)).join("\n");
           writeFileSync15(temp, contents.length > 0 ? `${contents}
 ` : "", {
             encoding: "utf8",
@@ -88146,7 +88336,7 @@ var init_managed_automation = __esm({
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 import { writeFileSync as writeFileSync16 } from "node:fs";
-import { join as join46 } from "node:path";
+import { join as join47 } from "node:path";
 import { tmpdir as tmpdir11 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -88178,7 +88368,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join46(tmpdir11(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join47(tmpdir11(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -88757,7 +88947,7 @@ import { createHash as createHash19 } from "node:crypto";
 import { existsSync as existsSync32 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
-import { dirname as dirname25, join as join47 } from "node:path";
+import { dirname as dirname25, join as join48 } from "node:path";
 function parseAllBootedIosDevices(jsonText) {
   let data;
   try {
@@ -88841,15 +89031,15 @@ function candidateRecordScripts(baseDir = dirname25(fileURLToPath4(import.meta.u
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join47(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join47(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join47(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join48(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join48(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join48(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join47(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join48(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join47(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join48(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join47(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join48(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
 function resolveRecordScript(baseDir = dirname25(fileURLToPath4(import.meta.url))) {
@@ -89253,12 +89443,12 @@ function observedAssertionPassed(event) {
   const data = resultEnvelopeData(event.result);
   if (!data || typeof data !== "object")
     return !tool.endsWith("proof_step");
-  const record2 = data;
-  if (tool.endsWith("proof_step") && record2.verified !== true)
+  const record3 = data;
+  if (tool.endsWith("proof_step") && record3.verified !== true)
     return false;
-  if (record2.verified === false || record2.ok === false)
+  if (record3.verified === false || record3.ok === false)
     return false;
-  return !Array.isArray(record2.errors) || record2.errors.length === 0;
+  return !Array.isArray(record3.errors) || record3.errors.length === 0;
 }
 function normalizeToolName(tool) {
   const bare = tool.startsWith("mcp__") ? tool.split("__").at(-1) ?? tool : tool;
@@ -89729,8 +89919,8 @@ var init_startup_integrity = __esm({
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
 import { createHash as createHash21, randomUUID as randomUUID12 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { chmodSync as chmodSync8, closeSync as closeSync12, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync17, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync16, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
-import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute15, join as join48, relative as relative9, resolve as resolve18, sep as sep10 } from "node:path";
+import { chmodSync as chmodSync8, closeSync as closeSync13, existsSync as existsSync33, fsyncSync, lstatSync as lstatSync18, mkdirSync as mkdirSync21, openSync as openSync13, readFileSync as readFileSync33, realpathSync as realpathSync17, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
+import { basename as basename11, dirname as dirname26, extname, isAbsolute as isAbsolute15, join as join49, relative as relative9, resolve as resolve18, sep as sep11 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function proofActionPayload(unparsedArgs) {
   if (!unparsedArgs || typeof unparsedArgs !== "object" || Array.isArray(unparsedArgs)) {
@@ -89771,14 +89961,14 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
   let coreBundleSha256 = null;
   try {
     if (typeof argv[1] === "string" && isAbsolute15(argv[1])) {
-      executedEntrypointPath = realpathSync16(argv[1]);
+      executedEntrypointPath = realpathSync17(argv[1]);
     }
   } catch {
     executedEntrypointPath = null;
   }
   if (attestation) {
     try {
-      loadedCoreBundlePath = realpathSync16(fileURLToPath5(attestation.entrypointUrl));
+      loadedCoreBundlePath = realpathSync17(fileURLToPath5(attestation.entrypointUrl));
       coreBundleSha256 = attestation.coreBundleSha256;
     } catch {
       loadedCoreBundlePath = null;
@@ -89794,7 +89984,7 @@ function captureProofWorkerStartup(argv = process.argv, attestation = readStartu
 }
 function realpathOrSelf(path) {
   try {
-    return realpathSync16(path);
+    return realpathSync17(path);
   } catch {
     return path;
   }
@@ -89802,7 +89992,7 @@ function realpathOrSelf(path) {
 function resolveProofCandidateEntrypoint(candidateRoot, argv) {
   let root;
   try {
-    root = realpathSync16(candidateRoot);
+    root = realpathSync17(candidateRoot);
   } catch {
     return null;
   }
@@ -89811,14 +90001,14 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   let arg;
   try {
-    arg = realpathSync16(authorityArg);
+    arg = realpathSync17(authorityArg);
   } catch {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join48(root, "packages", host);
-    const coreIndex = realpathOrSelf(join48(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join48(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join49(root, "packages", host);
+    const coreIndex = realpathOrSelf(join49(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join49(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -89837,7 +90027,7 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join48(hostRoot, "bin", "cdp-supervisor.js"))) {
+    if (host === "codex-plugin" && arg === realpathOrSelf(join49(hostRoot, "bin", "cdp-supervisor.js"))) {
       if (!existsSync33(coreIndex) || !existsSync33(coreSupervisor))
         return null;
       return {
@@ -89859,7 +90049,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
     if (!value || !isAbsolute15(value))
       return value ? null : "";
     try {
-      return realpathSync16(value);
+      return realpathSync17(value);
     } catch {
       return null;
     }
@@ -89872,7 +90062,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join48(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join49(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -89881,7 +90071,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
 }
 function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   try {
-    const root = realpathSync16(candidateRoot);
+    const root = realpathSync17(candidateRoot);
     const statusArgs = [
       "-C",
       root,
@@ -89894,8 +90084,8 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       return null;
     const verifiedBytes = [];
     for (const artifactPath of artifactPaths) {
-      const resolvedArtifactPath = realpathSync16(artifactPath);
-      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep10).join("/");
+      const resolvedArtifactPath = realpathSync17(artifactPath);
+      const artifactRelativePath = relative9(root, resolvedArtifactPath).split(sep11).join("/");
       if (!artifactRelativePath || artifactRelativePath === ".." || artifactRelativePath.startsWith("../")) {
         return null;
       }
@@ -89914,7 +90104,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
   }
 }
 function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) {
-  const root = realpathSync16(resolve18(candidateRoot));
+  const root = realpathSync17(resolve18(candidateRoot));
   const sha = execFileSync16("git", ["-C", root, "rev-parse", "HEAD"], {
     encoding: "utf8"
   }).trim();
@@ -89930,7 +90120,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join48(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join49(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -89999,14 +90189,14 @@ function isNormalizedDescendant(root, path) {
     return false;
   }
   const fromRoot = relative9(root, path);
-  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep10}`) && !isAbsolute15(fromRoot);
+  return fromRoot.length > 0 && fromRoot !== ".." && !fromRoot.startsWith(`..${sep11}`) && !isAbsolute15(fromRoot);
 }
 function hasExistingSymlink(root, path) {
-  const parts = relative9(root, path).split(sep10);
+  const parts = relative9(root, path).split(sep11);
   for (let length = 0; length <= parts.length; length += 1) {
     const candidate = resolve18(root, ...parts.slice(0, length));
     try {
-      if (lstatSync17(candidate).isSymbolicLink())
+      if (lstatSync18(candidate).isSymbolicLink())
         return true;
     } catch {
     }
@@ -90025,7 +90215,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join48(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join49(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -90039,9 +90229,9 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join48(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join49(args.projectRoot, "docs", "proof", args.runId);
   try {
-    lstatSync17(proofRoot);
+    lstatSync18(proofRoot);
     return true;
   } catch (error2) {
     return error2.code !== "ENOENT";
@@ -90065,15 +90255,15 @@ function parseProofGitChanges(porcelain) {
   const records = porcelain.split("\0");
   const changes = [];
   for (let index = 0; index < records.length; index += 1) {
-    const record2 = records[index];
-    if (!record2 || record2.length < 4)
+    const record3 = records[index];
+    if (!record3 || record3.length < 4)
       continue;
     const change = {
-      path: record2.slice(3).replaceAll("\\", "/"),
-      indexStatus: record2[0],
-      worktreeStatus: record2[1]
+      path: record3.slice(3).replaceAll("\\", "/"),
+      indexStatus: record3[0],
+      worktreeStatus: record3[1]
     };
-    if (/[RC]/.test(record2.slice(0, 2))) {
+    if (/[RC]/.test(record3.slice(0, 2))) {
       const sourcePath = records[index + 1];
       if (sourcePath)
         change.sourcePath = sourcePath.replaceAll("\\", "/");
@@ -90095,7 +90285,7 @@ function readProofGitInfo(root) {
 function proofRootHasTrackedEntries(root, proofRoot) {
   if (!isNormalizedDescendant(root, proofRoot))
     throw new Error("INVALID_PROOF_ROOT");
-  const path = relative9(root, proofRoot).replaceAll(sep10, "/");
+  const path = relative9(root, proofRoot).replaceAll(sep11, "/");
   return execFileSync16("git", ["ls-files", "-z", "--", path], {
     cwd: root,
     encoding: "utf8"
@@ -90192,17 +90382,17 @@ function writeProofReceiptAtomic(path, receipt2) {
   const temporary = resolve18(directory, `.${randomUUID12()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
-    descriptor = openSync12(temporary, "wx", 384);
+    descriptor = openSync13(temporary, "wx", 384);
     writeFileSync17(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
-    closeSync12(descriptor);
+    closeSync13(descriptor);
     descriptor = null;
     renameSync10(temporary, path);
     chmodSync8(path, 384);
   } catch (error2) {
     if (descriptor !== null)
-      closeSync12(descriptor);
+      closeSync13(descriptor);
     try {
       unlinkSync16(temporary);
     } catch {
@@ -90364,7 +90554,7 @@ function createProofCaptureHandler(deps) {
       return current.reasons;
     return sameProofAction(current.value, active.actionIdentity) ? [] : ["PROOF_ACTION_IDENTITY_CHANGED"];
   };
-  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep10, "/");
+  const repositoryPath = (active, path) => relative9(active.context.projectRoot, path).replaceAll(sep11, "/");
   const observedSetupScreenshots = (active) => {
     const owned = /* @__PURE__ */ new Set();
     for (const observation of deps.monitor.observations()) {
@@ -90524,7 +90714,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join48(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join49(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -91094,7 +91284,7 @@ import { createHash as createHash22 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir12 } from "node:os";
-import { dirname as dirname27, join as join49 } from "node:path";
+import { dirname as dirname27, join as join50 } from "node:path";
 function fail2(reason) {
   throw new MediaFailure(reason);
 }
@@ -91223,7 +91413,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join49(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join50(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -91248,7 +91438,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join49(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join50(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -91372,7 +91562,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir12();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join49(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join50(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -92594,8 +92784,8 @@ var init_nav_graph = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/auto-login.js
-import { lstatSync as lstatSync18, readFileSync as readFileSync34, readdirSync as readdirSync14, realpathSync as realpathSync17 } from "node:fs";
-import { dirname as dirname28, join as join50, resolve as resolve19 } from "node:path";
+import { lstatSync as lstatSync19, readFileSync as readFileSync34, readdirSync as readdirSync14, realpathSync as realpathSync18 } from "node:fs";
+import { dirname as dirname28, join as join51, resolve as resolve19 } from "node:path";
 function matchesAuthPattern(routeName) {
   const lower = routeName.toLowerCase();
   return AUTH_ROUTE_PATTERNS.some((p) => lower.includes(p));
@@ -92625,13 +92815,13 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join50(projectRoot, ".maestro");
-  const searchDirs = [join50(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join51(projectRoot, ".maestro");
+  const searchDirs = [join51(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
-      const maestroStat = lstatSync18(maestroDir);
-      const dirStat = lstatSync18(dir);
+      const maestroStat = lstatSync19(maestroDir);
+      const dirStat = lstatSync19(dir);
       if (maestroStat.isSymbolicLink() || dirStat.isSymbolicLink()) {
         throw new Error(`Refusing legacy login directory symlink at ${dir}.`);
       }
@@ -92645,17 +92835,17 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join50(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join51(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join50(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join51(dir, authFile));
   }
   return null;
 }
 function assertLegacyLoginFlow(projectRoot, flowPath) {
-  const stat2 = lstatSync18(flowPath);
+  const stat2 = lstatSync19(flowPath);
   if (!stat2.isFile() || stat2.isSymbolicLink()) {
     throw new Error(`Refusing legacy login flow symlink at ${flowPath}.`);
   }
@@ -92681,7 +92871,7 @@ function boundSessionProjectRoot() {
 }
 function canonicalRoot(path) {
   try {
-    return realpathSync17(path);
+    return realpathSync18(path);
   } catch {
     return null;
   }
@@ -92766,7 +92956,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   try {
     const parsed = parseAndValidateFlow(originalContent, {
       flowDir: dirname28(flowPath),
-      flowRoot: join50(projectRoot, ".maestro")
+      flowRoot: join51(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -93351,7 +93541,7 @@ var init_graceful_shutdown = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/maestro-generate.js
-import { basename as basename12, dirname as dirname29, join as join51 } from "node:path";
+import { basename as basename12, dirname as dirname29, join as join52 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -93410,7 +93600,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join51(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join52(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -93493,7 +93683,7 @@ var init_maestro_generate = __esm({
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync34, readdirSync as readdirSync15, readFileSync as readFileSync35, writeFileSync as writeFileSync18 } from "node:fs";
-import { basename as basename13, dirname as dirname30, join as join52, resolve as resolve20 } from "node:path";
+import { basename as basename13, dirname as dirname30, join as join53, resolve as resolve20 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function readNestedFlowEnvelope(result) {
   try {
@@ -93519,7 +93709,7 @@ function filterFlows(yamls, pattern) {
 function discoverFlows(dir, pattern) {
   if (!existsSync34(dir))
     return [];
-  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join52(dir, f)).sort();
+  const yamls = readdirSync15(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join53(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -93544,12 +93734,12 @@ function createMaestroTestAllHandler(deps = {}) {
     const requestedDeviceId = args.deviceId ?? matchingSessionDeviceId;
     const engineStatus = await resolveEngineStatus();
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join52(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join53(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve20(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join52(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join53(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
@@ -93582,7 +93772,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if ("error" in dispatch) {
       return failResult(dispatch.error);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join52(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join53(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -93741,7 +93931,7 @@ function createMaestroTestAllHandler(deps = {}) {
           break;
         continue;
       }
-      const safeFlowFile = join52(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      const safeFlowFile = join53(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync18(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
@@ -93933,8 +94123,8 @@ var init_maestro_test_all = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cross-platform-verify.js
-import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync19 } from "node:fs";
-import { join as join53, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync16, lstatSync as lstatSync20 } from "node:fs";
+import { join as join54, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -93957,9 +94147,9 @@ function discoverTestIDs(dir) {
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join53(d, entry);
+      const full = join54(d, entry);
       try {
-        const st = lstatSync19(full);
+        const st = lstatSync20(full);
         if (st.isSymbolicLink())
           continue;
         if (st.isDirectory()) {
@@ -94328,7 +94518,7 @@ var init_instrumentation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join54 } from "node:path";
+import { join as join55 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -94468,7 +94658,7 @@ function buildLiveDeps(input) {
     readShotFile: input.readShotFile,
     // Preserve Recorder.pushLive's `this` binding.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join54(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join55(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive,
     reportBlocked: input.reportBlocked
   };
@@ -94627,7 +94817,7 @@ import { createServer as createServer3 } from "node:http";
 import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync37 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname31, join as join55 } from "node:path";
+import { dirname as dirname31, join as join56 } from "node:path";
 function listen(server3, port) {
   return new Promise((resolve22, reject) => {
     const onErr = (e) => {
@@ -94893,7 +95083,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync37(join55(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync37(join56(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -95079,10 +95269,10 @@ var init_server3 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
-import { join as join56 } from "node:path";
+import { join as join57 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join56(getStateDir(), "observe", `${safe}.json`);
+  return join57(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -95795,16 +95985,16 @@ var init_target = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname32, join as join57 } from "node:path";
+import { dirname as dirname32, join as join58 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync19, renameSync as renameSync11, readFileSync as readFileSync38, readdirSync as readdirSync17, existsSync as existsSync35 } from "node:fs";
 import { createHash as createHash23 } from "node:crypto";
 function e2eDirFor(projectRoot) {
-  return join57(projectRoot, ".rn-agent", "e2e");
+  return join58(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join57(dir, `${id}.yaml`);
+  const file = join58(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -95921,9 +96111,9 @@ var init_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
-import { join as join58 } from "node:path";
+import { join as join59 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join58(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join59(projectRoot, ".rn-agent", "e2e.config.json");
   try {
     const raw = readFileSync39(filePath, "utf8");
     return JSON.parse(raw);
@@ -96078,7 +96268,7 @@ var init_lock_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
-import { join as join59 } from "node:path";
+import { join as join60 } from "node:path";
 import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync20, renameSync as renameSync12, readFileSync as readFileSync40, existsSync as existsSync36 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
@@ -96133,16 +96323,16 @@ function diffNewlyFailing(current, previousGreen) {
   return current.results.filter((r) => !r.passed && r.classification !== "skipped" && (previousGreen === null || wasPassing.has(r.testId))).map((r) => r.testId);
 }
 function e2eRunsDirFor(projectRoot) {
-  return join59(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join60(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync23(join59(file, ".."), { recursive: true });
+  mkdirSync23(join60(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
   writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
   renameSync12(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join59(e2eRunsDirFor(projectRoot), "index.json");
+  const file = join60(e2eRunsDirFor(projectRoot), "index.json");
   if (!existsSync36(file))
     return [];
   try {
@@ -96155,7 +96345,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join59(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join60(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -96163,11 +96353,11 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join59(dir, "index.json"), next);
+  writeJsonAtomic(join60(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join59(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  const file = join60(e2eRunsDirFor(projectRoot), `${runId}.json`);
   if (!existsSync36(file))
     return null;
   try {
@@ -96191,14 +96381,14 @@ var init_e2e_run = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join60 } from "node:path";
+import { join as join61 } from "node:path";
 import { mkdirSync as mkdirSync24, writeFileSync as writeFileSync21, renameSync as renameSync13, readFileSync as readFileSync41, readdirSync as readdirSync18, existsSync as existsSync37 } from "node:fs";
 function requestsDir(projectRoot) {
-  return join60(e2eRunsDirFor(projectRoot), "requests");
+  return join61(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join60(requestsDir(projectRoot), `${runId}.json`);
+  return join61(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
@@ -96377,7 +96567,7 @@ async function runE2eSuiteCore(args, deps = {}) {
   const verdict = computeVerdict(results);
   const prevGreenId = lastGreenRunId(projectRoot);
   const prevGreen = prevGreenId ? loadRunRecord(projectRoot, prevGreenId) : null;
-  const record2 = {
+  const record3 = {
     runId,
     startedAt,
     finishedAt: now().toISOString(),
@@ -96397,13 +96587,13 @@ async function runE2eSuiteCore(args, deps = {}) {
     results,
     previousGreenRunId: prevGreenId
   };
-  writeRunRecord(projectRoot, record2);
+  writeRunRecord(projectRoot, record3);
   return okResult({
     runId,
     verdict,
-    totals: record2.totals,
+    totals: record3.totals,
     results,
-    newlyFailing: diffNewlyFailing(record2, prevGreen),
+    newlyFailing: diffNewlyFailing(record3, prevGreen),
     metroReloaded
   });
 }
@@ -97498,7 +97688,7 @@ import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
-import { dirname as dirname33, join as join61 } from "node:path";
+import { dirname as dirname33, join as join62 } from "node:path";
 function trackedTool(name, desc, schema, handler, afterAuthority) {
   registeredToolNames.push(name);
   const gated = authorityGate.wrap(name, arbiterWrap(name, handler));
@@ -98121,7 +98311,7 @@ var init_index = __esm({
     init_managed_metro();
     init_process_cleanup();
     init_runtime_connection_recovery();
-    pkgPath = join61(dirname33(fileURLToPath7(import.meta.url)), "..", "package.json");
+    pkgPath = join62(dirname33(fileURLToPath7(import.meta.url)), "..", "package.json");
     pkgVersion = JSON.parse(readFileSync42(pkgPath, "utf8")).version;
     lockfile = null;
     diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
@@ -98535,7 +98725,7 @@ var init_index = __esm({
         return null;
       if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
         return null;
-      const secretPath = sessionId ? join61(dirname33(dirname33(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+      const secretPath = sessionId ? join62(dirname33(dirname33(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
       return readJsonStateFile(secretPath)?.signerCapability ?? null;
     };
     spawningSupervisorPid = process.ppid;
@@ -99635,8 +99825,8 @@ var init_index = __esm({
 // packages/rn-dev-agent-core/dist/supervisor.js
 import { randomUUID as randomUUID14 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
-import { lstatSync as lstatSync20, readFileSync as readFileSync43 } from "node:fs";
-import { dirname as dirname34, join as join62, resolve as resolve21 } from "node:path";
+import { lstatSync as lstatSync21, readFileSync as readFileSync43 } from "node:fs";
+import { dirname as dirname34, join as join63, resolve as resolve21 } from "node:path";
 import { fileURLToPath as fileURLToPath8 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/lifecycle/child-error-or-exit.js
@@ -100025,7 +100215,7 @@ function supervisorRelaunchArgs(supervisorPath, sqliteWarningFilterPath2, versio
 
 // packages/rn-dev-agent-core/dist/supervisor.js
 var here = dirname34(fileURLToPath8(import.meta.url));
-var sqliteWarningFilterPath = join62(here, "sqlite-warning-filter.js");
+var sqliteWarningFilterPath = join63(here, "sqlite-warning-filter.js");
 var unsupportedNode = unsupportedNodeVersionMessage();
 if (unsupportedNode) {
   process.stderr.write(`${unsupportedNode}
@@ -100042,12 +100232,12 @@ if (supervisorFlag.length > 0 && !process.execArgv.includes("--experimental-sqli
 }
 function legacyRepairArtifactPresent(cwd) {
   try {
-    if (lstatSync20(join62(cwd, ".rn-agent")).isSymbolicLink())
+    if (lstatSync21(join63(cwd, ".rn-agent")).isSymbolicLink())
       return true;
   } catch {
   }
   try {
-    lstatSync20(join62(cwd, ".rn-agent.bak"));
+    lstatSync21(join63(cwd, ".rn-agent.bak"));
     return true;
   } catch {
     return false;
@@ -100104,7 +100294,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     const workerEnvironment = {
       ...process.env,
       RN_BRIDGE_SUPERVISED: "1",
-      RN_DEV_AGENT_SESSION_CLI: join62(here, "rn-session.js"),
+      RN_DEV_AGENT_SESSION_CLI: join63(here, "rn-session.js"),
       RN_BRIDGE_RESTARTS: String(core.restartCount),
       ...core.lastExit ? { RN_BRIDGE_LAST_EXIT: core.lastExit } : {},
       ...authority && spawnAuthorityError === null ? authority.workerEnvironment(workerInstance) : {
@@ -100176,12 +100366,12 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     force.unref();
   };
   apply = apply2, resolveAuthorityForSpawn = resolveAuthorityForSpawn2, spawnWorker = spawnWorker2, closeAuthorityAndExit = closeAuthorityAndExit2, beginShutdown = beginShutdown2;
-  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ? resolve21(process.env.RN_BRIDGE_WORKER_PATH) : join62(here, "index.js");
+  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ? resolve21(process.env.RN_BRIDGE_WORKER_PATH) : join63(here, "index.js");
   const noLock2 = process.argv.includes("--no-lock");
   const diagnosticContractProbe2 = process.argv.includes("--diagnostic-contract-probe");
   let lockfile2 = null;
   if (!noLock2) {
-    const pkg = JSON.parse(readFileSync43(join62(here, "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync43(join63(here, "..", "package.json"), "utf8"));
     lockfile2 = new Lockfile({ version: pkg.version });
     const lockResult = lockfile2.acquire();
     if (lockResult.status === "conflict") {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/workflow-check.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/workflow-check.js
@@ -10449,13 +10449,16 @@ function fail2(code, message) {
 `);
   process.exit(code);
 }
-function readTextIfFile(filePath) {
+function readTextIfFile(filePath, reportReadError = false) {
   try {
     const stat = fs.lstatSync(filePath);
     if (!stat.isFile())
       return null;
     return fs.readFileSync(filePath, "utf8");
-  } catch {
+  } catch (error) {
+    if (reportReadError && error.code !== "ENOENT") {
+      fail2(2, `workflow-check: cannot read ${path.basename(filePath)}`);
+    }
     return null;
   }
 }
@@ -10559,8 +10562,7 @@ function preflight(projectRoot) {
   const lockManagers = new Set(locks.map((lock) => lock.manager));
   const inferredLock = declaration.kind === "absent" && lockManagers.size === 1 ? locks[0] : null;
   const matchingLock = field === null ? inferredLock : locks.find((lock) => lock.manager === field) ?? null;
-  const claudeMd = readTextIfFile(path.join(projectRoot, "CLAUDE.md"));
-  const claudeMdBlock = claudeMd !== null && claudeMd.includes(TEMPLATE_HEADING) ? "present" : "absent";
+  const claudeMdBlocks = ["CLAUDE.md", "CLAUDE.local.md"].map((file) => readTextIfFile(path.join(projectRoot, file), true)).filter((text) => text !== null && text.includes(TEMPLATE_HEADING));
   const resolvedManager = field ?? inferredLock?.manager ?? null;
   const relativeWorkspaceRoot = redactedWorkspaceRoot(projectRoot, workspaceRoot);
   const modulesPresent = nodeModulesPresent(workspaceRoot);
@@ -10575,8 +10577,8 @@ function preflight(projectRoot) {
     nodeModulesPresent: modulesPresent,
     yarnPnpPresent: pnpPresent,
     dependenciesReady: modulesPresent || resolvedManager === "yarn" && pnpPresent,
-    claudeMdBlock,
-    claudeMdSentinel: claudeMd !== null && claudeMd.includes(TEMPLATE_SENTINEL),
+    claudeMdBlock: claudeMdBlocks.length > 0 ? "present" : "absent",
+    claudeMdSentinel: claudeMdBlocks.some((text) => text.includes(TEMPLATE_SENTINEL)),
     stateRoot: stateRootFacts()
   };
   const where = locationPhrase(relativeWorkspaceRoot);

--- a/packages/codex-plugin/skills/rn-workflow/SKILL.md
+++ b/packages/codex-plugin/skills/rn-workflow/SKILL.md
@@ -70,8 +70,16 @@ node <package-root>/rn-dev-agent-core/dist/workflow-check.js preflight --project
 
 It reports `packageManager` (the `packageManager` field wins, lockfile
 inference is the fallback), the exact `installCommand`, `nodeModulesPresent`,
-the onboarding block, and the private-state-root kind and existence, with at
-most ONE actionable `stop`.
+`claudeMdBlock`, `claudeMdSentinel`, and the private-state-root kind and
+existence, with at most ONE actionable `stop`.
+
+The Claude facts are read-only: the exact Claude template heading in either
+Claude instruction file from Step 0 marks the block present, including legacy
+heading-only blocks. The sentinel fact is true only when a heading and
+sentinel occur in the same file. These facts do not inspect `AGENTS.md` or
+replace Step 0's onboarding decision.
+An instruction-file read error other than a missing file exits 2 with a
+stderr diagnostic and no JSON result; surface it and stop.
 
 In a monorepo the checker resolves the package-manager facts from the nearest
 ancestor that declares `packageManager` or holds a lockfile (bounded by the git

--- a/packages/codex-plugin/skills/rn-workflow/SKILL.md
+++ b/packages/codex-plugin/skills/rn-workflow/SKILL.md
@@ -54,7 +54,9 @@ plugin-root environment variable, marketplace source path, or cache scan.
 Read the project's injected agent-instruction block (for Codex projects the
 `AGENTS.md` block between `<!-- rn-dev-agent:codex-template-start -->` and
 `<!-- rn-dev-agent:codex-template-end -->`; a Claude-onboarded project carries
-the equivalent CLAUDE.md block) and `.rn-agent/local/troubleshooting.md`.
+the equivalent block in either `CLAUDE.md` or `CLAUDE.local.md`) and
+`.rn-agent/local/troubleshooting.md`. Keep shared instructions untouched when
+the block lives in `CLAUDE.local.md`.
 If no injected block exists → stop: "project not onboarded — run
 `$rn-dev-agent:setup`". Never start device work on an un-onboarded project.
 

--- a/packages/rn-dev-agent-core/src/domain/maestro-runner-report.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-runner-report.ts
@@ -172,6 +172,7 @@ export function runnerReportFingerprint(reportDir: string | null): RunnerReportF
 export function readStructuredFlowArtifact(
   reportDir: string | null,
   previous?: RunnerReportFingerprint,
+  readText: (path: string) => string = (path) => readFileSync(path, 'utf8'),
 ): StructuredFlowArtifact | null {
   if (!reportDir) return null;
   const reportPath = join(reportDir, 'report.json');
@@ -182,7 +183,7 @@ export function readStructuredFlowArtifact(
     commands: [],
   };
   try {
-    const reportText = readFileSync(reportPath, 'utf8');
+    const reportText = readText(reportPath);
     if (previous) {
       // An inconclusive baseline can prove nothing about freshness.
       if (Object.values(previous).includes(FINGERPRINT_INCONCLUSIVE)) return unfinalized;
@@ -215,7 +216,7 @@ export function readStructuredFlowArtifact(
     // report tree, not merely have a clean lexical path.
     const realDataFile = realpathSync(join(reportDir, normalizedDataFile));
     if (!realDataFile.startsWith(realpathSync(reportDir) + sep)) return unfinalized;
-    const dataText = readFileSync(realDataFile, 'utf8');
+    const dataText = readText(realDataFile);
     if (previous) {
       const dataHash = createHash('sha256').update(dataText).digest('hex');
       // A fresh report.json referencing a data file the invocation did NOT

--- a/packages/rn-dev-agent-core/src/domain/reusable-action.ts
+++ b/packages/rn-dev-agent-core/src/domain/reusable-action.ts
@@ -256,6 +256,7 @@ export interface AutoRepairOutcome {
 
 /** A single replay attempt's outcome. Append-only; oldest dropped at limit. */
 export interface RunRecord {
+  /** Bounded closed-vocabulary projection of runner failures; text, images, and terminal output are withheld. */
   runnerFailureEvidence?: import('./runner-failure-evidence.js').RunnerFailureEvidence;
   /** Unique replay identity, used to prove that a prologue produced a fresh record. */
   runId?: string;

--- a/packages/rn-dev-agent-core/src/domain/reusable-action.ts
+++ b/packages/rn-dev-agent-core/src/domain/reusable-action.ts
@@ -256,6 +256,7 @@ export interface AutoRepairOutcome {
 
 /** A single replay attempt's outcome. Append-only; oldest dropped at limit. */
 export interface RunRecord {
+  runnerFailureEvidence?: import('./runner-failure-evidence.js').RunnerFailureEvidence;
   /** Unique replay identity, used to prove that a prologue produced a fresh record. */
   runId?: string;
   timestamp: string; // ISO

--- a/packages/rn-dev-agent-core/src/domain/runner-failure-evidence.ts
+++ b/packages/rn-dev-agent-core/src/domain/runner-failure-evidence.ts
@@ -1,0 +1,185 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+} from 'node:fs';
+import { join, sep } from 'node:path';
+import {
+  readStructuredFlowArtifact,
+  type RunnerReportFingerprint,
+} from './maestro-runner-report.js';
+import type { LedgerInvocationTermination, LedgerObservationStatus } from './maestro-run-ledger.js';
+
+const MAX_CAPTURES = 8;
+const MAX_ROWS = 64;
+const MAX_REPORT_BYTES = 256 * 1024;
+const STATUSES = ['passed', 'failed', 'skipped', 'running', 'pending', 'unknown'] as const;
+const REPORT_STATES = ['missing', 'unavailable', 'oversized', 'unfinalized', 'finalized'] as const;
+
+type FailureCapture = {
+  attempt: number;
+  stage: number;
+  invocation: number;
+  exitCode: number | null;
+  signalPresent: boolean;
+  timedOut: boolean;
+  outputTruncated: boolean;
+  bootstrapFailure: boolean;
+  transportFailure: boolean;
+  report: (typeof REPORT_STATES)[number];
+  rowsTruncated: boolean;
+  commands: { index: number; status: LedgerObservationStatus; errorPresent: boolean }[];
+};
+
+export type RunnerFailureEvidence = {
+  version: 1;
+  incomplete: true;
+  withheld: 'text-images-terminal-output-and-original-artifacts';
+  capturesTruncated: boolean;
+  captures: FailureCapture[];
+};
+
+export function createRunnerFailureEvidence(): RunnerFailureEvidence {
+  return {
+    version: 1,
+    incomplete: true,
+    withheld: 'text-images-terminal-output-and-original-artifacts',
+    capturesTruncated: false,
+    captures: [],
+  };
+}
+
+function append(evidence: RunnerFailureEvidence, capture: FailureCapture): void {
+  evidence.captures.push(capture);
+  if (evidence.captures.length > MAX_CAPTURES) {
+    evidence.captures.splice(1, 1);
+    evidence.capturesTruncated = true;
+  }
+}
+
+export function captureRunnerFailure(
+  evidence: RunnerFailureEvidence,
+  reportDir: string | null,
+  previous: RunnerReportFingerprint,
+  stage: number,
+  invocation: number,
+  termination: Omit<LedgerInvocationTermination, 'artifactFinalized'>,
+  attempt = 1,
+): void {
+  const capture: FailureCapture = {
+    attempt,
+    stage,
+    invocation,
+    exitCode: Number.isSafeInteger(termination.exitCode) ? termination.exitCode : null,
+    signalPresent: termination.signal !== null,
+    timedOut: termination.timedOut,
+    outputTruncated: termination.outputTruncated,
+    bootstrapFailure: termination.bootstrapFailure,
+    transportFailure: termination.transportFailure,
+    report: 'missing',
+    rowsTruncated: false,
+    commands: [],
+  };
+  try {
+    if (reportDir) {
+      if (!lstatSync(reportDir).isDirectory()) throw new Error();
+      const root = realpathSync(reportDir);
+      const reportPath = join(root, 'report.json');
+      lstatSync(reportPath);
+      let readFailure: 'unavailable' | 'oversized' | undefined;
+      let remaining = MAX_REPORT_BYTES;
+      const artifact = readStructuredFlowArtifact(root, previous, (path) => {
+        let fd: number | undefined;
+        try {
+          if (!realpathSync(path).startsWith(root + sep)) throw new Error();
+          fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+          const stat = fstatSync(fd);
+          if (!stat.isFile()) throw new Error();
+          if (stat.size > remaining) {
+            readFailure = 'oversized';
+            throw new Error();
+          }
+          const bytes = Buffer.alloc(stat.size + 1);
+          const size = readSync(fd, bytes, 0, bytes.length, 0);
+          if (size !== stat.size || fstatSync(fd).size !== size) throw new Error();
+          remaining -= size;
+          return bytes.subarray(0, size).toString('utf8');
+        } catch (error) {
+          readFailure ??= 'unavailable';
+          throw error;
+        } finally {
+          if (fd !== undefined) closeSync(fd);
+        }
+      });
+      capture.report =
+        readFailure ?? (artifact ? (artifact.finalized ? 'finalized' : 'unfinalized') : 'missing');
+      if (artifact?.finalized && !readFailure) {
+        capture.rowsTruncated = artifact.commands.length > MAX_ROWS;
+        const rows = [...artifact.commands].sort(
+          (a, b) => Number(b.status === 'failed') - Number(a.status === 'failed'),
+        );
+        capture.commands = rows.slice(0, MAX_ROWS).map((row) => ({
+          index: row.index,
+          status: row.status,
+          errorPresent: row.error !== undefined,
+        }));
+      }
+    }
+  } catch (error) {
+    capture.report = (error as { code?: string }).code === 'ENOENT' ? 'missing' : 'unavailable';
+  }
+  append(evidence, capture);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+// Re-project at the action boundary; tool metadata is not a storage schema.
+export function collectRunnerFailureEvidence(
+  evidence: RunnerFailureEvidence,
+  value: unknown,
+): void {
+  const input = record(value);
+  if (input.version !== 1 || !Array.isArray(input.captures)) return;
+  evidence.capturesTruncated ||=
+    input.capturesTruncated === true || input.captures.length > MAX_CAPTURES;
+  const captures =
+    input.captures.length > MAX_CAPTURES
+      ? [input.captures[0], ...input.captures.slice(-(MAX_CAPTURES - 1))]
+      : input.captures;
+  for (const item of captures) {
+    const row = record(item);
+    if (!Number.isSafeInteger(row.stage) || !Number.isSafeInteger(row.invocation)) continue;
+    const state = REPORT_STATES.find((state) => state === row.report) ?? 'unavailable';
+    const commands = Array.isArray(row.commands) ? row.commands : [];
+    append(evidence, {
+      attempt: Number.isSafeInteger(row.attempt) ? Number(row.attempt) : 1,
+      stage: Number(row.stage),
+      invocation: Number(row.invocation),
+      exitCode: Number.isSafeInteger(row.exitCode) ? Number(row.exitCode) : null,
+      signalPresent: row.signalPresent === true,
+      timedOut: row.timedOut === true,
+      outputTruncated: row.outputTruncated === true,
+      bootstrapFailure: row.bootstrapFailure === true,
+      transportFailure: row.transportFailure === true,
+      report: state,
+      rowsTruncated: row.rowsTruncated === true || commands.length > MAX_ROWS,
+      commands: commands.slice(0, MAX_ROWS).flatMap((item) => {
+        const command = record(item);
+        if (!Number.isSafeInteger(command.index)) return [];
+        return [
+          {
+            index: Number(command.index),
+            status: STATUSES.find((status) => status === command.status) ?? 'unknown',
+            errorPresent: command.errorPresent === true,
+          },
+        ];
+      }),
+    });
+  }
+}

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -1,3 +1,8 @@
+import {
+  captureRunnerFailure,
+  createRunnerFailureEvidence,
+  type RunnerFailureEvidence,
+} from '../domain/runner-failure-evidence.js';
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
@@ -26,7 +31,7 @@ import {
 } from '../domain/action-engine-compat.js';
 import { parseM7Header, type M7Metadata } from '../domain/reusable-action.js';
 import { captureActionFromPath, type CapturedActionReplay } from '../domain/action-store.js';
-import { getActiveSession } from '../agent-device-wrapper.js';
+import { attachMeta, getActiveSession } from '../agent-device-wrapper.js';
 import { resolveBundleId, readExpoSlug } from '../project-config.js';
 import {
   chooseMaestroDispatch,
@@ -629,7 +634,10 @@ export function createMaestroRunHandler(
   const nativeOnlyHandler = replayFactory
     ? createMaestroRunHandler({ ...deps, replayDeps: undefined })
     : null;
-  return async (args) => {
+  const run = async (
+    args: MaestroRunArgs,
+    evidence: RunnerFailureEvidence,
+  ): Promise<ToolResult> => {
     // GH #116: validate params shape FIRST so a malformed payload is rejected
     // regardless of platform / dispatch-tier availability. CI envs without
     // maestro-runner or Maestro CLI would otherwise short-circuit at
@@ -1345,6 +1353,7 @@ export function createMaestroRunHandler(
     })();
     const stageCaptures: LedgerStageCaptureInput[] = [];
     let ledgerStageCursor = 0;
+    let invocationOrdinal = 0;
     const stageTerminationFromError = (
       error: unknown,
     ): Omit<LedgerInvocationTermination, 'artifactFinalized'> => {
@@ -1451,10 +1460,11 @@ export function createMaestroRunHandler(
                       Object.assign(error, { code: 'ETIMEDOUT' });
                       throw error;
                     }
-                    const executeRunner = (
+                    const executeRunner = async (
                       runnerPath: string,
                       prefixArgs: readonly string[] = [],
                     ) => {
+                      const fingerprint = runnerReportFingerprint(runnerReportDir);
                       beforeDispatch?.();
                       const remainingTimeout = flowDeadline - now();
                       if (remainingTimeout <= 0) {
@@ -1464,12 +1474,49 @@ export function createMaestroRunHandler(
                         Object.assign(error, { code: 'ETIMEDOUT' });
                         throw error;
                       }
-                      return execute(runnerPath, [...prefixArgs, ...finalArgs], {
-                        timeout: remainingTimeout,
-                        encoding: 'utf8',
-                        maxBuffer: 10 * 1024 * 1024,
-                        signal: flowAbort.signal,
-                      });
+                      const invocation = ++invocationOrdinal;
+                      try {
+                        const result = await execute(runnerPath, [...prefixArgs, ...finalArgs], {
+                          timeout: remainingTimeout,
+                          encoding: 'utf8',
+                          maxBuffer: 10 * 1024 * 1024,
+                          signal: flowAbort.signal,
+                        });
+                        if (
+                          outputIndicatesFlowFailure(
+                            combineRunnerOutput(result.stdout, result.stderr),
+                          )
+                        ) {
+                          captureRunnerFailure(
+                            evidence,
+                            runnerReportDir,
+                            fingerprint,
+                            ledgerStageIndex,
+                            invocation,
+                            {
+                              exitCode: 0,
+                              signal: null,
+                              timedOut: false,
+                              outputTruncated: false,
+                              bootstrapFailure: false,
+                              transportFailure: false,
+                            },
+                            ledgerAttempt.ordinal,
+                          );
+                        }
+                        return result;
+                      } catch (error) {
+                        captureRunnerFailure(
+                          evidence,
+                          runnerReportDir,
+                          fingerprint,
+                          ledgerStageIndex,
+                          invocation,
+                          stageTerminationFromError(error),
+                          ledgerAttempt.ordinal,
+                        );
+                        throw error;
+                      }
                     };
                     if (deps.execFile) {
                       const immediateStatus = await resolveEngineStatus();
@@ -2030,6 +2077,20 @@ export function createMaestroRunHandler(
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
+    }
+  };
+  return async (args) => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length
+        ? attachMeta(result, { runnerFailureEvidence: evidence })
+        : result;
+    } catch (error) {
+      if (error instanceof SessionAuthorityError && evidence.captures.length) {
+        error.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error;
     }
   };
 }

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -1,3 +1,9 @@
+import { attachMeta } from '../agent-device-wrapper.js';
+import {
+  collectRunnerFailureEvidence,
+  createRunnerFailureEvidence,
+  type RunnerFailureEvidence,
+} from '../domain/runner-failure-evidence.js';
 // Issue #104 — `cdp_run_action` MCP tool. Replays a learned action's
 // Maestro flow, parses failures, optionally auto-repairs on
 // SELECTOR_NOT_FOUND, and persists a RunRecord with auto-repair
@@ -558,7 +564,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
     deps.resolveAppFile ??
     ((appId: string, deviceId: string) => resolveIosAppFile(appId, { deviceId }));
   const resolveEngineStatus = deps.engineStatus ?? (() => getEngineStatus().catch(() => null));
-  return async (args: RunActionArgs): Promise<ToolResult> => {
+  const run = async (args: RunActionArgs, evidence: RunnerFailureEvidence): Promise<ToolResult> => {
     if (!args.actionId || typeof args.actionId !== 'string') {
       return failResult('cdp_run_action requires actionId', 'BAD_FILENAME');
     }
@@ -747,6 +753,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       const endedMs = Date.now();
       const timedRecord: RunRecord = {
         ...record,
+        ...(evidence.captures.length ? { runnerFailureEvidence: structuredClone(evidence) } : {}),
         runId,
         timing: {
           startedAt,
@@ -813,6 +820,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       );
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, 'maestro_run');
+      collectRunnerFailureEvidence(evidence, firstEnv.meta?.runnerFailureEvidence);
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
@@ -1267,6 +1275,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       );
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, 'maestro_run');
+      collectRunnerFailureEvidence(evidence, retryEnv.meta?.runnerFailureEvidence);
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
@@ -1464,6 +1473,20 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
             : {}),
         },
       );
+    }
+  };
+  return async (args: RunActionArgs): Promise<ToolResult> => {
+    const evidence = createRunnerFailureEvidence();
+    try {
+      const result = await run(args, evidence);
+      return evidence.captures.length
+        ? attachMeta(result, { runnerFailureEvidence: evidence })
+        : result;
+    } catch (error) {
+      if (error instanceof SessionAuthorityError && evidence.captures.length) {
+        error.attachMeta({ runnerFailureEvidence: evidence });
+      }
+      throw error;
     }
   };
 }

--- a/packages/rn-dev-agent-core/src/workflow-check.ts
+++ b/packages/rn-dev-agent-core/src/workflow-check.ts
@@ -97,12 +97,15 @@ function fail(code: number, message: string): never {
   process.exit(code);
 }
 
-function readTextIfFile(filePath: string): string | null {
+function readTextIfFile(filePath: string, reportReadError = false): string | null {
   try {
     const stat = fs.lstatSync(filePath);
     if (!stat.isFile()) return null;
     return fs.readFileSync(filePath, 'utf8');
-  } catch {
+  } catch (error) {
+    if (reportReadError && (error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      fail(2, `workflow-check: cannot read ${path.basename(filePath)}`);
+    }
     return null;
   }
 }
@@ -227,9 +230,9 @@ function preflight(projectRoot: string): { facts: PreflightFacts; stop: Stop | n
   const inferredLock = declaration.kind === 'absent' && lockManagers.size === 1 ? locks[0] : null;
   const matchingLock =
     field === null ? inferredLock : (locks.find((lock) => lock.manager === field) ?? null);
-  const claudeMd = readTextIfFile(path.join(projectRoot, 'CLAUDE.md'));
-  const claudeMdBlock =
-    claudeMd !== null && claudeMd.includes(TEMPLATE_HEADING) ? 'present' : 'absent';
+  const claudeMdBlocks = ['CLAUDE.md', 'CLAUDE.local.md']
+    .map((file) => readTextIfFile(path.join(projectRoot, file), true))
+    .filter((text): text is string => text !== null && text.includes(TEMPLATE_HEADING));
 
   const resolvedManager = field ?? inferredLock?.manager ?? null;
   const relativeWorkspaceRoot = redactedWorkspaceRoot(projectRoot, workspaceRoot);
@@ -245,8 +248,8 @@ function preflight(projectRoot: string): { facts: PreflightFacts; stop: Stop | n
     nodeModulesPresent: modulesPresent,
     yarnPnpPresent: pnpPresent,
     dependenciesReady: modulesPresent || (resolvedManager === 'yarn' && pnpPresent),
-    claudeMdBlock,
-    claudeMdSentinel: claudeMd !== null && claudeMd.includes(TEMPLATE_SENTINEL),
+    claudeMdBlock: claudeMdBlocks.length > 0 ? 'present' : 'absent',
+    claudeMdSentinel: claudeMdBlocks.some((text) => text.includes(TEMPLATE_SENTINEL)),
     stateRoot: stateRootFacts(),
   };
 

--- a/packages/rn-dev-agent-core/test/unit/runner-failure-evidence.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/runner-failure-evidence.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  captureRunnerFailure,
+  collectRunnerFailureEvidence,
+  createRunnerFailureEvidence,
+} from '../../dist/domain/runner-failure-evidence.js';
+import { runnerReportFingerprint } from '../../dist/domain/maestro-runner-report.js';
+import { createMaestroRunHandler } from '../../dist/tools/maestro-run.js';
+import { createLoginPrologueHandler } from '../../dist/tools/login-prologue.js';
+import {
+  _resetEngineStatusForTest,
+  _setEngineStatusForTest,
+  buildReplayEngineStatus,
+  MAESTRO_RUNNER_PIN,
+} from '../../dist/domain/engine-pin.js';
+import {
+  createPinnedRunActionHandler,
+  createTmpProject,
+  fixtureYaml,
+} from '../helpers/tmp-project.js';
+
+const SECRET = 'synthetic-login-017@example.invalid 739162';
+const termination = {
+  exitCode: 1,
+  signal: null,
+  timedOut: false,
+  outputTruncated: false,
+  bootstrapFailure: false,
+  transportFailure: false,
+};
+function report(dir: string, count = 2) {
+  mkdirSync(join(dir, 'flows'), { recursive: true });
+  writeFileSync(
+    join(dir, 'report.json'),
+    JSON.stringify({
+      status: 'failed',
+      flows: [
+        {
+          status: 'failed',
+          dataFile: 'flows/flow.json',
+          commands: {
+            total: count,
+            passed: count - 1,
+            failed: 1,
+            skipped: 0,
+            pending: 0,
+            running: 0,
+          },
+        },
+      ],
+    }),
+  );
+  writeFileSync(
+    join(dir, 'flows/flow.json'),
+    JSON.stringify({
+      commands: Array.from({ length: count }, (_, index) => ({
+        index,
+        type: SECRET,
+        status: index === count - 1 ? 'failed' : 'passed',
+        error: { message: SECRET },
+      })),
+    }),
+  );
+  writeFileSync(join(dir, 'failure.png'), SECRET);
+}
+function capture(dir: string | null, previous = {}) {
+  const evidence = createRunnerFailureEvidence();
+  captureRunnerFailure(evidence, dir, previous, 0, 1, termination);
+  assert.equal(JSON.stringify(evidence).includes(SECRET), false);
+  return evidence;
+}
+
+beforeEach(() =>
+  _setEngineStatusForTest(buildReplayEngineStatus('pinned-ok', MAESTRO_RUNNER_PIN.version, false)),
+);
+afterEach(() => _resetEngineStatusForTest());
+
+test('projection bounds rows, preserves the late failed index and excludes arbitrary fields and images', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'failure-projection-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  report(dir, 100);
+  const original = readFileSync(join(dir, 'flows/flow.json'));
+  const evidence = capture(dir);
+  assert.equal(evidence.captures[0].report, 'finalized');
+  assert.equal(evidence.captures[0].commands.length, 64);
+  assert.deepEqual(evidence.captures[0].commands[0], {
+    index: 99,
+    status: 'failed',
+    errorPresent: true,
+  });
+  assert.equal(evidence.captures[0].rowsTruncated, true);
+  assert.deepEqual(readFileSync(join(dir, 'flows/flow.json')), original);
+  assert.equal(capture(dir, runnerReportFingerprint(dir)).captures[0].report, 'missing');
+  const merged = createRunnerFailureEvidence();
+  for (let i = 0; i < 10; i++) {
+    collectRunnerFailureEvidence(merged, {
+      ...evidence,
+      captures: [
+        {
+          ...evidence.captures[0],
+          invocation: i,
+          unsafe: SECRET,
+          commands: [{ index: 1, status: SECRET, error: SECRET }],
+        },
+      ],
+    });
+  }
+  assert.equal(merged.captures.length, 8);
+  assert.deepEqual(
+    merged.captures.map((row) => row.invocation),
+    [0, 3, 4, 5, 6, 7, 8, 9],
+  );
+  assert.equal(merged.capturesTruncated, true);
+  assert.equal(JSON.stringify(merged).includes(SECRET), false);
+});
+
+for (const condition of ['missing', 'malformed', 'oversized', 'partial', 'symlink'] as const) {
+  test(`projection discloses ${condition} report without admitting unsafe evidence`, (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'failure-projection-'));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    report(dir);
+    const path = join(dir, 'report.json');
+    if (condition === 'missing') rmSync(path);
+    if (condition === 'malformed') writeFileSync(path, '{');
+    if (condition === 'oversized') writeFileSync(path, ' '.repeat(256 * 1024 + 1));
+    if (condition === 'partial') {
+      rmSync(join(dir, 'flows/flow.json'));
+      mkdirSync(join(dir, 'flows/flow.json'));
+    }
+    if (condition === 'symlink') {
+      rmSync(path);
+      symlinkSync(join(dir, 'failure.png'), path);
+    }
+    const expected = {
+      missing: 'missing',
+      malformed: 'unfinalized',
+      oversized: 'oversized',
+      partial: 'unavailable',
+      symlink: 'unavailable',
+    }[condition];
+    const evidence = capture(dir);
+    assert.equal(evidence.captures[0].report, expected);
+    assert.deepEqual(evidence.captures[0].commands, []);
+    assert.equal(evidence.incomplete, true);
+  });
+}
+
+const SERIAL = 'emulator-5580';
+const APP_ID = 'dev.example.retention';
+function handler(
+  execFile: NonNullable<Parameters<typeof createMaestroRunHandler>[0]>['execFile'],
+  releaseAndroidSlot?: NonNullable<
+    Parameters<typeof createMaestroRunHandler>[0]
+  >['releaseAndroidSlot'],
+) {
+  return createMaestroRunHandler({
+    getActiveSession: () => ({
+      name: 'retention',
+      platform: 'android',
+      deviceId: SERIAL,
+      appId: APP_ID,
+      openedAt: new Date(0).toISOString(),
+    }),
+    chooseDispatch: () => ({
+      runner: 'maestro-runner',
+      binPath: '/test/maestro-runner',
+      buildArgs: (_platform, flowFile) => ['test', flowFile],
+    }),
+    parkFlow: async (run) => run(),
+    claimNativeOrigin: async () => {},
+    completeNativeOrigin: async () => {},
+    relaunchManagedApp: async () => {},
+    reproveManagedOrigin: async () => {},
+    fastHealthCheck: async () => false,
+    execFile,
+    releaseAndroidSlot,
+  });
+}
+const runArgs = { inlineYaml: '- launchApp', platform: 'android' as const, appId: APP_ID };
+
+for (const condition of ['failure', 'timeout', 'spawn'] as const) {
+  test(`public maestro_run retains ${condition} evidence before cleanup and separates runs`, async () => {
+    let reportDir = '';
+    let executions = 0;
+    const run = handler(async (_file, args, options) => {
+      executions++;
+      assert.equal(options.maxBuffer, 10 * 1024 * 1024);
+      reportDir = args[args.indexOf('--output') + 1];
+      if (condition !== 'spawn') report(reportDir, 100);
+      throw Object.assign(new Error('runner failed'), {
+        stdout: 'x'.repeat(5000),
+        stderr: 'Error: Element not found',
+        code: condition === 'timeout' ? 'ETIMEDOUT' : condition === 'spawn' ? 'ENOENT' : 1,
+      });
+    });
+    for (let i = 0; i < 2; i++) {
+      const body = JSON.parse((await run(runArgs)).content[0].text);
+      assert.equal(body.ok, false);
+      assert.equal(body.meta.runnerFailureEvidence.captures.length, 1);
+      const row = body.meta.runnerFailureEvidence.captures[0];
+      assert.equal(row.invocation, 1);
+      assert.equal(row.timedOut, condition === 'timeout');
+      assert.equal(row.report, condition === 'spawn' ? 'missing' : 'finalized');
+      if (condition !== 'spawn') assert.equal(row.commands[0].index, 99);
+      assert.equal(existsSync(reportDir), false);
+    }
+    assert.equal(executions, 2, 'diagnostic capture causes no retry');
+  });
+}
+
+test('allowed Android recovery cannot overwrite the retained first failure', async () => {
+  let count = 0;
+  let reportDir = '';
+  let releases = 0;
+  const run = handler(
+    async (_file, args) => {
+      count++;
+      reportDir = args[args.indexOf('--output') + 1];
+      if (count === 1) {
+        report(reportDir, 3);
+        throw Object.assign(new Error('runner failed'), {
+          code: 1,
+          stdout: '',
+          stderr:
+            'Error: failed to create driver: create session: session not created: java.lang.IllegalStateException: UiAutomation not connected, UiAutomation@6baa57c[id=-1, displayId=0, flags=0]',
+        });
+      }
+      report(reportDir, 5);
+      return {
+        stdout: `Connecting to Android device: ${SERIAL}\nFlow execution completed: 1 passed, 0 failed, 0 skipped`,
+        stderr: '',
+      };
+    },
+    async () => {
+      releases++;
+      return { warnings: [] };
+    },
+  );
+  const body = JSON.parse((await run(runArgs)).content[0].text);
+  assert.equal(body.ok, true);
+  assert.equal(count, 2);
+  assert.equal(releases, 1);
+  assert.equal(body.meta.runnerFailureEvidence.captures[0].commands[0].index, 2);
+  assert.equal(body.meta.runnerFailureEvidence.captures.length, 1);
+  assert.equal(existsSync(reportDir), false);
+});
+
+test('login prologue forwards safe action evidence persisted on distinct existing RunRecords', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  project.seedAction('user-login', fixtureYaml({ id: 'user-login' }), null);
+  const evidence = capture(null);
+  let repairs = 0;
+  const runAction = createPinnedRunActionHandler({
+    maestroRun: async () => ({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            ok: false,
+            error: 'runner failure',
+            meta: {
+              output: 'Error: Element not found',
+              runnerFailureEvidence: { ...evidence, unsafe: SECRET },
+            },
+          }),
+        },
+      ],
+      isError: true,
+    }),
+    repairAction: async () => {
+      repairs++;
+      throw new Error('repair forbidden');
+    },
+  });
+  const prologue = createLoginPrologueHandler({ runAction });
+  for (let i = 0; i < 2; i++) {
+    const body = JSON.parse(
+      (await prologue({ projectRoot: realpathSync(project.root) })).content[0].text,
+    );
+    assert.equal(body.ok, false);
+    assert.equal(body.meta.internalError, undefined, body.error);
+    assert.equal(typeof body.meta.strictRunRecordId, 'string');
+    assert.deepEqual(body.meta.runnerFailureEvidence, evidence);
+  }
+  const runs = project.readSidecar('user-login').runHistory;
+  assert.equal(runs.length, 2);
+  assert.notEqual(runs[0].runId, runs[1].runId);
+  assert.deepEqual(runs[0].runnerFailureEvidence, evidence);
+  assert.equal(JSON.stringify(runs).includes(SECRET), false);
+  assert.equal(repairs, 0);
+});

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -13,6 +13,7 @@ import { SessionAuthorityError } from '../../../dist/session/registry.js';
 import { failResult, okResult } from '../../../dist/utils.js';
 import { arbiterWrap, DeviceSessionArbiter } from '../../../dist/lifecycle/device-arbiter.js';
 import { runMaestroInline } from '../../../dist/maestro-invoke.js';
+import { _setActiveSessionForTest } from '../../../dist/agent-device-wrapper.js';
 import { buildReplayEngineStatus, MAESTRO_RUNNER_PIN } from '../../../dist/domain/engine-pin.js';
 import { createLoginPrologueHandler } from '../../../dist/tools/login-prologue.js';
 import { appendRunRecordToSidecar } from '../../helpers/action-state.ts';
@@ -1146,6 +1147,7 @@ test('inline Maestro parking tolerates its own authenticated controller generati
 
 test('inline Maestro forwards its bounded deadline signal into managed runner cleanup', async () => {
   const { runtime, registry, status } = fixture();
+  _setActiveSessionForTest(null);
   status.bindings.runner = {
     platform: 'ios',
     deviceId: 'device',

--- a/packages/rn-dev-agent-core/test/unit/workflow-check.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/workflow-check.test.ts
@@ -1,7 +1,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -224,6 +232,70 @@ test('preflight reports an absent CLAUDE.md block without owning onboarding poli
   assert.equal(stopCode(body), null);
   assert.equal(facts(body).claudeMdBlock, 'absent');
   rmSync(root, { recursive: true, force: true });
+});
+
+test('preflight recognizes instruction blocks in either file without changing their bytes', () => {
+  const heading = '## React Native Development (rn-dev-agent)\n';
+  const sentinel = '<!-- rn-dev-agent:template-end -->\n';
+  const malformed = '## React Native Development (rn-dev-agen)\nbody\n';
+  const cases: Array<[string | null, string | null, string, boolean]> = [
+    [null, ONBOARDED_CLAUDE_MD, 'present', true],
+    ['# Shared company instructions\n', ONBOARDED_CLAUDE_MD, 'present', true],
+    [ONBOARDED_CLAUDE_MD, null, 'present', true],
+    [ONBOARDED_CLAUDE_MD, ONBOARDED_CLAUDE_MD, 'present', true],
+    [null, null, 'absent', false],
+    [malformed, malformed, 'absent', false],
+    [null, sentinel, 'absent', false],
+    [sentinel, null, 'absent', false],
+    [heading, null, 'present', false],
+    [null, heading, 'present', false],
+    [heading, sentinel, 'present', false],
+    [sentinel, heading, 'present', false],
+    [heading, ONBOARDED_CLAUDE_MD, 'present', true],
+    [ONBOARDED_CLAUDE_MD, heading, 'present', true],
+    [malformed, ONBOARDED_CLAUDE_MD, 'present', true],
+    [ONBOARDED_CLAUDE_MD, malformed, 'present', true],
+  ];
+  for (const [shared, local, block, complete] of cases) {
+    const root = makeProject({ lockfile: 'yarn.lock', claudeMd: shared });
+    if (local !== null) writeFileSync(join(root, 'CLAUDE.local.md'), local);
+    try {
+      const { result, body } = run(['preflight', '--project', root]);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(stopCode(body), null);
+      assert.equal(facts(body).claudeMdBlock, block);
+      assert.equal(facts(body).claudeMdSentinel, complete);
+      for (const [file, content] of [
+        ['CLAUDE.md', shared],
+        ['CLAUDE.local.md', local],
+      ] as const) {
+        if (content === null) assert.equal(existsSync(join(root, file)), false);
+        else assert.deepEqual(readFileSync(join(root, file)), Buffer.from(content));
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('preflight does not hide an instruction-file read error behind another valid block', () => {
+  for (const file of ['CLAUDE.md', 'CLAUDE.local.md']) {
+    const root = makeProject({ lockfile: 'yarn.lock' });
+    writeFileSync(join(root, 'CLAUDE.local.md'), ONBOARDED_CLAUDE_MD);
+    chmodSync(join(root, file), 0);
+    try {
+      const { result, body } = run(['preflight', '--project', root]);
+      assert.equal(result.status, 2);
+      assert.equal(body, null);
+      assert.equal(result.stderr.trim(), `workflow-check: cannot read ${file}`);
+    } finally {
+      chmodSync(join(root, file), 0o600);
+      for (const name of ['CLAUDE.md', 'CLAUDE.local.md']) {
+        assert.deepEqual(readFileSync(join(root, name)), Buffer.from(ONBOARDED_CLAUDE_MD));
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
 });
 
 test('preflight stops when package.json is missing entirely', () => {

--- a/packages/shared-agent-knowledge/commands/run-action.md
+++ b/packages/shared-agent-knowledge/commands/run-action.md
@@ -167,6 +167,13 @@ Example calls:
    temporary artifact that is deleted after every run — no report path is
    returned, and none should be looked for.
 
+   A failed replay may also carry `meta.runnerFailureEvidence`, persisted on
+   the RunRecord: a bounded closed-vocabulary projection of each runner
+   failure (exit code, timeout/signal flags, report state, per-command
+   status) marked `incomplete: true`, with text, screenshots, and terminal
+   output withheld. It is diagnostic context only and never changes the
+   outcome, refusal, or auto-repair decision.
+
    When `meta.trailingVerification.trailingVerificationOnly === true`, the
    result remains failed and the goal state remains unproven, but the ledger
    proved every authored mutation completed and only trailing verification

--- a/packages/shared-agent-knowledge/skills/rn-workflow/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-workflow/SKILL.md
@@ -61,8 +61,15 @@ node <plugin-root>/rn-dev-agent-core/dist/workflow-check.js preflight --project 
 (`<plugin-root>` = `${CLAUDE_PLUGIN_ROOT}` on Claude, the Codex package root on
 Codex.) It reports `packageManager` (the `packageManager` field wins, lockfile
 inference is the fallback), the exact `installCommand`, `nodeModulesPresent`,
-the Claude instruction block, and the private-state-root kind and existence, with at
-most ONE actionable `stop`.
+`claudeMdBlock`, `claudeMdSentinel`, and the private-state-root kind and
+existence, with at most ONE actionable `stop`.
+
+The Claude facts are read-only: the exact heading in either instruction file
+from Step 0 marks the block present, including legacy heading-only blocks.
+The sentinel fact is true only when a heading and sentinel occur in the same
+file. These facts do not replace Step 0's onboarding decision.
+An instruction-file read error other than a missing file exits 2 with a
+stderr diagnostic and no JSON result; surface it and stop.
 
 In a monorepo the checker resolves the package-manager facts from the nearest
 ancestor that declares `packageManager` or holds a lockfile (bounded by the git

--- a/packages/shared-agent-knowledge/skills/rn-workflow/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-workflow/SKILL.md
@@ -42,9 +42,11 @@ There is no internal state to track — the only state ever consulted is a fresh
 
 ### Step 0 — Read the authoritative local instructions
 
-Read the project's injected CLAUDE.md block (from
+Read the project's injected block in `CLAUDE.md` or `CLAUDE.local.md` (from
 `## React Native Development (rn-dev-agent)` through
 `<!-- rn-dev-agent:template-end -->`) and `.rn-agent/local/troubleshooting.md`.
+Either instruction file can supply the block; keep shared instructions untouched
+when the block lives in `CLAUDE.local.md`.
 If the block is absent → stop: "project not onboarded — run
 `/rn-dev-agent:setup`". Never start device work on an un-onboarded project.
 
@@ -59,7 +61,7 @@ node <plugin-root>/rn-dev-agent-core/dist/workflow-check.js preflight --project 
 (`<plugin-root>` = `${CLAUDE_PLUGIN_ROOT}` on Claude, the Codex package root on
 Codex.) It reports `packageManager` (the `packageManager` field wins, lockfile
 inference is the fallback), the exact `installCommand`, `nodeModulesPresent`,
-the CLAUDE.md block, and the private-state-root kind and existence, with at
+the Claude instruction block, and the private-state-root kind and existence, with at
 most ONE actionable `stop`.
 
 In a monorepo the checker resolves the package-manager facts from the nearest


### PR DESCRIPTION
## Intent

Ship the bounded correction for https://github.com/Lykhoyda/rn-dev-agent/issues/930 on PR #942 (branch fm/issue-930): workflow-check preflight must recognize a valid rn-dev-agent integration block in CLAUDE.local.md when the shared CLAUDE.md must remain untouched. Recognize the same valid integration block in either supported file while retaining correct existing CLAUDE.md behavior; preserve current requirements for the block itself; missing or malformed blocks must not become valid; I/O errors must not be disguised as success; never write to the user's shared CLAUDE.md or either file merely to make preflight pass; both-present behavior follows existing supported host semantics rather than invented precedence. Use existing block validation and file lookup seams, not a parallel parser. No authority allow/refuse policy changes beyond recognizing this already-supported location, no registry or storage migration, no new compatibility framework, no changes to other H1 items; Issue 888 is excluded and deferred. Independent of Issue 865 Redux dispatch and darwin-signing-compat; do not touch their branches or runs. The preflight change (commits 3d92499f, 84f1f03f) was already validated on this PR and remains unchanged.

The new commit b2d4e00c implements the captain-approved bounded PR942 diagnostic-retention correction (data/open-pr-corrections/pr942-diagnostic-retention-approved.md), using the architect-confirmed bounded design: retain only generated closed-vocabulary projected JSON of runner failure evidence, with text, images, terminal output and unsafe original artifacts withheld. Retain bounded, owned useful structured runner failure evidence before the temporary report tree is overwritten or disposed, through the existing invocation/report seam (maestro_run executeRunner, readStructuredFlowArtifact, runnerReportFingerprint) and the existing action/prologue seams (cdp_run_action re-projects meta.runnerFailureEvidence and persists it on the existing RunRecord in the existing sidecar storage; login prologue forwards it). Explicit incompleteness (incomplete: true, withheld, capturesTruncated, rowsTruncated), containment (realpath inside the report root, O_NOFOLLOW, regular-file checks, 256 KiB byte budget, 8 captures, 64 rows), freshness via the existing fingerprint, and existing cleanup ordering are preserved. No real login values, secrets, environment, unrelated files or indefinite full-tree retention; no arbitrary free-text redaction machinery; projection is a closed vocabulary only (numbers, booleans, enum states), which is why raw error messages, screenshots and terminal output are deliberately not retained. Deliberate design: readStructuredFlowArtifact gained an injectable readText parameter so the capture path can enforce byte budget and symlink containment without a second parser; RunRecord gained an optional runnerFailureEvidence field; the handlers wrap their original body so evidence attaches via attachMeta on the result or on SessionAuthorityError.

Keep public refusal codes, permissions, timeouts, the 10 MiB exec buffer, classification, repair eligibility, authority/admission, interaction semantics and whole-flow abort unchanged. Failed capture cannot change outcome, upgrade proof, or cause a retry. Do not add a generic framework, new MCP tool, report registry, second parser, parser-duration correction, fixture/runner upgrade, or iOS resolver correction. Do not change lock, process-identity, or permission logic in atomic-writer/process-birth: an earlier zero-RunRecord test failure was a Codex sandbox artifact (setuid /bin/ps blocked so writer identity was unknown), diagnosed in data/pr942-retention-persistence-diagnosis/report.md; the same suite passes natively (75/75 in reports/issue-930/relaunch-retention-suite.tap) and the test now asserts meta.internalError is undefined and strictRunRecordId is a string so a sandboxed run names its cause. AGENTS.md documents that caveat. Device-free tests cover bounded failure capture, late terminal evidence, missing/malformed/oversized/partial/symlink input, timeout/spawn failure, run separation, secret exclusion, cleanup ordering, and unchanged outcome/refusal/repair decisions; captured-evidence tests are not successful-login acceptance. Shipped host bundles were regenerated with corepack yarn build:host-runtimes. Two one-sentence changesets bump rn-dev-agent-core and rn-dev-agent-plugin.

Delivery constraints: no native device run, no new app/device journeys, no load waivers, no manual login or raw runner workarounds, no merge. Observe remains excluded for PR942 only. The Android owned-app removal dependency is implemented separately in the rn-qa helper (PR40) and must not be bolted onto this PR. Independent rn-dev-agent-qa acceptance still gates runtime changes; passing unit tests do not substitute for it. GPT reviews must use the supported Astra model configuration, never Sol.

## What Changed

- `workflow-check preflight` now reads both `CLAUDE.md` and `CLAUDE.local.md` for the rn-dev-agent instruction block: `claudeMdBlock` is present when either file contains the heading, `claudeMdSentinel` is true only when heading and sentinel share a file, and a read error other than a missing file exits 2 instead of being reported as an absent block. Neither file is written.
- Added `domain/runner-failure-evidence.ts`, a closed-vocabulary projection (exit code, signal/timeout/truncation flags, report state, per-command status) captured in `maestro_run`'s `executeRunner` before the temporary report tree is disposed, bounded to 8 captures, 64 rows and 256 KiB with realpath/`O_NOFOLLOW`/regular-file containment; it is attached as `meta.runnerFailureEvidence` on the result or `SessionAuthorityError`, and `cdp_run_action` persists it on the existing `RunRecord` (new optional `runnerFailureEvidence` field) without changing outcome, refusal, repair or retry decisions. `readStructuredFlowArtifact` gained an injectable `readText` parameter for this.
- Unit tests cover both behaviors (`workflow-check.test.ts`, new `runner-failure-evidence.test.ts`); rebuilt Claude/Codex host bundles, updated the `run-action` command and `rn-workflow` skill docs, documented the sandboxed `/bin/ps` RunRecord caveat in `AGENTS.md`, and added two patch changesets for `rn-dev-agent-core` and `rn-dev-agent-plugin`.

## Risk Assessment

✅ Low: Both changes are bounded and traced end to end: preflight reuses the existing heading/sentinel check across two files with read errors now surfaced as exit 2, and failure-evidence capture is a closed-vocabulary projection that runs before report-tree disposal, cannot alter outcomes or retries (wrappers only attach meta), is bounded by byte/capture/row limits with symlink and O_NOFOLLOW containment, and persists through the existing sidecar path with correct attempt ordinals; the branch commits are patch-identical to the SHAs the intent references.

## Testing

Installed dependencies and built the core package, ran the two targeted unit suites (workflow-check and runner-failure-evidence, all passing), then produced product-level evidence: a preflight CLI before/after transcript proving the base bundle misses a CLAUDE.local.md block while this build and both shipped host bundles recognize it without touching either file and without hiding read errors, and a demo transcript showing maestro_run and a persisted cdp_run_action RunRecord retain only the closed-vocabulary failure projection with no secrets after the report tree is deleted. No UI surface is involved, so no screenshots apply. Worktree left clean.

<details>
<summary>Evidence: Preflight CLI before/after transcript (base shipped bundle vs. this build, byte-identical files, read-error exit 2)</summary>

<code>== [BASE cc992e65] preflight --project &lt;shared CLAUDE.md without block + CLAUDE.local.md with block&gt;&#10;{ &#34;verdict&#34;: &#34;pass&#34;, &#34;claudeMdBlock&#34;: &#34;absent&#34;, &#34;claudeMdSentinel&#34;: false }&#10;== [NEW c4d29180]&#10;{ &#34;verdict&#34;: &#34;pass&#34;, &#34;claudeMdBlock&#34;: &#34;present&#34;, &#34;claudeMdSentinel&#34;: true }&#10;== sha256 before/after: CLAUDE.md f6caab9c… and CLAUDE.local.md 5844f1f9… unchanged&#10;== [NEW] chmod 0 CLAUDE.md -&gt; stderr &#34;workflow-check: cannot read CLAUDE.md&#34;, exit=2&#10;== [NEW] malformed local block, no shared block -&gt; {&#34;claudeMdBlock&#34;:&#34;absent&#34;,&#34;claudeMdSentinel&#34;:false}</code>

```text
== project: shared CLAUDE.md (no block) + CLAUDE.local.md (valid block)
--- CLAUDE.md
# Shared company instructions

Do not edit without review.
--- CLAUDE.local.md
# Local

## React Native Development (rn-dev-agent)
body
<!-- rn-dev-agent:template-end -->

== sha256 before
f6caab9cf1d3ca3cdad6e5dfc223fe0d7273626d0acb2dab42c694d98f703c33  CLAUDE.md
5844f1f9cbe11b83ce602d4e7aa928de55d09a59b9dd1092137a448eb713c7e0  CLAUDE.local.md

== [BASE] node workflow-check.js preflight --project <root>
{
  "verdict": "pass",
  "stop": null,
  "claudeMdBlock": "absent",
  "claudeMdSentinel": false
}
exit=0

== [NEW] node workflow-check.js preflight --project <root>
{
  "verdict": "pass",
  "stop": null,
  "claudeMdBlock": "present",
  "claudeMdSentinel": true
}
exit=0

== sha256 after (both files must be byte-identical)
f6caab9cf1d3ca3cdad6e5dfc223fe0d7273626d0acb2dab42c694d98f703c33  CLAUDE.md
5844f1f9cbe11b83ce602d4e7aa928de55d09a59b9dd1092137a448eb713c7e0  CLAUDE.local.md

== [NEW] unreadable CLAUDE.md (chmod 0) must fail loudly, not pass on the local block
workflow-check: cannot read CLAUDE.md
exit=2

== [NEW] malformed local block + no shared block must stay absent
{"claudeMdBlock":"absent","claudeMdSentinel":false}
```
</details>
<details>
<summary>Evidence: Shipped claude-plugin and codex-plugin bundles recognize CLAUDE.local.md</summary>

```text
== shipped bundle packages/claude-plugin/rn-dev-agent-core/dist/workflow-check.js @ c4d29180
{"verdict":"pass","claudeMdBlock":"present","claudeMdSentinel":true}
== shipped bundle packages/codex-plugin/rn-dev-agent-core/dist/workflow-check.js @ c4d29180
{"verdict":"pass","claudeMdBlock":"present","claudeMdSentinel":true}
```
</details>
<details>
<summary>Evidence: Runner failure evidence: maestro_run envelope and persisted RunRecord after a failed runner</summary>

<code>maestro_run: ok=false, report dir deleted after run: true&#10;meta.runnerFailureEvidence contains secret string: false (secret only in pre-existing meta.output)&#10;{ version:1, incomplete:true, withheld:&#34;text-images-terminal-output-and-original-artifacts&#34;, captures:[{ attempt:1, stage:0, invocation:1, exitCode:1, report:&#34;finalized&#34;, rowsTruncated:true, commands:[{index:69,status:&#34;failed&#34;,errorPresent:true}, … 64 rows] }] }&#10;&#10;cdp_login_prologue -&gt; cdp_run_action: ok=false internalError=undefined strictRunRecordId=string&#10;persisted RunRecords in sidecar: 1; sidecar contains secret: false; injected non-vocabulary keys persisted: false&#10;RunRecord.runnerFailureEvidence = same closed-vocabulary projection</code>

```text
== maestro_run public envelope after a failed runner (report tree had 70 commands, secrets in every row, failure.png)
ok=false error="Maestro device authority refused: requested emulator-5580, direct runner/WDA evidence was missing (reported-device-missing). Underlying failure: runner failed"
report dir deleted after run: true
meta.runnerFailureEvidence contains secret string: false
envelope keys carrying the secret (pre-existing runner-output disclosure, unchanged by this PR): meta.output
meta.runnerFailureEvidence (commands list elided to first 3 of 64):
{
  "version": 1,
  "incomplete": true,
  "withheld": "text-images-terminal-output-and-original-artifacts",
  "capturesTruncated": false,
  "captures": [
    {
      "attempt": 1,
      "stage": 0,
      "invocation": 1,
      "exitCode": 1,
      "signalPresent": false,
      "timedOut": false,
      "outputTruncated": false,
      "bootstrapFailure": false,
      "transportFailure": false,
      "report": "finalized",
      "rowsTruncated": true,
      "commands": [
        {
          "index": 69,
          "status": "failed",
          "errorPresent": true
        },
        {
          "index": 0,
          "status": "passed",
          "errorPresent": true
        },
        {
          "index": 1,
          "status": "passed",
          "errorPresent": true
        }
      ]
    }
  ]
}

== cdp_login_prologue -> cdp_run_action result
ok=false internalError=undefined strictRunRecordId=string
persisted RunRecords in sidecar: 1; runId=ad2ec152-9fd3-4d94-b55b-ffd99792feb6
sidecar contains secret string: false
sidecar contains injected non-vocabulary keys (unsafe/rawStderr): false
RunRecord.runnerFailureEvidence as persisted:
{
  "version": 1,
  "incomplete": true,
  "withheld": "text-images-terminal-output-and-original-artifacts",
  "capturesTruncated": false,
  "captures": [
    {
      "attempt": 1,
      "stage": 0,
      "invocation": 1,
      "exitCode": 1,
      "signalPresent": false,
      "timedOut": false,
      "outputTruncated": false,
      "bootstrapFailure": false,
      "transportFailure": false,
      "report": "finalized",
      "rowsTruncated": true,
      "commands": [
        {
          "index": 69,
          "status": "failed",
          "errorPresent": true
        },
        {
          "index": 0,
          "status": "passed",
          "errorPresent": true
        }
      ]
    }
  ]
}
```
</details>
<details>
<summary>Evidence: TAP output: workflow-check.test.ts (34 pass)</summary>

```text
TAP version 13
# Subtest: preflight passes a declared pnpm project and reports the frozen-lockfile install
ok 1 - preflight passes a declared pnpm project and reports the frozen-lockfile install
  ---
  duration_ms: 62.697083
  type: 'test'
  ...
# Subtest: preflight infers yarn from the lockfile and never proposes pnpm for it
ok 2 - preflight infers yarn from the lockfile and never proposes pnpm for it
  ---
  duration_ms: 59.429
  type: 'test'
  ...
# Subtest: preflight stops on a packageManager field that contradicts the lockfile
ok 3 - preflight stops on a packageManager field that contradicts the lockfile
  ---
  duration_ms: 60.105084
  type: 'test'
  ...
# Subtest: preflight stops when lockfiles infer multiple package managers
ok 4 - preflight stops when lockfiles infer multiple package managers
  ---
  duration_ms: 60.313583
  type: 'test'
  ...
# Subtest: preflight accepts multiple lockfiles for the same package manager
ok 5 - preflight accepts multiple lockfiles for the same package manager
  ---
  duration_ms: 60.272583
  type: 'test'
  ...
# Subtest: preflight rejects malformed package.json before lockfile inference
ok 6 - preflight rejects malformed package.json before lockfile inference
  ---
  duration_ms: 62.227042
  type: 'test'
  ...
# Subtest: preflight rejects an unsupported packageManager before lockfile inference
ok 7 - preflight rejects an unsupported packageManager before lockfile inference
  ---
  duration_ms: 64.17725
  type: 'test'
  ...
# Subtest: preflight stops when neither packageManager field nor lockfile exists
ok 8 - preflight stops when neither packageManager field nor lockfile exists
  ---
  duration_ms: 62.615083
  type: 'test'
  ...
# Subtest: preflight stops with the declared install command when node_modules is missing
ok 9 - preflight stops with the declared install command when node_modules is missing
  ---
  duration_ms: 60.521625
  type: 'test'
  ...
# Subtest: preflight reports an absent CLAUDE.md block without owning onboarding policy
ok 10 - preflight reports an absent CLAUDE.md block without owning onboarding policy
  ---
  duration_ms: 61.510833
  type: 'test'
  ...
# Subtest: preflight recognizes instruction blocks in either file without changing their bytes
ok 11 - preflight recognizes instruction blocks in either file without changing their bytes
  ---
  duration_ms: 1087.524375
  type: 'test'
  ...
# Subtest: preflight does not hide an instruction-file read error behind another valid block
ok 12 - preflight does not hide an instruction-file read error behind another valid block
  ---
  duration_ms: 125.414667
  type: 'test'
  ...
# Subtest: preflight stops when package.json is missing entirely
ok 13 - preflight stops when package.json is missing entirely
  ---
  duration_ms: 63.612
  type: 'test'
  ...
# Subtest: state root kind follows XDG_STATE_HOME and platform defaults
ok 14 - state root kind follows XDG_STATE_HOME and platform defaults
  ---
  duration_ms: 184.214958
  type: 'test'
  ...
# Subtest: output never leaks absolute project or home paths
ok 15 - output never leaks absolute project or home paths
  ---
  duration_ms: 62.243833
  type: 'test'
  ...
# Subtest: postflight stops while package.json still carries the session integration
ok 16 - postflight stops while package.json still carries the session integration
  ---
  duration_ms: 343.555334
  type: 'test'
  ...
# Subtest: postflight stops on Metro sentinels without package-script residue
ok 17 - postflight stops on Metro sentinels without package-script residue
  ---
  duration_ms: 294.861
  type: 'test'
  ...
# Subtest: postflight stops on generated integration files without manifest references
ok 18 - postflight stops on generated integration files without manifest references
  ---
  duration_ms: 651.178834
  type: 'test'
  ...
# Subtest: postflight passes a clean project and reports recording residue as a fact
ok 19 - postflight passes a clean project and reports recording residue as a fact
  ---
  duration_ms: 533.638208
  type: 'test'
  ...
# Subtest: postflight surfaces outstanding authority from a provided status projection in reverse-cleanup order
ok 20 - postflight surfaces outstanding authority from a provided status projection in reverse-cleanup order
  ---
  duration_ms: 1229.325042
  type: 'test'
  ...
# Subtest: postflight stops when the provided status is not the canonical public envelope
ok 21 - postflight stops when the provided status is not the canonical public envelope
  ---
  duration_ms: 284.174917
  type: 'test'
  ...
# Subtest: preflight rejects a packageManager value without an exact corepack version
ok 22 - preflight rejects a packageManager value without an exact corepack version
  ---
  duration_ms: 188.836542
  type: 'test'
  ...
# Subtest: yarn install command follows the declared major generation
ok 23 - yarn install command follows the declared major generation
  ---
  duration_ms: 126.235042
  type: 'test'
  ...
# Subtest: inferred yarn classic lockfile content selects the frozen-lockfile command
ok 24 - inferred yarn classic lockfile content selects the frozen-lockfile command
  ---
  duration_ms: 66.252542
  type: 'test'
  ...
# Subtest: yarn plug-n-play installation counts as dependency readiness
ok 25 - yarn plug-n-play installation counts as dependency readiness
  ---
  duration_ms: 61.136375
  type: 'test'
  ...
# Subtest: a declared manager without its lockfile stops before recommending a frozen install
ok 26 - a declared manager without its lockfile stops before recommending a frozen install
  ---
  duration_ms: 68.720333
  type: 'test'
  ...
# Subtest: preflight resolves the hoisted monorepo workspace root from the app directory
ok 27 - preflight resolves the hoisted monorepo workspace root from the app directory
  ---
  duration_ms: 66.401
  type: 'test'
  ...
# Subtest: preflight reports the hoisted workspace install command when the root has no node_modules
ok 28 - preflight reports the hoisted workspace install command when the root has no node_modules
  ---
  duration_ms: 61.905042
  type: 'test'
  ...
# Subtest: a workspace-root manifest defect names the workspace root, not the app root
ok 29 - a workspace-root manifest defect names the workspace root, not the app root
  ---
  duration_ms: 67.17425
  type: 'test'
  ...
# Subtest: a lockfile beside the app wins over the monorepo workspace root
ok 30 - a lockfile beside the app wins over the monorepo workspace root
  ---
  duration_ms: 63.834333
  type: 'test'
  ...
# Subtest: the workspace walk never escapes the git repository root
ok 31 - the workspace walk never escapes the git repository root
  ---
  duration_ms: 64.111083
  type: 'test'
  ...
# Subtest: postflight without a status file passes as unproven cleanup
ok 32 - postflight without a status file passes as unproven cleanup
  ---
  duration_ms: 324.962541
  type: 'test'
  ...
# Subtest: postflight proves cleanup only from a status envelope with every binding clear
ok 33 - postflight proves cleanup only from a status envelope with every binding clear
  ---
  duration_ms: 285.112667
  type: 'test'
  ...
# Subtest: invalid arguments exit 2 without a verdict
ok 34 - invalid arguments exit 2 without a verdict
  ---
  duration_ms: 60.370083
  type: 'test'
  ...
1..34
# tests 34
# suites 0
# pass 34
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 7067.103542
```
</details>
<details>
<summary>Evidence: TAP output: runner-failure-evidence.test.ts (11 pass)</summary>

```text
TAP version 13
# Subtest: projection bounds rows, preserves the late failed index and excludes arbitrary fields and images
ok 1 - projection bounds rows, preserves the late failed index and excludes arbitrary fields and images
  ---
  duration_ms: 6.142541
  type: 'test'
  ...
# Subtest: projection discloses missing report without admitting unsafe evidence
ok 2 - projection discloses missing report without admitting unsafe evidence
  ---
  duration_ms: 1.807083
  type: 'test'
  ...
# Subtest: projection discloses malformed report without admitting unsafe evidence
ok 3 - projection discloses malformed report without admitting unsafe evidence
  ---
  duration_ms: 2.759125
  type: 'test'
  ...
# Subtest: projection discloses oversized report without admitting unsafe evidence
ok 4 - projection discloses oversized report without admitting unsafe evidence
  ---
  duration_ms: 1.809125
  type: 'test'
  ...
# Subtest: projection discloses partial report without admitting unsafe evidence
ok 5 - projection discloses partial report without admitting unsafe evidence
  ---
  duration_ms: 2.0995
  type: 'test'
  ...
# Subtest: projection discloses symlink report without admitting unsafe evidence
ok 6 - projection discloses symlink report without admitting unsafe evidence
  ---
  duration_ms: 1.855833
  type: 'test'
  ...
# Subtest: public maestro_run retains failure evidence before cleanup and separates runs
ok 7 - public maestro_run retains failure evidence before cleanup and separates runs
  ---
  duration_ms: 226.663042
  type: 'test'
  ...
# Subtest: public maestro_run retains timeout evidence before cleanup and separates runs
ok 8 - public maestro_run retains timeout evidence before cleanup and separates runs
  ---
  duration_ms: 47.928334
  type: 'test'
  ...
# Subtest: public maestro_run retains spawn evidence before cleanup and separates runs
ok 9 - public maestro_run retains spawn evidence before cleanup and separates runs
  ---
  duration_ms: 48.11275
  type: 'test'
  ...
# Subtest: allowed Android recovery cannot overwrite the retained first failure
ok 10 - allowed Android recovery cannot overwrite the retained first failure
  ---
  duration_ms: 24.529042
  type: 'test'
  ...
# (node:78993) ExperimentalWarning: SQLite is an experimental feature and might change at any time
# (Use `node --trace-warnings ...` to show where the warning was created)
# Subtest: login prologue forwards safe action evidence persisted on distinct existing RunRecords
ok 11 - login prologue forwards safe action evidence persisted on distinct existing RunRecords
  ---
  duration_ms: 2135.383709
  type: 'test'
  ...
1..11
# tests 11
# suites 0
# pass 11
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2713.050166
```
</details>
<details>
<summary>Evidence: Reproducible scripts for the transcripts</summary>

```text
#!/bin/bash
# Product-level transcript: workflow-check preflight on a project whose shared CLAUDE.md has NO rn-dev-agent block
# and whose CLAUDE.local.md carries the valid block. Compares the base-commit shipped CLI bundle with this build.
set -u
EV=~/.no-mistakes/evidence/01M1VASETRQ64JHN4NGWC20S2S
WT=~/.no-mistakes/worktrees/1eccd0b444be/01M1VASETRQ64JHN4NGWC20S2S
BASE="$EV/workflow-check.base-cc992e65.js"
NEW="$WT/packages/rn-dev-agent-core/dist/workflow-check.js"
ROOT=$(mktemp -d "${TMPDIR:-/tmp}/preflight-local-XXXXXX")
mkdir -p "$ROOT/.git" "$ROOT/node_modules/react"
echo '{"name":"app"}' > "$ROOT/package.json"; : > "$ROOT/yarn.lock"; echo 'module.exports = {};' > "$ROOT/metro.config.js"
printf '# Shared company instructions\n\nDo not edit without review.\n' > "$ROOT/CLAUDE.md"
printf '# Local\n\n## React Native Development (rn-dev-agent)\nbody\n<!-- rn-dev-agent:template-end -->\n' > "$ROOT/CLAUDE.local.md"
echo "== project: shared CLAUDE.md (no block) + CLAUDE.local.md (valid block)"
echo "--- CLAUDE.md"; cat "$ROOT/CLAUDE.md"; echo "--- CLAUDE.local.md"; cat "$ROOT/CLAUDE.local.md"
echo; echo "== sha256 before"; (cd "$ROOT" && shasum -a 256 CLAUDE.md CLAUDE.local.md)
for label in BASE NEW; do
  cli=${!label}
  echo; echo "== [$label] node workflow-check.js preflight --project <root>"
  node "$cli" preflight --project "$ROOT" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const b=JSON.parse(s);console.log(JSON.stringify({verdict:b.verdict,stop:b.stop,claudeMdBlock:b.facts.claudeMdBlock,claudeMdSentinel:b.facts.claudeMdSentinel},null,2))})'
  echo "exit=${PIPESTATUS[0]}"
done
echo; echo "== sha256 after (both files must be byte-identical)"; (cd "$ROOT" && shasum -a 256 CLAUDE.md CLAUDE.local.md)
echo; echo "== [NEW] unreadable CLAUDE.md (chmod 0) must fail loudly, not pass on the local block"
chmod 0 "$ROOT/CLAUDE.md"
node "$NEW" preflight --project "$ROOT"; echo "exit=$?"
chmod 600 "$ROOT/CLAUDE.md"
echo; echo "== [NEW] malformed local block + no shared block must stay absent"
printf '## React Native Development (rn-dev-agen)\nbody\n' > "$ROOT/CLAUDE.local.md"
node "$NEW" preflight --project "$ROOT" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const b=JSON.parse(s);console.log(JSON.stringify({claudeMdBlock:b.facts.claudeMdBlock,claudeMdSentinel:b.facts.claudeMdSentinel}))})'
rm -rf "$ROOT"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"377aca59b3df4bb47befe5d39f84ade09b233b59","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `packages/rn-dev-agent-core/src/workflow-check.ts:234` - readTextIfFile uses lstat and returns null for anything that is not a regular file, so a CLAUDE.local.md that is a symlink (a common dotfiles setup for the gitignored personal file) reports claudeMdBlock &#39;absent&#39; even though Claude Code loads it. This is the pre-existing CLAUDE.md lookup semantics reused as the intent requires, it fails closed rather than disguising an error, and Step 0 still owns the onboarding decision, so no change is needed for this bounded correction. Noting it only because the local file is the one most likely to be symlinked.
- ℹ️ `packages/rn-dev-agent-core/src/domain/action-db.ts:364` - The SQLite mirror&#39;s loadState rebuilds RunRecords from columns and does not carry runnerFailureEvidence. This is consistent with the intent (sidecar is the persisted store, no storage migration): loadAction reads the JSON sidecar, and the mirror already omits runId and timing today, so nothing that consumes the evidence (login prologue, run-action) loses it.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`corepack yarn install --immutable` then `corepack yarn build` in packages/rn-dev-agent-core (fresh tsc dist required by both test files)</code>
- <code>`node --test --test-reporter=tap test/unit/workflow-check.test.ts` (34/34 pass, includes the new either-file recognition matrix and read-error tests)</code>
- <code>`node --test --test-reporter=tap test/unit/runner-failure-evidence.test.ts` (11/11 pass: projection bounds, missing/malformed/oversized/partial/symlink reports, maestro_run failure/timeout/spawn retention and run separation, Android recovery not overwriting first failure, login prologue persisting evidence on distinct RunRecords)</code>
- <code>Manual before/after CLI transcript: base-commit shipped bundle `workflow-check.js` (cc992e65) vs. this build on a project with a shared CLAUDE.md lacking the block and a CLAUDE.local.md carrying it; sha256 of both files compared before and after; chmod-0 CLAUDE.md read-error case; malformed local block case</code>
- <code>Manual check of the regenerated shipped bundles `packages/claude-plugin/rn-dev-agent-core/dist/workflow-check.js` and `packages/codex-plugin/rn-dev-agent-core/dist/workflow-check.js` at c4d29180 on the same CLAUDE.local.md project</code>
- <code>Manual demo script driving the public `createMaestroRunHandler` with a failing fake runner that writes a 70-command report with secrets and failure.png, then `createLoginPrologueHandler` -&gt; pinned `cdp_run_action` handler, dumping the returned envelope and the persisted sidecar RunRecord</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
