### PR TITLE
docs: lead the README with the product story and proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,116 @@
+<div align="center">
+
 # rn-dev-agent
+
+### Your agent writes the code. This proves it runs.
+
+A plugin for **Claude Code** and **Codex** that turns your coding agent into a React Native
+development partner — one that reads your running app's component tree, store state, and
+navigation over the Chrome DevTools Protocol, taps real UI on iOS and Android, and **records the
+evidence** that the feature actually works.
 
 [![CI](https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-lykhoyda.github.io%2Frn--dev--agent-blue)](https://lykhoyda.github.io/rn-dev-agent/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-A coding-agent plugin for **Claude Code** and **Codex** that turns an AI agent into a React Native development partner. It explores your codebase, designs architecture, implements features — then **proves everything works live on the simulator** by reading the component tree, store state, and navigation stack through the Chrome DevTools Protocol, driving the app like a user, and recording the evidence.
+**[Get started](#see-it-in-60-seconds)** · **[Documentation](https://lykhoyda.github.io/rn-dev-agent/)** · **[Benchmarks](https://lykhoyda.github.io/rn-dev-agent/benchmarks/)** · **[Tools](https://lykhoyda.github.io/rn-dev-agent/tools/)**
 
-**MCP tools for live React Native development** · **Claude: 16 slash commands + 11 skills** · **Codex: 16 explicit workflow skills + 11 domain skills (27 total)** · **118 best-practice rules** · [Full documentation](https://lykhoyda.github.io/rn-dev-agent/)
-
----
-
-## Why this exists
-
-Coding agents are good at writing React Native code and bad at knowing whether it actually works. This plugin closes that loop:
-
-- **Live verification, not "trust me it works."** After implementing a feature, the agent connects to your running app via CDP, navigates to the screen, checks the component tree, exercises interactions, and confirms store state — before declaring victory.
-- **Replayable actions.** Every verified flow is saved as a parameterised Maestro action in `.rn-agent/actions/`. A 3-step wizard that took ~14 minutes as an interactive walk replays in **~4 seconds** (~210× faster). Actions self-repair when `testID`s drift.
-- **Native device control on both platforms.** In-tree XCTest (iOS) and UiAutomator (Android) runners give the agent real taps, typing, scrolling, and screenshots — with prebuilt artifacts so first use skips the multi-minute cold build.
-- **Curated best practices.** 118 indexed rules (48 React Native + 70 React/web, integrated from [Vercel's agent skills](https://github.com/vercel-labs/agent-skills)) applied during architecture and review — crash prevention, list performance, animations, state management.
-- **Watch it work.** The [Observe workflow](https://lykhoyda.github.io/rn-dev-agent/commands/observe/) serves a local web UI with a live tool-call timeline, device mirror, and route/store/component-tree panels — plus Actions and E2E tabs to replay saved flows straight from the browser.
+</div>
 
 ![The observe UI live: inspecting a failed flow, checking store state, replaying a saved action, and running the locked E2E suite — all from the browser](apps/docs-site/public/observe/observe-demo.gif)
 
-## Quick start
+---
 
-### 1. Install
+## See it in 60 seconds
 
-Jump to your host: **[Claude Code](#claude-code)** · **[Codex](#codex)**
-
-#### Claude Code
-
-Published marketplace:
-
-```bash
+```text
+# 1. Install (Claude Code — Codex below)
 /plugin marketplace add Lykhoyda/rn-dev-agent
 /plugin install rn-dev-agent@rn-dev-agent
 /reload-plugins
 ```
 
-Local checkout: `claude --plugin-dir /path/to/rn-dev-agent` (the root `.claude-plugin/marketplace.json` resolves the plugin package from `packages/claude-plugin/`).
-
-#### Codex
-
-Published marketplace:
-
-```bash
-codex plugin marketplace add Lykhoyda/rn-dev-agent
-codex plugin add rn-dev-agent@rn-dev-agent
-```
-
-Local checkout: register the package directory `/path/to/rn-dev-agent/packages/codex-plugin` — not the repository root. The Codex package is self-contained (bundled MCP runtime, native runner sources, helpers, and runner manifest) and loads the same `cdp` MCP server from its `.mcp.json`. Codex does not load Claude Code hooks — `No plugin hooks` is expected. Codex 0.145.0 is the live-refresh floor; older hosts are restart-only. An external CLI/manual plugin change always requires exiting and relaunching Codex.
-
-### 2. Set up your project
-
-```bash
-cd /path/to/your-rn-app
-```
-
-Invoke setup for your host:
-
 ```text
-Claude: /rn-dev-agent:setup
-Codex:  $rn-dev-agent:setup
+# 2. Onboard your app — checks the toolchain, writes the project config
+/rn-dev-agent:setup
+
+# 3. Ask for a feature. Get it back verified on the simulator.
+/rn-dev-agent:rn-feature-dev add a shopping cart with badge, item list, and checkout flow
 ```
 
-Claude setup manages `CLAUDE.md`; Codex setup manages an idempotent sentinel-
-bounded `AGENTS.md` block. Codex runs strictly read-only package/recovery
-diagnostics first and previews every later project write for consent.
+The agent explores your codebase, designs the change, implements it — then connects to the running
+app, navigates to the screen, checks the component tree and store state, taps through the flow, and
+saves the walk as a replayable test. You get working code **and** the proof.
 
-Setup checks the full toolchain. Claude hooks and normal runtime use can perform
-the automatic handling shown below; Codex setup keeps recovery diagnosis
-read-only and prints the exact commands for the user to confirm and run.
+Codex users: replace `/rn-dev-agent:<name>` with `$rn-dev-agent:<name>`. [Install steps →](#install)
 
-| Check | Required | Automatic handling |
-|-------|----------|--------------|
-| Node.js ≥ 24 | Yes | No |
-| CDP bridge deps | Yes | Yes |
-| rn-fast-runner (iOS) | iOS targets only | Prebuilt artifact on releases; one-time `xcodebuild build-for-testing` fallback |
-| rn-android-runner (Android) | Android targets only | Prebuilt artifact on releases; Gradle build fallback on first use |
-| [maestro-runner](https://github.com/devicelab-dev/maestro-runner) | Yes | Yes (pin-cache engine `>= 1.1.24`, attested 1.1.24 checksum-verified) |
-| iOS Simulator / Android Emulator | One platform | No |
-| Session-bound Metro | Yes | Project integration starts or validates it through literal `pnpm ios` / `pnpm android` |
-| CDP connection | Yes | `rn_session` owns the binding; `cdp_status` is passive and `cdp_connect` pins the exact target |
-| ffmpeg | Optional (proof videos) | Yes |
-| idb + idb-companion | Optional (smooth observe-UI mirroring) | Yes |
+---
 
-Claude automation failures and Codex missing prerequisites are reported with
-step-by-step manual instructions. [Full setup guide](https://lykhoyda.github.io/rn-dev-agent/getting-started/)
+## Coding agents ship blind
 
-**Prebuilt runners:** on a released version, the device runners install from a verified prebuilt artifact (SHA-256-checked local cache, then the GitHub Release asset for your exact plugin version), so the first `device_snapshot action=open` skips the cold build. Resolution is fail-open — offline, a checksum mismatch, or a dev checkout falls back transparently to the on-machine build (the host's `doctor` workflow reports which one you got). Force local builds with `RN_RUNNER_BUILD=local`.
+They are good at writing React Native code and bad at knowing whether it runs. This plugin closes
+that loop — and everything below is measured on a real Expo app, not a synthetic benchmark.
 
-### 3. Build something
+| | |
+|---|---|
+| **Verified, not claimed** | After implementing, the agent connects over CDP, walks the screen, reads the component tree and store, exercises the interaction, and screenshots the result — before it says "done" |
+| **210× faster replays** | A 3-step wizard that took ~14 min as an interactive walk replays in **~4 s** as a saved action. Average session time across the measured features dropped from ~12 min to ~4 min once actions existed |
+| **Flows that repair themselves** | When a `testID` drifts, the saved action fuzzy-matches the live snapshot, patches its own YAML, and retries. Cosmetic drift is absorbed; genuinely broken product logic is surfaced, never auto-fixed |
+| **3–25 min, description → verified** | Simple features land in 3–5 min, complex multi-step flows in 11–25 min — **zero crashes across 38 measured stories** |
+| **iOS and Android, one contract** | In-tree XCTest and UiAutomator runners give real taps, typing, scrolling, and screenshots — shipped as prebuilt artifacts so first use skips the cold build |
+| **Both hosts, full parity** | Claude Code: 16 slash commands + 11 skills + 5 agents. Codex: 27 native skills (16 workflow + 11 domain). 81 MCP tools and 118 best-practice rules on both |
 
-```text
-Claude: /rn-dev-agent:rn-feature-dev add a shopping cart with badge, item list, and checkout flow
-Codex:  $rn-dev-agent:rn-feature-dev add a shopping cart with badge, item list, and checkout flow
+[Full benchmarks and methodology →](https://lykhoyda.github.io/rn-dev-agent/benchmarks/)
+
+## Is this for you?
+
+**Yes, if** you build React Native or Expo apps with a coding agent, you run an iOS Simulator or
+Android Emulator locally, and you are tired of reviewing changes that were never actually opened.
+It pays off most on apps with real navigation, real state, and flows you re-walk every session.
+
+**Not yet, if** you work on web-only React, have no local simulator or emulator, or need an agent
+pointed at production or store-signed builds — that last one is deliberately out of scope, see
+[Security](#security).
+
+---
+
+## How it works
+
+```
+  /rn-dev-agent:rn-feature-dev "<what you want>"
+        │
+        ├─ 1 Discover    understand the feature, plan the work
+        ├─ 2 Explore     parallel agents map screens, store, navigation, conventions
+        ├─ 3 Question    clarify edge cases, error states, data flow
+        ├─ 4 Architect   design the change against your existing patterns
+        ├─ 5 Implement   store, components, navigation, testIDs
+        ├─ 5.5 VERIFY    ◀── CDP health · component tree · store state · interaction · screenshot
+        ├─ 6 Review      parallel agents check correctness and RN conventions
+        └─ 7 PROOF       ◀── rehearse off camera, persist the action, record a clean replay
+                                                            │
+                                    working code  +  video  +  screenshots  +  PR body
 ```
 
-## The pipeline
+Phase 5.5 is the one that makes the difference: nothing is reported as working until it has been
+observed working. Phase 7 rehearses first, so discovery fumbling never ends up in the recording.
 
-`/rn-feature-dev` runs an [8-phase pipeline](https://lykhoyda.github.io/rn-dev-agent/commands/rn-feature-dev/) — from understanding your codebase to verified code with proof recordings:
+[The 8-phase pipeline in detail →](https://lykhoyda.github.io/rn-dev-agent/commands/rn-feature-dev/)
 
-| Phase | What happens |
-|-------|--------------|
-| 1. Discovery | Understand the feature, create a task plan |
-| 2. Exploration | Parallel agents map screens, store, navigation, conventions |
-| 3. Questions | Clarify edge cases, error states, data flow |
-| 4. Architecture | Design the implementation with the architect agent |
-| 5. Implementation | Build the feature — store, components, navigation, testIDs |
-| 5.5. Verification | **Prove it works live** — CDP health, component tree, store state, interaction, screenshot |
-| 6. Review | Parallel review agents check correctness and RN conventions |
-| 7. Proof | **Rehearse off camera**, persist a Maestro action, then record a deterministic replay — discovery never appears in the video |
+## Commands
 
-## Workflows
-
-The tables use Claude spelling. Codex provides native explicit parity for every
-row: replace `/rn-dev-agent:<name>` with `$rn-dev-agent:<name>`. Codex exposes
-exactly these 16 workflow skills plus 11 domain skills; install-time
-`source-command-*` migration is deliberately disabled.
-
-**Develop & test:**
+Claude spelling shown. Codex has native parity for every row — use `$rn-dev-agent:<name>`.
 
 | Command | Purpose |
 |---------|---------|
-| `/rn-dev-agent:run-workflow <journey>` | Establish the proven operating sequence before a real device journey |
-| `/rn-dev-agent:rn-feature-dev <desc>` | Full 8-phase feature pipeline (above) |
+| `/rn-dev-agent:rn-feature-dev <desc>` | Full 8-phase feature pipeline |
 | `/rn-dev-agent:test-feature <desc>` | Test an already-implemented feature; auto-replays a matching saved action |
 | `/rn-dev-agent:debug-screen` | Diagnose and fix a broken screen — parallel evidence from CDP + native logs + component tree |
-| `/rn-dev-agent:build-and-test <desc>` | Build the app (local or EAS), install on device, then test |
 | `/rn-dev-agent:proof-capture <desc>` | Rehearsal-gated video + screenshots + generated PR body |
-| `/rn-dev-agent:observe` | Local web UI to **watch the agent live** — tool-call timeline, device mirror, route/store/component-tree panels, browser-triggered action + E2E replays ([guide](https://lykhoyda.github.io/rn-dev-agent/commands/observe/)) |
+| `/rn-dev-agent:observe` | Local web UI to **watch the agent live** — tool-call timeline, device mirror, route/store/component-tree panels, browser-triggered action and E2E replays ([guide](https://lykhoyda.github.io/rn-dev-agent/commands/observe/)) |
+| `/rn-dev-agent:setup` | Onboard a project — Claude manages `CLAUDE.md`, Codex manages `AGENTS.md`; every project write is previewed |
+
+<details>
+<summary><strong>The other 10 commands — actions, regression, build, diagnostics</strong></summary>
 
 **Actions & regression:**
 
@@ -139,38 +120,56 @@ exactly these 16 workflow skills plus 11 domain skills; install-time
 | `/rn-dev-agent:run-action <name>` | Replay a saved action with auto-repair and structured run records |
 | `/rn-dev-agent:lock-e2e <name>` | Promote a verified action into a **frozen, locked e2e regression test** (strict no-repair run required) |
 
-**Setup & diagnostics:**
+**Build & session:**
 
 | Command | Purpose |
 |---------|---------|
-| `/rn-dev-agent:setup` | Onboard a project — Claude manages `CLAUDE.md`; Codex manages `AGENTS.md`; nav/store/scaffold writes are previewed |
+| `/rn-dev-agent:run-workflow <journey>` | Establish the proven operating sequence before a real device journey |
+| `/rn-dev-agent:build-and-test <desc>` | Build the app (local or EAS), install on device, then test |
+
+**Diagnostics:**
+
+| Command | Purpose |
+|---------|---------|
 | `/rn-dev-agent:doctor` | Strictly read-only multi-axis plugin/MCP/schema/task/environment diagnosis; recommends but never executes recovery |
 | `/rn-dev-agent:check-env` | Quick environment-readiness check |
 | `/rn-dev-agent:nav-graph` | Extract and inspect the app navigation graph |
 | `/rn-dev-agent:check-vercel-rules` | Report drift between bundled best-practice rules and upstream |
 | `/rn-dev-agent:send-feedback` | Open a GitHub issue with sanitized environment context |
 
-The plugin also keeps a gitignored per-project troubleshooting memory (`.rn-agent/local/troubleshooting.md`) — auto-captured failures and config notes, read at session start.
+Codex exposes exactly these 16 workflow skills plus 11 domain skills; install-time
+`source-command-*` migration is deliberately disabled.
 
-## Actions: replayable flows + the LLM/pragmatic hybrid
+The plugin also keeps a gitignored per-project troubleshooting memory
+(`.rn-agent/local/troubleshooting.md`) — auto-captured failures and config notes, read at session start.
 
-An **action** is a saved Maestro flow the agent **emits** when verification passes — not something you author. Each task then splits into two regimes: **pragmatic reusable actions** for the predictable parts (login, navigation, multi-step setup) and **LLM-driven discovery** for the part that's actually new. Actions serve as prologues to reach a known state before fresh interactive work.
+</details>
+
+## Actions: the memory of the loop
+
+An **action** is a saved Maestro flow the agent **emits** when verification passes — not something
+you author. Each task then splits in two: **replayable actions** for the predictable parts (login,
+navigation, multi-step setup) and **live discovery** for the part that is actually new. Actions run
+as prologues to reach a known state before fresh interactive work.
 
 | | |
 |---|---|
 | **What** | A saved, parameterised flow with a metadata header and `${KEY}` placeholders |
 | **Where** | `.rn-agent/actions/<name>.yaml` — the plugin's home in your project is `.rn-agent/` |
 | **Create one** | Run `/rn-dev-agent:test-feature <description>`; the verified walk is saved automatically |
-| **Run one** | `/rn-dev-agent:run-action <name>` — the agent also picks actions automatically when it needs a known state |
+| **Run one** | `/rn-dev-agent:run-action <name>` — the agent also picks actions itself when it needs a known state |
 | **Self-repair** | If a `testID` changes, `cdp_repair_action` fuzzy-matches against the live snapshot, patches the YAML, and retries. Small UI drift is absorbed; broken product logic is surfaced, never auto-fixed |
 | **Lock it in** | `/rn-dev-agent:lock-e2e` freezes a passing action into `.rn-agent/e2e/` — locked tests run strict (no repair) via `cdp_run_e2e_suite` |
-| **Why hybrid** | Pure scripts don't adapt; pure LLM re-derives everything every session. Actions are the memory of the LLM loop — every successful verification adds one, every drift gets quietly absorbed, every truly broken flow escalates |
+| **Why it works** | Pure scripts don't adapt; a pure LLM re-derives everything every session. Every successful verification adds an action, every drift gets quietly absorbed, every truly broken flow escalates |
 
-[Full actions guide — why the hybrid matters, tool surface, comparison vs Detox/Maestro/pure-LLM](https://lykhoyda.github.io/rn-dev-agent/actions/)
+[Full actions guide →](https://lykhoyda.github.io/rn-dev-agent/actions/)
 
-## MCP tools
+## Under the hood
 
-The plugin exposes MCP tools across six families ([full reference](https://lykhoyda.github.io/rn-dev-agent/tools/)):
+Everything the commands above are built from — expand what you need.
+
+<details>
+<summary><strong>81 MCP tools across six families</strong></summary>
 
 | Family | What it's for | Examples |
 |---|---|---|
@@ -181,44 +180,50 @@ The plugin exposes MCP tools across six families ([full reference](https://lykho
 | **Testing** | E2E replay and PR-ready proof | `proof_step`, `cross_platform_verify`, `maestro_run`, `maestro_test_all` (`cdp_auto_login` is legacy per-call recovery, not a failed-login fallback or PR proof) |
 | **Macro-Asserts** | State-assertive replays — internal state, not pixels | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` |
 
-The committed tool surface is asserted in CI against a golden registry (`packages/rn-dev-agent-core/test/fixtures/tool-registry.json`), so tool additions and removals can't silently drift.
+The committed tool surface is asserted in CI against a golden registry
+(`packages/rn-dev-agent-core/test/fixtures/tool-registry.json`), so tool additions and removals
+can't silently drift. [Full tool reference →](https://lykhoyda.github.io/rn-dev-agent/tools/)
 
-**Reliability features baked into the tool layer:**
+</details>
+
+<details>
+<summary><strong>Reliability baked into the tool layer</strong></summary>
 
 - **Self-healing taps** — a stale `@ref` is re-bound by identity (testID/label/role, unique match only). Opt out with `RN_SELF_HEAL=0`. A dispatched tap is never replayed because its effect is uncertain: on iOS an unchanged tap stays a success carrying `meta.noUiChange`, and on Android a tap whose effect cannot be observed fails (`INTERACTION_EFFECT_UNVERIFIED`, `mutation: possible`) rather than reporting success.
-- **Quiescence bypass (iOS)** — XCTest's private idle-wait is disabled by default so apps with Reanimated/looping animations can't hang queries (the same WebDriverAgent-lineage technique Maestro uses). Opt out with `RN_QUIESCENCE_BYPASS=0`.
-- **Engine pinning** — setup installs attested maestro-runner `1.1.24` in the versioned pin-cache (floor `>= 1.1.24`) and verifies its checksum fail-closed; replay and `/doctor` refuse missing, older, or unattested engines.
+- **Quiescence bypass (iOS)** — XCTest's private idle-wait is disabled by default so apps with Reanimated or looping animations can't hang queries. Opt out with `RN_QUIESCENCE_BYPASS=0`.
+- **Engine pinning** — setup installs attested [maestro-runner](https://github.com/devicelab-dev/maestro-runner) `1.1.24` in the versioned pin-cache (floor `>= 1.1.24`) and verifies its checksum fail-closed; replay and `/doctor` refuse missing, older, or unattested engines.
 - **Degraded-runtime detection** — when taps succeed but the app doesn't respond, results carry a "simulator likely wedged, reboot it" hint instead of a misleading "element not found."
 
-## Specialized agents
+</details>
 
-Five agents, each running a focused protocol: [tester](https://lykhoyda.github.io/rn-dev-agent/agents/rn-tester/), [debugger](https://lykhoyda.github.io/rn-dev-agent/agents/rn-debugger/), [code explorer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-explorer/), [architect](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-architect/), [reviewer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-reviewer/).
+<details>
+<summary><strong>118 curated best-practice rules</strong></summary>
 
-> **Note:** `rn-tester` and `rn-debugger` need MCP tools, which don't propagate to spawned subagents — use `/rn-dev-agent:test-feature` and `/rn-dev-agent:debug-screen`, which run the protocols inline (GH #31).
+48 React Native + 70 React/web rules, indexed and applied during architecture and review — crash
+prevention, list performance, animations, state management. Integrated from
+[Vercel's agent skills](https://github.com/vercel-labs/agent-skills); run
+`/rn-dev-agent:check-vercel-rules` to see drift against upstream.
+[Best practices →](https://lykhoyda.github.io/rn-dev-agent/best-practices/)
 
-## App setup
+</details>
 
-**Most apps need zero setup** — the plugin reads the React fiber tree directly via Metro's CDP endpoint.
+<details>
+<summary><strong>Five specialized agents</strong></summary>
 
-**Zustand stores** — one line in your app entry ([details](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)):
+Each runs a focused protocol: [tester](https://lykhoyda.github.io/rn-dev-agent/agents/rn-tester/),
+[debugger](https://lykhoyda.github.io/rn-dev-agent/agents/rn-debugger/),
+[code explorer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-explorer/),
+[architect](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-architect/),
+[reviewer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-reviewer/).
 
-```typescript
-if (__DEV__) {
-  global.__ZUSTAND_STORES__ = { auth: useAuthStore, cart: useCartStore };
-}
-```
+> **Note:** `rn-tester` and `rn-debugger` need MCP tools, which don't propagate to spawned
+> subagents — use `/rn-dev-agent:test-feature` and `/rn-dev-agent:debug-screen`, which run the
+> protocols inline (GH #31).
 
-**Redux** — auto-detected, no setup needed.
+</details>
 
-**testIDs** — add to interactive elements for reliable queries:
-
-```tsx
-<Pressable testID="checkout-button" onPress={handleCheckout}>
-  <Text testID="cart-badge">{itemCount}</Text>
-</Pressable>
-```
-
-## Architecture
+<details>
+<summary><strong>Architecture</strong></summary>
 
 ```
 Claude Code / Codex
@@ -241,11 +246,110 @@ Claude Code / Codex
       E2E test execution: maestro-runner 1.1.24 (pin-cache only)
 ```
 
-[Architecture details](https://lykhoyda.github.io/rn-dev-agent/architecture/)
+[Architecture details →](https://lykhoyda.github.io/rn-dev-agent/architecture/)
+
+</details>
+
+---
+
+## Install
+
+### Claude Code
+
+```text
+/plugin marketplace add Lykhoyda/rn-dev-agent
+/plugin install rn-dev-agent@rn-dev-agent
+/reload-plugins
+```
+
+Local checkout: `claude --plugin-dir /path/to/rn-dev-agent` (the root `.claude-plugin/marketplace.json`
+resolves the plugin package from `packages/claude-plugin/`).
+
+### Codex
+
+```bash
+codex plugin marketplace add Lykhoyda/rn-dev-agent
+codex plugin add rn-dev-agent@rn-dev-agent
+```
+
+Local checkout: register the package directory `/path/to/rn-dev-agent/packages/codex-plugin` — not
+the repository root. The Codex package is self-contained (bundled MCP runtime, native runner
+sources, helpers, and runner manifest) and loads the same `cdp` MCP server from its `.mcp.json`.
+Codex does not load Claude Code hooks — `No plugin hooks` is expected. Codex 0.145.0 is the
+live-refresh floor; older hosts are restart-only. An external CLI or manual plugin change always
+requires exiting and relaunching Codex.
+
+### Then set up your project
+
+```text
+cd /path/to/your-rn-app
+
+Claude: /rn-dev-agent:setup
+Codex:  $rn-dev-agent:setup
+```
+
+Claude setup manages `CLAUDE.md`; Codex setup manages an idempotent sentinel-bounded `AGENTS.md`
+block, runs strictly read-only package/recovery diagnostics first, and previews every later
+project write for consent. [Full setup guide →](https://lykhoyda.github.io/rn-dev-agent/getting-started/)
+
+<details>
+<summary><strong>What setup checks, and what it fixes for you</strong></summary>
+
+Claude hooks and normal runtime use can perform the automatic handling below; Codex setup keeps
+recovery diagnosis read-only and prints the exact commands for you to confirm and run.
+
+| Check | Required | Automatic handling |
+|-------|----------|--------------|
+| Node.js ≥ 24 | Yes | No |
+| CDP bridge deps | Yes | Yes |
+| rn-fast-runner (iOS) | iOS targets only | Prebuilt artifact on releases; one-time `xcodebuild build-for-testing` fallback |
+| rn-android-runner (Android) | Android targets only | Prebuilt artifact on releases; Gradle build fallback on first use |
+| [maestro-runner](https://github.com/devicelab-dev/maestro-runner) | Yes | Yes (pin-cache engine `>= 1.1.24`, attested 1.1.24 checksum-verified) |
+| iOS Simulator / Android Emulator | One platform | No |
+| Session-bound Metro | Yes | Project integration starts or validates it through literal `pnpm ios` / `pnpm android` |
+| CDP connection | Yes | `rn_session` owns the binding; `cdp_status` is passive and `cdp_connect` pins the exact target |
+| ffmpeg | Optional (proof videos) | Yes |
+| idb + idb-companion | Optional (smooth observe-UI mirroring) | Yes |
+
+Claude automation failures and Codex missing prerequisites are reported with step-by-step manual
+instructions.
+
+**Prebuilt runners:** on a released version, the device runners install from a verified prebuilt
+artifact (SHA-256-checked local cache, then the GitHub Release asset for your exact plugin
+version), so the first `device_snapshot action=open` skips the cold build. Resolution is fail-open
+— offline, a checksum mismatch, or a dev checkout falls back transparently to the on-machine build
+(the host's `doctor` workflow reports which one you got). Force local builds with
+`RN_RUNNER_BUILD=local`.
+
+</details>
+
+### What your app needs
+
+**Most apps need zero setup** — the plugin reads the React fiber tree directly via Metro's CDP
+endpoint. Redux is auto-detected.
+
+**Zustand stores** — one line in your app entry
+([details](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)):
+
+```typescript
+if (__DEV__) {
+  global.__ZUSTAND_STORES__ = { auth: useAuthStore, cart: useCartStore };
+}
+```
+
+**testIDs** — add to interactive elements for reliable queries:
+
+```tsx
+<Pressable testID="checkout-button" onPress={handleCheckout}>
+  <Text testID="cart-badge">{itemCount}</Text>
+</Pressable>
+```
+
+---
 
 ## Benchmarks
 
-38 stories completed on the test app (35 Ralph Loop + 3 Liquid Glass). [Full benchmarks](https://lykhoyda.github.io/rn-dev-agent/benchmarks/)
+38 stories completed on the public test app (35 Ralph Loop + 3 Liquid Glass).
 
 | Complexity | Time | Crashes | Manual interventions |
 |-----------|------|---------|---------------------|
@@ -254,7 +358,51 @@ Claude Code / Codex
 | Complex (3-step wizard, onboarding) | 11–25 min | 0 | 0 |
 | Glass UI (BlurView, Reanimated, haptics) | 27–90 min | 0 | 1 (Metro restart) |
 
-**Libraries tested:** react-hook-form, zod, @tanstack/react-query, @gorhom/bottom-sheet, @shopify/flash-list, zustand, react-native-svg, expo-notifications, react-native-reanimated, react-native-gesture-handler, expo-haptics, expo-blur
+**Libraries verified end-to-end:** react-hook-form, zod, @tanstack/react-query,
+@gorhom/bottom-sheet, @shopify/flash-list, zustand, react-native-svg, expo-notifications,
+react-native-reanimated, react-native-gesture-handler, expo-haptics, expo-blur
+
+[Full benchmarks →](https://lykhoyda.github.io/rn-dev-agent/benchmarks/)
+
+## Security
+
+The `cdp_evaluate` tool runs arbitrary JavaScript in your app's Hermes runtime with full access to
+the component tree, store state, AsyncStorage, and any in-memory secrets. This is **intentional** —
+runtime introspection is what makes the plugin useful — but it means **only run this plugin against
+apps where you trust the agent's prompts**.
+
+- **Local dev environments only.** Do not point the plugin at production builds, store-signed apps, or any app holding real user data.
+- **Treat the agent like a developer with shell access to your laptop.** Any prompt that reaches `cdp_evaluate` (directly or through another tool) can read or mutate your app's runtime state.
+- **Use the fenced session as CDP authority.** `rn_session` binds the intended worktree, Metro, app, and device; `cdp_targets` may explain ambient Hermes processes but never authorizes selecting one. See [Parallel session authority](https://lykhoyda.github.io/rn-dev-agent/session-authority/).
+
+The plugin makes no attempt to sandbox `cdp_evaluate`. If you need that, gate tool access through
+your agent's permission prompts rather than trusting the tool layer.
+
+<details>
+<summary><strong>What the observability UI and the local evidence store record</strong></summary>
+
+The **observability UI** ([`/rn-dev-agent:observe`](https://lykhoyda.github.io/rn-dev-agent/commands/observe/))
+binds to `127.0.0.1` only and rejects cross-origin requests via Host-header + `Sec-Fetch-Site`
+checks. It is read-only except for two deliberate, CSRF-token-gated endpoints that trigger action
+and locked-E2E replays. Tool arguments are deep-redacted fail-closed before reaching the stream and
+typed fill text is never streamed verbatim (see the
+[security posture](https://lykhoyda.github.io/rn-dev-agent/commands/observe/#security-posture) for
+what is redacted and what stays visible), and the recorder keeps only a small bounded in-memory
+ring buffer — the event stream itself never touches disk (action RunRecords and locked-E2E run
+output follow the session state directory: fenced sessions use their session-private runtime state,
+while an unfenced process uses `.rn-agent/state/` for actions and `.rn-agent/state/e2e-runs/` for
+E2E history; `.rn-agent/e2e/` contains the locked test definitions).
+
+Meaningful tool failures and immediate successful retries also feed a separate, local-only evidence
+store at `~/.claude/rn-agent/experience/patterns.jsonl`. Records are sanitized before writing,
+deduplicated, capped at 500 patterns, and retained for 14 days; ordinary successful calls are never
+stored. Runner failures may also retain up to five sanitized diagnostics bundles alongside that
+store, each capped at 200 typed lifecycle events and 256 KB for reviewed feedback or an explicit
+`collect_logs` export. From an installed plugin package, inspect the read-only trend report with
+`node <plugin-package>/rn-dev-agent-core/dist/experience-trends.js --since <previous-report-ISO-timestamp>`
+(omit `--since` for the last 24 hours). The command never updates the evidence store or uploads data.
+
+</details>
 
 ## Troubleshooting
 
@@ -265,42 +413,28 @@ Claude Code / Codex
 | CDP rejected (1006) | Close React Native DevTools, Flipper, or Chrome DevTools |
 | Zustand store error | Add `global.__ZUSTAND_STORES__` ([setup](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)) |
 | Plugin not detected (Claude) | `/plugin install rn-dev-agent@rn-dev-agent` then `/reload-plugins` |
-| Plugin not detected (Codex) | Inspect with `codex plugin list --json` and `/mcp verbose`; user-confirm `codex plugin add rn-dev-agent@rn-dev-agent --json`, then relaunch after external changes |
-| Codex tools fail after upgrade | `/mcp verbose` inspects only. Relaunch Codex for external/manual changes or legacy hosts; never kill another host's bridge |
 | Subagent says "MCP tools unavailable" | Never spawn `rn-tester`/`rn-debugger` via the Task tool — use `/rn-dev-agent:test-feature` or `/rn-dev-agent:debug-screen` instead (GH #31) |
-| Blank white screen after many reloads | NativeWind stylesheet corruption after 5+ `cdp_reload` cycles — kill and restart Metro, relaunch the app |
 
 <details>
-<summary><strong>Advanced: device-runner issues</strong></summary>
+<summary><strong>More: host recovery, device runners, wedged simulators</strong></summary>
 
 | Problem | Solution |
 |---------|----------|
+| Plugin not detected (Codex) | Inspect with `codex plugin list --json` and `/mcp verbose`; user-confirm `codex plugin add rn-dev-agent@rn-dev-agent --json`, then relaunch after external changes |
+| Codex tools fail after upgrade | `/mcp verbose` inspects only. Relaunch Codex for external/manual changes or legacy hosts; never kill another host's bridge |
+| Blank white screen after many reloads | NativeWind stylesheet corruption after 5+ `cdp_reload` cycles — kill and restart Metro, relaunch the app |
 | `device_scroll` times out on Reanimated screens | A `waitForIdle` round-trip can deadlock against Reanimated worklets; scroll routes through the in-tree runner's HID synthesis instead. Ensure the runner is healthy via the device session |
 | Legacy `AgentDeviceRunner` re-appears on iOS | Stale `~/.agent-device/daemon.json` respawns the upstream runner. The plugin terminates stale processes at session-open (opt out: `RN_DEVICE_KILL_LEGACY=0`); manual cleanup: `pkill -f AgentDeviceRunner && rm -f ~/.agent-device/daemon.{json,lock}` |
 | iOS "rn-fast-runner did not become ready" | The runner self-build timed out or failed. In a source checkout, pre-build once: `cd packages/rn-fast-runner/RnFastRunner && xcodebuild build-for-testing -project RnFastRunner.xcodeproj -scheme RnFastRunner -destination "platform=iOS Simulator,id=<UDID>" -derivedDataPath ../build/DerivedData` |
-| `device_fill` reports `TEXT_ENTRY_UNVERIFIED` | A fill attempt ran, but stable exact read-back could not prove the requested value. Check `meta.mutation`: retry from a fresh snapshot only when it is `none`; for `observed` or `possible`, read and rebind the field before correcting it so a blind retry cannot double-type. |
-| Need an intentional coordinate tap | Use `device_press({x, y})` (or a batch press step with `x`/`y`). With a visible iOS keyboard, raw coordinates are geometry-unknown: the keyboard is proven hidden before the one tap. Prefer fresh refs for normal UI controls. |
-| Native logs include another device/app | Reopen the exact device session. `collect_logs` pins Android to that session's adb serial and iOS to that simulator plus the current target-app PID; it fails closed when exact scope cannot be resolved. When the probe runs and proves the app is not running, the stream stays pinned to that simulator and reports `scopes.native_ios.process = app-not-running-device-scoped` so a crash trail is still captured. |
+| `device_fill` reports `TEXT_ENTRY_UNVERIFIED` | A fill attempt ran, but stable exact read-back could not prove the requested value. Check `meta.mutation`: retry from a fresh snapshot only when it is `none`; for `observed` or `possible`, read and rebind the field before correcting it so a blind retry cannot double-type |
+| Need an intentional coordinate tap | Use `device_press({x, y})` (or a batch press step with `x`/`y`). With a visible iOS keyboard, raw coordinates are geometry-unknown: the keyboard is proven hidden before the one tap. Prefer fresh refs for normal UI controls |
+| Native logs include another device/app | Reopen the exact device session. `collect_logs` pins Android to that session's adb serial and iOS to that simulator plus the current target-app PID; it fails closed when exact scope cannot be resolved. When the probe runs and proves the app is not running, the stream stays pinned to that simulator and reports `scopes.native_ios.process = app-not-running-device-scoped` so a crash trail is still captured |
 | Want XCTest's stock idle-waits back | Kill the running runner (`pkill -f RnFastRunnerUITests`), set `RN_QUIESCENCE_BYPASS=0`, reopen the device session, and inspect the next device result's `meta.quiescenceBypass` |
 | Seeing `meta.reResolved` / `meta.noUiChange` | Stale-ref healing at work; `meta.noUiChange` means the iOS tap was dispatched but changed nothing. Disable ref healing with `RN_SELF_HEAL=0` (`retryIfNoChange` is a deprecated no-op — taps are never replayed) |
 
 </details>
 
-[Full troubleshooting guide](https://lykhoyda.github.io/rn-dev-agent/troubleshooting/)
-
-## Security
-
-The `cdp_evaluate` tool runs arbitrary JavaScript in your app's Hermes runtime with full access to the component tree, store state, AsyncStorage, and any in-memory secrets. This is **intentional** — runtime introspection is what makes the plugin useful — but it means **only run this plugin against apps where you trust the agent's prompts**.
-
-- **Local dev environments only.** Do not point the plugin at production builds, store-signed apps, or any app holding real user data.
-- **Treat the agent like a developer with shell access to your laptop.** Any prompt that reaches `cdp_evaluate` (directly or through another tool) can read or mutate your app's runtime state.
-- **Use the fenced session as CDP authority.** `rn_session` binds the intended worktree, Metro, app, and device; `cdp_targets` may explain ambient Hermes processes but never authorizes selecting one. See [Parallel session authority](https://lykhoyda.github.io/rn-dev-agent/session-authority/).
-
-The plugin makes no attempt to sandbox `cdp_evaluate`. If you need that, gate tool access through your agent's permission prompts rather than trusting the tool layer.
-
-The **observability UI** ([`/rn-dev-agent:observe`](https://lykhoyda.github.io/rn-dev-agent/commands/observe/)) binds to `127.0.0.1` only and rejects cross-origin requests via Host-header + `Sec-Fetch-Site` checks. It is read-only except for two deliberate, CSRF-token-gated endpoints that trigger action and locked-E2E replays. Tool arguments are deep-redacted fail-closed before reaching the stream and typed fill text is never streamed verbatim (see the [security posture](https://lykhoyda.github.io/rn-dev-agent/commands/observe/#security-posture) for what is redacted and what stays visible), and the recorder keeps only a small bounded in-memory ring buffer — the event stream itself never touches disk (action RunRecords and locked-E2E run output follow the session state directory: fenced sessions use their session-private runtime state, while an unfenced process uses `.rn-agent/state/` for actions and `.rn-agent/state/e2e-runs/` for E2E history; `.rn-agent/e2e/` contains the locked test definitions).
-
-Meaningful tool failures and immediate successful retries also feed a separate, local-only evidence store at `~/.claude/rn-agent/experience/patterns.jsonl`. Records are sanitized before writing, deduplicated, capped at 500 patterns, and retained for 14 days; ordinary successful calls are never stored. Runner failures may also retain up to five sanitized diagnostics bundles alongside that store, each capped at 200 typed lifecycle events and 256 KB for reviewed feedback or an explicit `collect_logs` export. From an installed plugin package, inspect the read-only trend report with `node <plugin-package>/rn-dev-agent-core/dist/experience-trends.js --since <previous-report-ISO-timestamp>` (omit `--since` for the last 24 hours). The command never updates the evidence store or uploads data.
+[Full troubleshooting guide →](https://lykhoyda.github.io/rn-dev-agent/troubleshooting/)
 
 ## Keeping up to date
 
@@ -316,7 +450,8 @@ Codex:  codex plugin marketplace upgrade rn-dev-agent
 
 Release notes: [GitHub Releases](https://github.com/Lykhoyda/rn-dev-agent/releases) · [core changelog](packages/rn-dev-agent-core/CHANGELOG.md)
 
-## Development
+<details>
+<summary><strong>Development — building from source</strong></summary>
 
 This is a Yarn workspace monorepo:
 
@@ -338,7 +473,8 @@ corepack yarn install --immutable
 corepack yarn build:host-runtimes   # builds core + generates both host packages
 ```
 
-Run locally: `claude --plugin-dir /path/to/rn-dev-agent` (Claude Code) or register `packages/codex-plugin` (Codex).
+Run locally: `claude --plugin-dir /path/to/rn-dev-agent` (Claude Code) or register
+`packages/codex-plugin` (Codex).
 
 ```bash
 corepack yarn test          # complete unit-test suite
@@ -346,8 +482,23 @@ corepack yarn lint          # oxlint
 corepack yarn format:check  # oxfmt
 ```
 
-Versioning uses [changesets](https://github.com/changesets/changesets); every tool-surface change must update the golden registry (`node scripts/update-tool-registry.mjs`).
+Versioning uses [changesets](https://github.com/changesets/changesets); every tool-surface change
+must update the golden registry (`node scripts/update-tool-registry.mjs`).
 
-## License
+</details>
 
-MIT
+---
+
+<div align="center">
+
+### Stop taking your agent's word for it.
+
+```text
+/plugin marketplace add Lykhoyda/rn-dev-agent
+```
+
+**[Read the docs](https://lykhoyda.github.io/rn-dev-agent/)** · **[Star the repo](https://github.com/Lykhoyda/rn-dev-agent)** · **[Report a bug](https://github.com/Lykhoyda/rn-dev-agent/issues/new)** or run `/rn-dev-agent:send-feedback`
+
+Free · open source · MIT
+
+</div>

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ version), so the first `device_snapshot action=open` skips the cold build. Resol
 endpoint. Redux is auto-detected.
 
 **Zustand stores** — one line in your app entry
-([details](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)):
+([details](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-bridge-call)):
 
 ```typescript
 if (__DEV__) {
@@ -403,7 +403,7 @@ store, each capped at 200 typed lifecycle events and 256 KB for reviewed feedbac
 | "Metro not found" | Inspect `rn_session(action="status")`, then use literal `pnpm ios` or `pnpm android` through the confirmed project integration |
 | "No Hermes target" | Open the bound app, inspect passive `cdp_status`, then use `cdp_connect` to pin the exact signed target |
 | CDP rejected (1006) | Close React Native DevTools, Flipper, or Chrome DevTools |
-| Zustand store error | Add `global.__ZUSTAND_STORES__` ([setup](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)) |
+| Zustand store error | Add `global.__ZUSTAND_STORES__` ([setup](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-bridge-call)) |
 | Plugin not detected (Claude) | `/plugin install rn-dev-agent@rn-dev-agent` then `/reload-plugins` |
 | Subagent says "MCP tools unavailable" | Never spawn `rn-tester`/`rn-debugger` via the Task tool — use `/rn-dev-agent:test-feature` or `/rn-dev-agent:debug-screen` instead (GH #31) |
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ benchmarks.
 | **Verified, not claimed** | After implementing, the agent connects over CDP, walks the screen, reads the component tree and store, exercises the interaction, and screenshots the result — before it says "done" |
 | **210× faster replays** | A 3-step wizard that took ~14 min as an interactive walk replays in **~4 s** as a saved action. Average session time across the measured features dropped from ~12 min to ~4 min once actions existed |
 | **Flows that repair themselves** | When a `testID` drifts, the saved action fuzzy-matches the live snapshot, patches its own YAML, and retries. Cosmetic drift is absorbed; genuinely broken product logic is surfaced, never auto-fixed |
-| **Minutes, not sessions** | Simple features land in 3–5 min, complex multi-step flows in 11–25 min; heavy glass-UI work runs longer. **Zero crashes across all 38 measured stories** |
+| **Minutes, not sessions** | Simple features land in 3–5 min, complex multi-step flows in 11–25 min. **Zero crashes and zero manual interventions across all 35 measured features** |
 | **iOS and Android, one contract** | In-tree XCTest and UiAutomator runners give real taps, typing, scrolling, and screenshots — shipped as prebuilt artifacts so first use skips the cold build |
 | **Both hosts, full parity** | Claude Code: 16 slash commands + 11 skills + 5 agents. Codex: 27 native skills (16 workflow + 11 domain). The same 81 MCP tools on both |
 
@@ -341,18 +341,17 @@ if (__DEV__) {
 
 ## Benchmarks
 
-38 stories completed on the public test app (35 Ralph Loop + 3 Liquid Glass).
+35 features completed on the public test app.
 
 | Complexity | Time | Crashes | Manual interventions |
 |-----------|------|---------|---------------------|
 | Simple (search, toggle, store) | 3–5 min | 0 | 0 |
 | Medium (forms, charts, lists) | 5–10 min | 0 | 0 |
 | Complex (3-step wizard, onboarding) | 11–25 min | 0 | 0 |
-| Glass UI (BlurView, Reanimated, haptics) | 27–90 min | 0 | 1 (Metro restart) |
 
 **Libraries verified end-to-end:** react-hook-form, zod, @tanstack/react-query,
 @gorhom/bottom-sheet, @shopify/flash-list, zustand, react-native-svg, expo-notifications,
-react-native-reanimated, react-native-gesture-handler, expo-haptics, expo-blur
+react-native-reanimated, react-native-gesture-handler, expo-haptics
 
 [Full benchmarks →](https://lykhoyda.github.io/rn-dev-agent/benchmarks/)
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,17 @@ Codex users: replace `/rn-dev-agent:<name>` with `$rn-dev-agent:<name>`. [Instal
 ## Coding agents ship blind
 
 They are good at writing React Native code and bad at knowing whether it runs. This plugin closes
-that loop — and everything below is measured on a real Expo app, not a synthetic benchmark.
+that loop — and the numbers below come from real features built on a real Expo app, not synthetic
+benchmarks.
 
 | | |
 |---|---|
 | **Verified, not claimed** | After implementing, the agent connects over CDP, walks the screen, reads the component tree and store, exercises the interaction, and screenshots the result — before it says "done" |
 | **210× faster replays** | A 3-step wizard that took ~14 min as an interactive walk replays in **~4 s** as a saved action. Average session time across the measured features dropped from ~12 min to ~4 min once actions existed |
 | **Flows that repair themselves** | When a `testID` drifts, the saved action fuzzy-matches the live snapshot, patches its own YAML, and retries. Cosmetic drift is absorbed; genuinely broken product logic is surfaced, never auto-fixed |
-| **3–25 min, description → verified** | Simple features land in 3–5 min, complex multi-step flows in 11–25 min — **zero crashes across 38 measured stories** |
+| **Minutes, not sessions** | Simple features land in 3–5 min, complex multi-step flows in 11–25 min; heavy glass-UI work runs longer. **Zero crashes across all 38 measured stories** |
 | **iOS and Android, one contract** | In-tree XCTest and UiAutomator runners give real taps, typing, scrolling, and screenshots — shipped as prebuilt artifacts so first use skips the cold build |
-| **Both hosts, full parity** | Claude Code: 16 slash commands + 11 skills + 5 agents. Codex: 27 native skills (16 workflow + 11 domain). 81 MCP tools and 118 best-practice rules on both |
+| **Both hosts, full parity** | Claude Code: 16 slash commands + 11 skills + 5 agents. Codex: 27 native skills (16 workflow + 11 domain). The same 81 MCP tools on both |
 
 [Full benchmarks and methodology →](https://lykhoyda.github.io/rn-dev-agent/benchmarks/)
 
@@ -166,7 +167,9 @@ as prologues to reach a known state before fresh interactive work.
 
 ## Under the hood
 
-Everything the commands above are built from — expand what you need.
+Everything the commands above are built from — expand what you need. The architecture and review
+phases also apply a bundled set of React Native and React
+[best-practice rules](https://lykhoyda.github.io/rn-dev-agent/best-practices/).
 
 <details>
 <summary><strong>81 MCP tools across six families</strong></summary>
@@ -193,17 +196,6 @@ can't silently drift. [Full tool reference →](https://lykhoyda.github.io/rn-de
 - **Quiescence bypass (iOS)** — XCTest's private idle-wait is disabled by default so apps with Reanimated or looping animations can't hang queries. Opt out with `RN_QUIESCENCE_BYPASS=0`.
 - **Engine pinning** — setup installs attested [maestro-runner](https://github.com/devicelab-dev/maestro-runner) `1.1.24` in the versioned pin-cache (floor `>= 1.1.24`) and verifies its checksum fail-closed; replay and `/doctor` refuse missing, older, or unattested engines.
 - **Degraded-runtime detection** — when taps succeed but the app doesn't respond, results carry a "simulator likely wedged, reboot it" hint instead of a misleading "element not found."
-
-</details>
-
-<details>
-<summary><strong>118 curated best-practice rules</strong></summary>
-
-48 React Native + 70 React/web rules, indexed and applied during architecture and review — crash
-prevention, list performance, animations, state management. Integrated from
-[Vercel's agent skills](https://github.com/vercel-labs/agent-skills); run
-`/rn-dev-agent:check-vercel-rules` to see drift against upstream.
-[Best practices →](https://lykhoyda.github.io/rn-dev-agent/best-practices/)
 
 </details>
 
@@ -493,9 +485,7 @@ must update the golden registry (`node scripts/update-tool-registry.mjs`).
 
 ### Stop taking your agent's word for it.
 
-```text
-/plugin marketplace add Lykhoyda/rn-dev-agent
-```
+**[Install it in 60 seconds →](#see-it-in-60-seconds)**
 
 **[Read the docs](https://lykhoyda.github.io/rn-dev-agent/)** · **[Star the repo](https://github.com/Lykhoyda/rn-dev-agent)** · **[Report a bug](https://github.com/Lykhoyda/rn-dev-agent/issues/new)** or run `/rn-dev-agent:send-feedback`
 


### PR DESCRIPTION
## Intent

Captain (2026-09-06): "Improve current readme, take it from marketing perspective as well."

Captain (2026-09-06, follow-up): "also don't include much advertisement for vercel rules check and so on as it's distract from the rn-dev-agent main goal"

Context the captain's ask refers to: the current `README.md` of rn-dev-agent, the public plugin repository (https://github.com/Lykhoyda/rn-dev-agent, MIT, 11 stars, published to the Claude Code and Codex plugin marketplaces, docs at https://lykhoyda.github.io/rn-dev-agent/). It is 353 lines: a one-paragraph pitch, a "Why this exists" list, quick start, the 8-phase pipeline table, three command tables, actions, MCP tool families, agents, app setup, architecture diagram, benchmarks, troubleshooting, a long security section, updating, development, license. It is accurate and complete but reads as an engineering reference: the value proposition is buried under tool inventories, the benchmarks and the 210x replay figure appear far down, and a first-time visitor has to read a lot before understanding what they get and why they should install it.

## What Changed

- Rewrote the README opening as a centered hero with a tagline, a "See it in 60 seconds" install-to-verified-feature walkthrough, and a "Coding agents ship blind" / "Is this for you?" framing, moving the 210× replay figure and headline benchmark results into an outcomes table near the top instead of far down the page.
- Restructured the rest of the page around the core loop: "How it works", "Commands", "Actions: the memory of the loop", and "Under the hood", with the MCP tool inventory, agents, install, app setup, security, benchmarks, and development notes condensed into collapsible sections and a closing call-to-action footer. Vercel rules-check mentions were trimmed so they no longer compete with the main pitch.
- Corrected stale content while restructuring: benchmark claims now match the benchmarks page (35 measured features, zero crashes and zero manual interventions, Glass UI row and expo-blur removed) and the Zustand doc anchors point at the current docs pages.

## Risk Assessment

✅ Low: Documentation-only rewrite of README.md; every quantitative claim, command name, tool count, version pin, asset path, and anchor was verified against the repository and docs, and the Vercel-rules mention is reduced to a single collapsed command-table row as the intent requires.

## Testing

No automated test covers README content and none was appropriate to add, so validation was manual and evidence-driven: I rendered both the base and target README with GitHub's markdown API, screenshotted the reviewer-visible surfaces, verified every in-page anchor, local file reference, external link, and numeric claim, and confirmed Vercel advertising was reduced to a single collapsed command row. Everything checked out and no defects were found.

![Target README hero (tagline, pitch, badges, demo GIF)](https://github.com/user-attachments/assets/30ecc5e0-b0a4-4dc4-a198-b63733771f84)
![Base README hero for comparison (badges first, Vercel link in bullets)](https://github.com/user-attachments/assets/60386897-5677-4b8e-9635-45f177e582b6)
![Target value-proposition table with 210x replay and zero-crash figures](https://github.com/user-attachments/assets/2e3c0f7d-88c8-4e2c-81d3-ae3695713475)
![Target How it works pipeline diagram](https://github.com/user-attachments/assets/5f92ea6d-3a93-4186-81f0-445fe86cc873)
![Target Commands section (vercel check only inside collapsed details)](https://github.com/user-attachments/assets/2a09c8f7-5cff-4b88-b3f9-2a515557755d)
![Target footer call to action](https://github.com/user-attachments/assets/1e3e1e71-fad0-4dd4-8522-074f746e647a)
<details>
<summary>Evidence: Full GitHub-rendered HTML of target README</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>README (target 71ad0f65)</title>
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown-light.min.css">
<style>body{margin:0;background:#fff}.markdown-body{box-sizing:border-box;max-width:1012px;margin:0 auto;padding:32px}</style>
</head><body><article class="markdown-body"><div align="center" dir="auto">
<h1 dir="auto">rn-dev-agent</h1>
<h3 dir="auto">Your agent writes the code. This proves it runs.</h3>
<p dir="auto">A plugin for <strong>Claude Code</strong> and <strong>Codex</strong> that turns your coding agent into a React Native<br>
development partner — one that reads your running app's component tree, store state, and<br>
navigation over the Chrome DevTools Protocol, taps real UI on iOS and Android, and <strong>records the<br>
evidence</strong> that the feature actually works.</p>
<p dir="auto"><a href="https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml"><img src="https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml/badge.svg" alt="CI" style="max-width: 100%;"></a><br>
<a href="https://lykhoyda.github.io/rn-dev-agent/" rel="nofollow"><img src="https://camo.githubusercontent.com/85ee46e1530e2ab35dcb6e59a531984834ae394507740235034834cf23933d2e/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f646f63732d6c796b686f7964612e6769746875622e696f253246726e2d2d6465762d2d6167656e742d626c7565" alt="Docs" data-canonical-src="https://img.shields.io/badge/docs-lykhoyda.github.io%2Frn--dev--agent-blue" style="max-width: 100%;"></a><br>
<a href="LICENSE"><img src="https://camo.githubusercontent.com/8bb50fd2278f18fc326bf71f6e88ca8f884f72f179d3e555e20ed30157190d0d/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4d49542d677265656e2e737667" alt="License: MIT" data-canonical-src="https://img.shields.io/badge/license-MIT-green.svg" style="max-width: 100%;"></a></p>
<p dir="auto"><strong><a href="#see-it-in-60-seconds">Get started</a></strong> · <strong><a href="https://lykhoyda.github.io/rn-dev-agent/" rel="nofollow">Documentation</a></strong> · <strong><a href="https://lykhoyda.github.io/rn-dev-agent/benchmarks/" rel="nofollow">Benchmarks</a></strong> · <strong><a href="https://lykhoyda.github.io/rn-dev-agent/tools/" rel="nofollow">Tools</a></strong></p>
</div>
<p dir="auto"><a target="_blank" rel="noopener noreferrer" href="apps/docs-site/public/observe/observe-demo.gif"><img src="file://~/.no-mistakes/worktrees/3df3fd656078/01M1WAKPN4YZFJ6H7BMS3HA9E9/apps/docs-site/public/observe/observe-demo.gif" alt="The observe UI live: inspecting a failed flow, checking store state, replaying a saved action, and running the locked E2E suite — all from the browser" data-animated-image="" style="max-width: 100%;"></a></p>
<hr>
<h2 dir="auto">See it in 60 seconds</h2>
<pre lang="text" class="notranslate"><code class="notranslate"># 1. Install (Claude Code — Codex below)
/plugin marketplace add Lykhoyda/rn-dev-agent
/plugin install rn-dev-agent@rn-dev-agent
/reload-plugins
</code></pre>
<pre lang="text" class="notranslate"><code class="notranslate"># 2. Onboard your app — checks the toolchain, writes the project config
/rn-dev-agent:setup

# 3. Ask for a feature. Get it back verified on the simulator.
/rn-dev-agent:rn-feature-dev add a shopping cart with badge, item list, and checkout flow
</code></pre>
<p dir="auto">The agent explores your codebase, designs the change, implements it — then connects to the running<br>
app, navigates to the screen, checks the component tree and store state, taps through the flow, and<br>
saves the walk as a replayable test. You get working code <strong>and</strong> the proof.</p>
<p dir="auto">Codex users: replace <code class="notranslate">/rn-dev-agent:&lt;name&gt;</code> with <code class="notranslate">$rn-dev-agent:&lt;name&gt;</code>. <a href="#install">Install steps →</a></p>
<hr>
<h2 dir="auto">Coding agents ship blind</h2>
<p dir="auto">They are good at writing React Native code and bad at knowing whether it runs. This plugin closes<br>
that loop — and the numbers below come from real features built on a real Expo app, not synthetic<br>
benchmarks.</p>
<markdown-accessiblity-table><table role="table">
<thead>
<tr>
<th></th>
<th></th>
</tr>
</thead>
<tbody>
<tr>
<td><strong>Verified, not claimed</strong></td>
<td>After implementing, the agent connects over CDP, walks the screen, reads the component tree and store, exercises the interaction, and screenshots the result — before it says "done"</td>
</tr>
<tr>
<td><strong>210× faster replays</strong></td>
<td>A 3-step wizard that took ~14 min as an interactive walk replays in <strong>~4 s</strong> as a saved action. Average session time across the measured features dropped from ~12 min to ~4 min once actions existed</td>
</tr>
<tr>
<td><strong>Flows that repair themselves</strong></td>
<td>When a <code class="notranslate">testID</code> drifts, the saved action fuzzy-matches the live snapshot, patches its own YAML, and retries. Cosmetic drift is absorbed; genuinely broken product logic is surfaced, never auto-fixed</td>
</tr>
<tr>
<td><strong>Minutes, not sessions</strong></td>
<td>Simple features land in 3–5 min, complex multi-step flows in 11–25 min; heavy glass-UI work runs longer. <strong>Zero crashes across all 38 measured stories</strong></td>
</tr>
<tr>
<td><strong>iOS and Android, one contract</strong></td>
<td>In-tree XCTest and UiAutomator runners give real taps, typing, scrolling, and screenshots — shipped as prebuilt artifacts so first use skips the cold build</td>
</tr>
<tr>
<td><strong>Both hosts, full parity</strong></td>
<td>Claude Code: 16 slash commands + 11 skills + 5 agents. Codex: 27 native skills (16 workflow + 11 domain). The same 81 MCP tools on both</td>
</tr>
</tbody>
</table></markdown-accessiblity-table>
<p dir="auto"><a href="https://lykhoyda.github.io/rn-dev-agent/benchmarks/" rel="nofollow">Full benchmarks and methodology →</a></p>
<h2 dir="auto">Is this for you?</h2>
<p dir="auto"><strong>Yes, if</strong> you build React Native or Expo apps with a coding agent, you run an iOS Simulator or<br>
Android Emulator locally, and you are tired of reviewing changes that were never actually opened.<br>
It pays off most on apps with real navigation, real state, and flows you re-walk every session.</p>
<p dir="auto"><strong>Not yet, if</strong> you work on web-only React, have no local simulator or emulator, or need an agent<br>
pointed at production or store-signed builds — that last one is deliberately out of scope, see<br>
<a href="#security">Security</a>.</p>
<hr>
<h2 dir="auto">How it works</h2>
<pre class="notranslate"><code class="notranslate">  /rn-dev-agent:rn-feature-dev "&lt;what you want&gt;"
        │
        ├─ 1 Discover    understand the feature, plan the work
        ├─ 2 Explore     parallel agents map screens, store, navigation, conventions
        ├─ 3 Question    clarify edge cases, error states, data flow
        ├─ 4 Architect   design the change against your existing patterns
        ├─ 5 Implement   store, components, navigation, testIDs
        ├─ 5.5 VERIFY    ◀── CDP health · component tree · store state · interaction · screenshot
        ├─ 6 Review      parallel agents check correctness and RN conventions
        └─ 7 PROOF       ◀── rehearse off camera, persist the action, record a clean replay
                                                            │
                                    working code  +  video  +  screenshots  +  PR body
</code></pre>
<p dir="auto">Phase 5.5 is the one that makes the difference: nothing is reported as working until it has been<br>
observed working. Phase 7 rehearses first, so discovery fumbling never ends up in the recording.</p>
<p dir="auto"><a href="https://lykhoyda.github.io/rn-dev-agent/commands/rn-feature-dev/" rel="nofollow">The 8-phase pipeline in detail →</a></p>
<h2 dir="auto">Commands</h2>
<p dir="auto">Claude spelling shown. Codex has native parity for every row — use <code class="notranslate">$rn-dev-agent:&lt;name&gt;</code>

... [28004 bytes truncated] ...

">codex plugin list --json</code> and <code class="notranslate">/mcp verbose</code>; user-confirm <code class="notranslate">codex plugin add rn-dev-agent@rn-dev-agent --json</code>, then relaunch after external changes</td>
</tr>
<tr>
<td>Codex tools fail after upgrade</td>
<td><code class="notranslate">/mcp verbose</code> inspects only. Relaunch Codex for external/manual changes or legacy hosts; never kill another host's bridge</td>
</tr>
<tr>
<td>Blank white screen after many reloads</td>
<td>NativeWind stylesheet corruption after 5+ <code class="notranslate">cdp_reload</code> cycles — kill and restart Metro, relaunch the app</td>
</tr>
<tr>
<td><code class="notranslate">device_scroll</code> times out on Reanimated screens</td>
<td>A <code class="notranslate">waitForIdle</code> round-trip can deadlock against Reanimated worklets; scroll routes through the in-tree runner's HID synthesis instead. Ensure the runner is healthy via the device session</td>
</tr>
<tr>
<td>Legacy <code class="notranslate">AgentDeviceRunner</code> re-appears on iOS</td>
<td>Stale <code class="notranslate">~/.agent-device/daemon.json</code> respawns the upstream runner. The plugin terminates stale processes at session-open (opt out: <code class="notranslate">RN_DEVICE_KILL_LEGACY=0</code>); manual cleanup: <code class="notranslate">pkill -f AgentDeviceRunner &amp;&amp; rm -f ~/.agent-device/daemon.{json,lock}</code></td>
</tr>
<tr>
<td>iOS "rn-fast-runner did not become ready"</td>
<td>The runner self-build timed out or failed. In a source checkout, pre-build once: <code class="notranslate">cd packages/rn-fast-runner/RnFastRunner &amp;&amp; xcodebuild build-for-testing -project RnFastRunner.xcodeproj -scheme RnFastRunner -destination "platform=iOS Simulator,id=&lt;UDID&gt;" -derivedDataPath ../build/DerivedData</code></td>
</tr>
<tr>
<td><code class="notranslate">device_fill</code> reports <code class="notranslate">TEXT_ENTRY_UNVERIFIED</code></td>
<td>A fill attempt ran, but stable exact read-back could not prove the requested value. Check <code class="notranslate">meta.mutation</code>: retry from a fresh snapshot only when it is <code class="notranslate">none</code>; for <code class="notranslate">observed</code> or <code class="notranslate">possible</code>, read and rebind the field before correcting it so a blind retry cannot double-type</td>
</tr>
<tr>
<td>Need an intentional coordinate tap</td>
<td>Use <code class="notranslate">device_press({x, y})</code> (or a batch press step with <code class="notranslate">x</code>/<code class="notranslate">y</code>). With a visible iOS keyboard, raw coordinates are geometry-unknown: the keyboard is proven hidden before the one tap. Prefer fresh refs for normal UI controls</td>
</tr>
<tr>
<td>Native logs include another device/app</td>
<td>Reopen the exact device session. <code class="notranslate">collect_logs</code> pins Android to that session's adb serial and iOS to that simulator plus the current target-app PID; it fails closed when exact scope cannot be resolved. When the probe runs and proves the app is not running, the stream stays pinned to that simulator and reports <code class="notranslate">scopes.native_ios.process = app-not-running-device-scoped</code> so a crash trail is still captured</td>
</tr>
<tr>
<td>Want XCTest's stock idle-waits back</td>
<td>Kill the running runner (<code class="notranslate">pkill -f RnFastRunnerUITests</code>), set <code class="notranslate">RN_QUIESCENCE_BYPASS=0</code>, reopen the device session, and inspect the next device result's <code class="notranslate">meta.quiescenceBypass</code></td>
</tr>
<tr>
<td>Seeing <code class="notranslate">meta.reResolved</code> / <code class="notranslate">meta.noUiChange</code></td>
<td>Stale-ref healing at work; <code class="notranslate">meta.noUiChange</code> means the iOS tap was dispatched but changed nothing. Disable ref healing with <code class="notranslate">RN_SELF_HEAL=0</code> (<code class="notranslate">retryIfNoChange</code> is a deprecated no-op — taps are never replayed)</td>
</tr>
</tbody>
</table></markdown-accessiblity-table>
</details>
<p dir="auto"><a href="https://lykhoyda.github.io/rn-dev-agent/troubleshooting/" rel="nofollow">Full troubleshooting guide →</a></p>
<h2 dir="auto">Keeping up to date</h2>
<p dir="auto">Enable auto-update in the host plugin manager, or update manually:</p>
<pre lang="text" class="notranslate"><code class="notranslate">Claude: /plugin update rn-dev-agent@rn-dev-agent
        /reload-plugins
Codex:  codex plugin marketplace upgrade rn-dev-agent
        codex plugin add rn-dev-agent@rn-dev-agent --json
        # relaunch after this external mutation
</code></pre>
<p dir="auto">Release notes: <a href="https://github.com/Lykhoyda/rn-dev-agent/releases">GitHub Releases</a> · <a href="packages/rn-dev-agent-core/CHANGELOG.md">core changelog</a></p>
\<details>
<summary><strong>Development — building from source</strong></summary>
<p dir="auto">This is a Yarn workspace monorepo:</p>
<markdown-accessiblity-table><table role="table">
<thead>
<tr>
<th>Package</th>
<th>What it is</th>
</tr>
</thead>
<tbody>
<tr>
<td><code class="notranslate">packages/rn-dev-agent-core</code></td>
<td>The MCP server (CDP bridge, device control, actions, testing) — all TypeScript source and tests</td>
</tr>
<tr>
<td><code class="notranslate">packages/claude-plugin</code></td>
<td>Claude Code plugin package — manifest, commands, agents, skills, hooks, MCP registration</td>
</tr>
<tr>
<td><code class="notranslate">packages/codex-plugin</code></td>
<td>Codex plugin package — self-contained with bundled runtime</td>
</tr>
<tr>
<td><code class="notranslate">packages/shared-agent-knowledge</code></td>
<td>Source of truth both host packages are generated from</td>
</tr>
<tr>
<td><code class="notranslate">packages/rn-fast-runner</code></td>
<td>In-tree iOS XCTest device runner</td>
</tr>
<tr>
<td><code class="notranslate">packages/rn-android-runner</code></td>
<td>In-tree Android UiAutomator device runner</td>
</tr>
<tr>
<td><code class="notranslate">apps/docs-site</code></td>
<td>Astro Starlight docs → <a href="https://lykhoyda.github.io/rn-dev-agent/" rel="nofollow">lykhoyda.github.io/rn-dev-agent</a></td>
</tr>
</tbody>
</table></markdown-accessiblity-table>
<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">git clone https://github.com/Lykhoyda/rn-dev-agent.git
<span class="pl-c1">cd</span> rn-dev-agent
corepack <span class="pl-c1">enable</span>
corepack yarn install --immutable
corepack yarn build:host-runtimes   <span class="pl-c"><span class="pl-c">#</span> builds core + generates both host packages</span></pre></div>
<p dir="auto">Run locally: <code class="notranslate">claude --plugin-dir /path/to/rn-dev-agent</code> (Claude Code) or register<br>
<code class="notranslate">packages/codex-plugin</code> (Codex).</p>
<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">corepack yarn <span class="pl-c1">test</span>          <span class="pl-c"><span class="pl-c">#</span> complete unit-test suite</span>
corepack yarn lint          <span class="pl-c"><span class="pl-c">#</span> oxlint</span>
corepack yarn format:check  <span class="pl-c"><span class="pl-c">#</span> oxfmt</span></pre></div>
<p dir="auto">Versioning uses <a href="https://github.com/changesets/changesets">changesets</a>; every tool-surface change<br>
must update the golden registry (<code class="notranslate">node scripts/update-tool-registry.mjs</code>).</p>
</details>
<hr>
<div align="center" dir="auto">
<h3 dir="auto">Stop taking your agent's word for it.</h3>
<p dir="auto"><strong><a href="#see-it-in-60-seconds">Install it in 60 seconds →</a></strong></p>
<p dir="auto"><strong><a href="https://lykhoyda.github.io/rn-dev-agent/" rel="nofollow">Read the docs</a></strong> · <strong><a href="https://github.com/Lykhoyda/rn-dev-agent">Star the repo</a></strong> · <strong><a href="https://github.com/Lykhoyda/rn-dev-agent/issues/new">Report a bug</a></strong> or run <code class="notranslate">/rn-dev-agent:send-feedback</code></p>
<p dir="auto">Free · open source · MIT</p>
</div></article></body></html>
```
</details>
<details>
<summary>Evidence: External link check (28 URLs, all HTTP 200)</summary>

```text
200 https://github.com/Lykhoyda/rn-dev-agent
200 https://github.com/Lykhoyda/rn-dev-agent.git
200 https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml
200 https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml/badge.svg
200 https://github.com/Lykhoyda/rn-dev-agent/issues/new
200 https://github.com/Lykhoyda/rn-dev-agent/releases
200 https://github.com/changesets/changesets
200 https://github.com/devicelab-dev/maestro-runner
200 https://img.shields.io/badge/docs-lykhoyda.github.io%2Frn--dev--agent-blue
200 https://img.shields.io/badge/license-MIT-green.svg
200 https://lykhoyda.github.io/rn-dev-agent/
200 https://lykhoyda.github.io/rn-dev-agent/actions/
200 https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-architect/
200 https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-explorer/
200 https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-reviewer/
200 https://lykhoyda.github.io/rn-dev-agent/agents/rn-debugger/
200 https://lykhoyda.github.io/rn-dev-agent/agents/rn-tester/
200 https://lykhoyda.github.io/rn-dev-agent/architecture/
200 https://lykhoyda.github.io/rn-dev-agent/benchmarks/
200 https://lykhoyda.github.io/rn-dev-agent/best-practices/
200 https://lykhoyda.github.io/rn-dev-agent/commands/observe/
200 https://lykhoyda.github.io/rn-dev-agent/commands/observe/#security-posture
200 https://lykhoyda.github.io/rn-dev-agent/commands/rn-feature-dev/
200 https://lykhoyda.github.io/rn-dev-agent/getting-started/
200 https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line
200 https://lykhoyda.github.io/rn-dev-agent/session-authority/
200 https://lykhoyda.github.io/rn-dev-agent/tools/
200 https://lykhoyda.github.io/rn-dev-agent/troubleshooting/
```
</details>
<details>
<summary>Evidence: Vercel mentions and claim counts</summary>

```text
vercel mentions: base=2 target=1 (only `/rn-dev-agent:check-vercel-rules` row in collapsed table)
tool registry: 81 | claude commands: 16 | claude skills: 11 | claude agents: 5 | codex skills: 27
anchors: #see-it-in-60-seconds OK, #install OK, #security OK
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cf29434156415ead6e547f8ebc140f7e6840a78a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 9d9d5c05..71ad0f65` — confirmed the change is confined to README.md</code>
- <code>`grep -ic vercel` on base vs target README — 2 mentions reduced to 1, remaining one is a collapsed command-table row</code>
- <code>Verified README counts against the repo: `tool-registry.json` length (81), `ls packages/claude-plugin/{commands,skills,agents}` (16/11/5), `ls packages/codex-plugin/skills` (27)</code>
- `Checked existence of locally referenced files: observe-demo.gif, LICENSE, core CHANGELOG.md, tool-registry.json`
- <code>Rendered base and target README with `gh api markdown -X POST -f mode=gfm -F text=@README.md` and wrapped in github-markdown-css</code>
- <code>In-browser check via `chrome-devtools-axi eval` that anchors #see-it-in-60-seconds, #install, #security resolve to headings</code>
- `Captured screenshots of the target render (hero, value props, how-it-works, commands, footer CTA) and the base hero for comparison`
- <code>HTTP-checked all 28 external URLs in README with `curl -L -o /dev/null -w %{http_code}` — all 200</code>
- <code>`git status --porcelain` — worktree clean after testing</code>
</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `README.md:60` - The README headline table says &#34;Zero crashes across all 38 measured stories&#34; and the Benchmarks section claims 38 stories (35 Ralph Loop + 3 Liquid Glass) with a Glass UI row (27–90 min, 1 Metro restart). The authoritative benchmarks page (apps/docs-site/src/content/docs/benchmarks.mdx) documents only 35 features, states &#34;zero crashes and zero manual interventions across all 35 measured builds&#34;, and has no Liquid Glass / Glass UI row. The mismatch predates this change but the rewrite now promotes it above the fold as a marketing claim. Either add the 3 Liquid Glass stories to benchmarks.mdx (the owner) or drop them from the README; I could not verify the underlying data so I left the numbers untouched.
- ℹ️ `README.md:320` - README&#39;s &#34;What your app needs&#34; shows the raw `global.__ZUSTAND_STORES__` one-liner, while the linked getting-started page now recommends the setup-scaffolded `getBridge()?.registerStores(...)` call. The raw global is still read by the core (injected-helpers.ts) and hinted in the cdp_store_state tool description, so the README is not wrong, only a different path than the docs page. Judgment call on whether the README should switch to the bridge snippet; left as is.

🔧 Fix: align README benchmark claims with benchmarks page
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
