### PR TITLE
fix(core): print snapshot element refs as @eN and accept a copied eN

### DIFF
--- a/.changeset/align-element-ref-formats.md
+++ b/.changeset/align-element-ref-formats.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Print snapshot and find element refs as `@eN`, matching the pinned form the current frame authorises for press, and accept a copied bare `eN` at the argv boundary (GH #979).

--- a/apps/docs-site/src/content/docs/tools/device/device_press.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_press.mdx
@@ -11,7 +11,7 @@ Tap a UI element by its @ref from device_snapshot, or at explicit raw x/y coordi
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `ref` | `string` | No |  |  | Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y. |
+| `ref` | `string` | No |  |  | Snapshot element ref "@e3" ("e3" accepted). Omit when using x/y. |
 | `x` | `number` | No |  |  | Raw tap X coordinate; requires y and no ref |
 | `y` | `number` | No |  |  | Raw tap Y coordinate; requires x and no ref |
 | `doubleTap` | `boolean` | No |  |  | Use double-tap gesture |

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -10901,6 +10901,9 @@ function resolveScreenRect(entries) {
   }
   return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
 }
+function pinnedElementRef(ref) {
+  return /^e\d+$/.test(ref) ? `@${ref}` : ref;
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -29796,7 +29799,7 @@ import { execFile as execFileCb9 } from "node:child_process";
 import { promisify as promisify11 } from "node:util";
 function candidateFromNode(n) {
   return {
-    ref: n.ref,
+    ref: pinnedElementRef(n.ref),
     label: n.label,
     testID: n.identifier,
     type: n.type,
@@ -34582,7 +34585,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const center = isRefMapFresh() ? refCenter(ref) : null;
         if (!center) {
@@ -34620,7 +34623,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const flagArgs = cliArgs.slice(3);
       const delayRaw = optionValue(flagArgs, "--delay-ms");
@@ -34838,7 +34841,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const includeSystemUi = cliArgs.includes("--include-system-ui");
         const center = isRefMapFresh() ? refCenter(ref) : null;
@@ -34873,7 +34876,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const atX = optionValue(cliArgs, "--at-x");
       const atY = optionValue(cliArgs, "--at-y");
@@ -34919,7 +34922,8 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
       return args;
     }
     case "longpress": {
-      const [target, yOrDuration, durationMaybe] = positionals;
+      const [rawTarget, yOrDuration, durationMaybe] = positionals;
+      const target = rawTarget && pinnedElementRef(rawTarget);
       if (target?.startsWith("@")) {
         const duration3 = Number(yOrDuration);
         const center = isRefMapFresh() ? refCenter(target) : null;
@@ -35270,7 +35274,7 @@ function selfHealEnabled(env) {
   return v !== "0" && v !== "false";
 }
 function tapRetryPolicy(cliArgs, builtCommand, x, y, _opts) {
-  const ref = cliArgs[1];
+  const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
   const exactTarget = ref?.startsWith("@") ? getFreshRefTarget(ref) : null;
   const keyboardTarget = exactTarget?.snapshotElementType === "Key" || exactTarget?.snapshotElementType === "Keyboard" || cliArgs.includes(IME_KEY_FLAG);
   const verificationRequired = !keyboardTarget && RETRYABLE_TAP_COMMANDS.has(builtCommand) && !cliArgs.includes("--double-tap") && !cliArgs.includes("--count") && !cliArgs.includes("--hold-ms") && x !== void 0 && y !== void 0;
@@ -35345,7 +35349,8 @@ async function settleWithRetryIfNoChange(firstResult, _dispatch, ctx, policy, de
   return failClosed ? unverifiedInteractionResult(first.result, policy.targetKey, "no-ui-change") : flagNoUiChange(first.result, policy.targetKey);
 }
 function staleRefFail(ref, reason, cachedMetadata, candidates = []) {
-  const message = reason === "ambiguous" ? `Element at ref ${ref} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${ref} no longer hittable \u2014 UI re-rendered since snapshot`;
+  const pinned = pinnedElementRef(ref);
+  const message = reason === "ambiguous" ? `Element at ref ${pinned} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${pinned} no longer hittable \u2014 UI re-rendered since snapshot`;
   const hint = reason === "ambiguous" ? "Multiple elements share the cached identity. The ref-map was refreshed by this call \u2014 pick the intended ref from `candidates` and retry." : reason === "snapshot-failed" ? "Snapshot infrastructure failed during re-resolution. Check cdp_status / reopen the device session, then retry." : "Element not re-resolvable by identity (it changed or unmounted). Call device_snapshot action=snapshot and re-find the target.";
   return failResult(message, "STALE_REF", {
     cachedMetadata,
@@ -74629,6 +74634,7 @@ function createDeviceScreenshotHandler(_getClient) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/device-batch.js
+init_fast_runner_ref_map();
 var INTERACTIVE_A11Y_TYPES = /* @__PURE__ */ new Set([
   "Button",
   "TextField",
@@ -74661,7 +74667,7 @@ function salientizeSnapshotData(data) {
       continue;
     const entry = {};
     if (n.ref)
-      entry.ref = n.ref;
+      entry.ref = pinnedElementRef(String(n.ref));
     if (type)
       entry.type = type;
     if (typeof n.label === "string" && n.label)
@@ -74728,7 +74734,7 @@ async function resolveTestIDViaSnapshot(testID) {
 function ambiguousTestIDFail(testID, refs) {
   return failResult(`testID "${testID}" matches ${refs.length} elements \u2014 refusing to guess-tap`, "AMBIGUOUS_TESTID", {
     testID,
-    candidates: refs.slice(0, 5).map((r) => `@${r}`),
+    candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)),
     hint: "Make the testID unique, or target a specific @ref from device_snapshot instead."
   });
 }
@@ -74791,11 +74797,11 @@ async function executeStep(step, getClient2, abortSignal) {
           });
         }
         if (step.tap)
-          return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+          return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
         return okResult({
-          resolved: ref,
+          resolved: pinnedElementRef(ref),
           testID: step.testID,
-          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => `@${r}`) } : {},
+          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)) } : {},
           snapshotEnvelopePreviewBytes: envelope?.length ?? 0
         });
       }
@@ -74836,7 +74842,7 @@ async function executeStep(step, getClient2, abortSignal) {
             testID: step.testID
           });
         }
-        return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+        return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
       }
       if (step.ref) {
         const ref = step.ref.startsWith("@") ? step.ref : `@${step.ref}`;
@@ -96873,7 +96879,7 @@ trackedTool("device_find", 'Find a UI element by visible text and optionally int
   includeSystemUi: external_exports.boolean().optional().describe("Include Android system UI in matching (default false; may leave the app).")
 }, createDeviceFindHandler(getClient));
 trackedTool("device_press", 'Tap a UI element by its @ref from device_snapshot, or at explicit raw x/y coordinates. Exact raw control can operate without a managed Metro target and always labels meta.originAuthority as proven or not-proven; not-proven results are never strict source evidence. Pass exactly one target form. On iOS, a latest-snapshot Key/Keyboard ref is runner-validated against the current live keyboard and activated exactly once (meta.keyboardGuard="keyboard_target"); stale, forged, missing-keyboard, or raw-coordinate targets never receive that exemption. Ordinary app-content taps dismiss only through a safe native hide/dismiss control or optional JS tier, then refresh and uniquely re-resolve before one tap. Supports double-tap, repeated taps, long hold, and post-tap focus settle. Requires an open session. Stale ordinary app @refs self-heal by identity re-resolution (meta.reResolved); stale iOS Key/Keyboard refs refuse with KEYBOARD_TARGET_STALE and mutation:none. A command is never replayed after a possible dispatch; uncertain Android effects fail with one-attempt typed uncertainty. On Android the tap is scoped to the owned app window: a @ref belonging to another package (system navigation, IME, dialogs) is refused with OUTSIDE_APP_WINDOW \u2014 use device_find with includeSystemUi=true and action="click" for system UI.', {
-  ref: external_exports.string().optional().describe('Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y.'),
+  ref: external_exports.string().optional().describe('Snapshot element ref "@e3" ("e3" accepted). Omit when using x/y.'),
   x: external_exports.number().optional().describe("Raw tap X coordinate; requires y and no ref"),
   y: external_exports.number().optional().describe("Raw tap Y coordinate; requires x and no ref"),
   doubleTap: external_exports.boolean().optional().describe("Use double-tap gesture"),
@@ -97209,7 +97215,7 @@ trackedTool("device_batch", "Execute a sequence of exact-device UI interactions 
       "screenshot"
     ]).describe("Step action"),
     text: external_exports.string().optional().describe("(find) Visible text to match. (fill) Text to type into the field."),
-    ref: external_exports.string().optional().describe('(press/fill) Element ref from snapshot (e.g. "e5"). Beware: refs can go stale across step transitions; prefer testID for cross-step actions.'),
+    ref: external_exports.string().optional().describe('(press/fill) Snapshot ref "@e5" ("e5" accepted). Refs go stale across steps; prefer testID.'),
     x: external_exports.number().optional().describe("(press) Raw X coordinate; requires y and no ref/testID"),
     y: external_exports.number().optional().describe("(press) Raw Y coordinate; requires x and no ref/testID"),
     testID: external_exports.string().optional().describe("(find/press/fill) PREFERRED exact identity. Fill still requires text and calls the same exact-fill coordinator as device_fill."),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -20237,6 +20237,9 @@ function resolveScreenRect(entries) {
   }
   return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
 }
+function pinnedElementRef(ref) {
+  return /^e\d+$/.test(ref) ? `@${ref}` : ref;
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -27171,7 +27174,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const center = isRefMapFresh() ? refCenter(ref) : null;
         if (!center) {
@@ -27209,7 +27212,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const flagArgs = cliArgs.slice(3);
       const delayRaw = optionValue(flagArgs, "--delay-ms");
@@ -27427,7 +27430,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const includeSystemUi = cliArgs.includes("--include-system-ui");
         const center = isRefMapFresh() ? refCenter(ref) : null;
@@ -27462,7 +27465,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const atX = optionValue(cliArgs, "--at-x");
       const atY = optionValue(cliArgs, "--at-y");
@@ -27508,7 +27511,8 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
       return args;
     }
     case "longpress": {
-      const [target, yOrDuration, durationMaybe] = positionals;
+      const [rawTarget, yOrDuration, durationMaybe] = positionals;
+      const target = rawTarget && pinnedElementRef(rawTarget);
       if (target?.startsWith("@")) {
         const duration3 = Number(yOrDuration);
         const center = isRefMapFresh() ? refCenter(target) : null;
@@ -27859,7 +27863,7 @@ function selfHealEnabled(env) {
   return v !== "0" && v !== "false";
 }
 function tapRetryPolicy(cliArgs, builtCommand, x, y, _opts) {
-  const ref = cliArgs[1];
+  const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
   const exactTarget = ref?.startsWith("@") ? getFreshRefTarget(ref) : null;
   const keyboardTarget = exactTarget?.snapshotElementType === "Key" || exactTarget?.snapshotElementType === "Keyboard" || cliArgs.includes(IME_KEY_FLAG);
   const verificationRequired = !keyboardTarget && RETRYABLE_TAP_COMMANDS.has(builtCommand) && !cliArgs.includes("--double-tap") && !cliArgs.includes("--count") && !cliArgs.includes("--hold-ms") && x !== void 0 && y !== void 0;
@@ -27934,7 +27938,8 @@ async function settleWithRetryIfNoChange(firstResult, _dispatch, ctx, policy, de
   return failClosed ? unverifiedInteractionResult(first.result, policy.targetKey, "no-ui-change") : flagNoUiChange(first.result, policy.targetKey);
 }
 function staleRefFail(ref, reason, cachedMetadata, candidates = []) {
-  const message = reason === "ambiguous" ? `Element at ref ${ref} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${ref} no longer hittable \u2014 UI re-rendered since snapshot`;
+  const pinned = pinnedElementRef(ref);
+  const message = reason === "ambiguous" ? `Element at ref ${pinned} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${pinned} no longer hittable \u2014 UI re-rendered since snapshot`;
   const hint = reason === "ambiguous" ? "Multiple elements share the cached identity. The ref-map was refreshed by this call \u2014 pick the intended ref from `candidates` and retry." : reason === "snapshot-failed" ? "Snapshot infrastructure failed during re-resolution. Check cdp_status / reopen the device session, then retry." : "Element not re-resolvable by identity (it changed or unmounted). Call device_snapshot action=snapshot and re-find the target.";
   return failResult(message, "STALE_REF", {
     cachedMetadata,
@@ -31298,7 +31303,7 @@ import { execFile as execFileCb8 } from "node:child_process";
 import { promisify as promisify10 } from "node:util";
 function candidateFromNode(n) {
   return {
-    ref: n.ref,
+    ref: pinnedElementRef(n.ref),
     label: n.label,
     testID: n.identifier,
     type: n.type,
@@ -77313,7 +77318,7 @@ function salientizeSnapshotData(data) {
       continue;
     const entry = {};
     if (n.ref)
-      entry.ref = n.ref;
+      entry.ref = pinnedElementRef(String(n.ref));
     if (type)
       entry.type = type;
     if (typeof n.label === "string" && n.label)
@@ -77380,7 +77385,7 @@ async function resolveTestIDViaSnapshot(testID) {
 function ambiguousTestIDFail(testID, refs) {
   return failResult(`testID "${testID}" matches ${refs.length} elements \u2014 refusing to guess-tap`, "AMBIGUOUS_TESTID", {
     testID,
-    candidates: refs.slice(0, 5).map((r) => `@${r}`),
+    candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)),
     hint: "Make the testID unique, or target a specific @ref from device_snapshot instead."
   });
 }
@@ -77442,11 +77447,11 @@ async function executeStep(step, getClient2, abortSignal) {
           });
         }
         if (step.tap)
-          return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+          return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
         return okResult({
-          resolved: ref,
+          resolved: pinnedElementRef(ref),
           testID: step.testID,
-          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => `@${r}`) } : {},
+          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)) } : {},
           snapshotEnvelopePreviewBytes: envelope?.length ?? 0
         });
       }
@@ -77487,7 +77492,7 @@ async function executeStep(step, getClient2, abortSignal) {
             testID: step.testID
           });
         }
-        return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+        return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
       }
       if (step.ref) {
         const ref = step.ref.startsWith("@") ? step.ref : `@${step.ref}`;
@@ -77728,6 +77733,7 @@ var init_device_batch = __esm({
     init_utils();
     init_keyboard_guard();
     init_device_list();
+    init_fast_runner_ref_map();
     INTERACTIVE_A11Y_TYPES = /* @__PURE__ */ new Set([
       "Button",
       "TextField",
@@ -99361,7 +99367,7 @@ var init_index = __esm({
       includeSystemUi: external_exports.boolean().optional().describe("Include Android system UI in matching (default false; may leave the app).")
     }, createDeviceFindHandler(getClient));
     trackedTool("device_press", 'Tap a UI element by its @ref from device_snapshot, or at explicit raw x/y coordinates. Exact raw control can operate without a managed Metro target and always labels meta.originAuthority as proven or not-proven; not-proven results are never strict source evidence. Pass exactly one target form. On iOS, a latest-snapshot Key/Keyboard ref is runner-validated against the current live keyboard and activated exactly once (meta.keyboardGuard="keyboard_target"); stale, forged, missing-keyboard, or raw-coordinate targets never receive that exemption. Ordinary app-content taps dismiss only through a safe native hide/dismiss control or optional JS tier, then refresh and uniquely re-resolve before one tap. Supports double-tap, repeated taps, long hold, and post-tap focus settle. Requires an open session. Stale ordinary app @refs self-heal by identity re-resolution (meta.reResolved); stale iOS Key/Keyboard refs refuse with KEYBOARD_TARGET_STALE and mutation:none. A command is never replayed after a possible dispatch; uncertain Android effects fail with one-attempt typed uncertainty. On Android the tap is scoped to the owned app window: a @ref belonging to another package (system navigation, IME, dialogs) is refused with OUTSIDE_APP_WINDOW \u2014 use device_find with includeSystemUi=true and action="click" for system UI.', {
-      ref: external_exports.string().optional().describe('Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y.'),
+      ref: external_exports.string().optional().describe('Snapshot element ref "@e3" ("e3" accepted). Omit when using x/y.'),
       x: external_exports.number().optional().describe("Raw tap X coordinate; requires y and no ref"),
       y: external_exports.number().optional().describe("Raw tap Y coordinate; requires x and no ref"),
       doubleTap: external_exports.boolean().optional().describe("Use double-tap gesture"),
@@ -99613,7 +99619,7 @@ var init_index = __esm({
           "screenshot"
         ]).describe("Step action"),
         text: external_exports.string().optional().describe("(find) Visible text to match. (fill) Text to type into the field."),
-        ref: external_exports.string().optional().describe('(press/fill) Element ref from snapshot (e.g. "e5"). Beware: refs can go stale across step transitions; prefer testID for cross-step actions.'),
+        ref: external_exports.string().optional().describe('(press/fill) Snapshot ref "@e5" ("e5" accepted). Refs go stale across steps; prefer testID.'),
         x: external_exports.number().optional().describe("(press) Raw X coordinate; requires y and no ref/testID"),
         y: external_exports.number().optional().describe("(press) Raw Y coordinate; requires x and no ref/testID"),
         testID: external_exports.string().optional().describe("(find/press/fill) PREFERRED exact identity. Fill still requires text and calls the same exact-fill coordinator as device_fill."),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -10901,6 +10901,9 @@ function resolveScreenRect(entries) {
   }
   return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
 }
+function pinnedElementRef(ref) {
+  return /^e\d+$/.test(ref) ? `@${ref}` : ref;
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -29796,7 +29799,7 @@ import { execFile as execFileCb9 } from "node:child_process";
 import { promisify as promisify11 } from "node:util";
 function candidateFromNode(n) {
   return {
-    ref: n.ref,
+    ref: pinnedElementRef(n.ref),
     label: n.label,
     testID: n.identifier,
     type: n.type,
@@ -34582,7 +34585,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const center = isRefMapFresh() ? refCenter(ref) : null;
         if (!center) {
@@ -34620,7 +34623,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const flagArgs = cliArgs.slice(3);
       const delayRaw = optionValue(flagArgs, "--delay-ms");
@@ -34838,7 +34841,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const includeSystemUi = cliArgs.includes("--include-system-ui");
         const center = isRefMapFresh() ? refCenter(ref) : null;
@@ -34873,7 +34876,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const atX = optionValue(cliArgs, "--at-x");
       const atY = optionValue(cliArgs, "--at-y");
@@ -34919,7 +34922,8 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
       return args;
     }
     case "longpress": {
-      const [target, yOrDuration, durationMaybe] = positionals;
+      const [rawTarget, yOrDuration, durationMaybe] = positionals;
+      const target = rawTarget && pinnedElementRef(rawTarget);
       if (target?.startsWith("@")) {
         const duration3 = Number(yOrDuration);
         const center = isRefMapFresh() ? refCenter(target) : null;
@@ -35270,7 +35274,7 @@ function selfHealEnabled(env) {
   return v !== "0" && v !== "false";
 }
 function tapRetryPolicy(cliArgs, builtCommand, x, y, _opts) {
-  const ref = cliArgs[1];
+  const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
   const exactTarget = ref?.startsWith("@") ? getFreshRefTarget(ref) : null;
   const keyboardTarget = exactTarget?.snapshotElementType === "Key" || exactTarget?.snapshotElementType === "Keyboard" || cliArgs.includes(IME_KEY_FLAG);
   const verificationRequired = !keyboardTarget && RETRYABLE_TAP_COMMANDS.has(builtCommand) && !cliArgs.includes("--double-tap") && !cliArgs.includes("--count") && !cliArgs.includes("--hold-ms") && x !== void 0 && y !== void 0;
@@ -35345,7 +35349,8 @@ async function settleWithRetryIfNoChange(firstResult, _dispatch, ctx, policy, de
   return failClosed ? unverifiedInteractionResult(first.result, policy.targetKey, "no-ui-change") : flagNoUiChange(first.result, policy.targetKey);
 }
 function staleRefFail(ref, reason, cachedMetadata, candidates = []) {
-  const message = reason === "ambiguous" ? `Element at ref ${ref} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${ref} no longer hittable \u2014 UI re-rendered since snapshot`;
+  const pinned = pinnedElementRef(ref);
+  const message = reason === "ambiguous" ? `Element at ref ${pinned} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${pinned} no longer hittable \u2014 UI re-rendered since snapshot`;
   const hint = reason === "ambiguous" ? "Multiple elements share the cached identity. The ref-map was refreshed by this call \u2014 pick the intended ref from `candidates` and retry." : reason === "snapshot-failed" ? "Snapshot infrastructure failed during re-resolution. Check cdp_status / reopen the device session, then retry." : "Element not re-resolvable by identity (it changed or unmounted). Call device_snapshot action=snapshot and re-find the target.";
   return failResult(message, "STALE_REF", {
     cachedMetadata,
@@ -74629,6 +74634,7 @@ function createDeviceScreenshotHandler(_getClient) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/device-batch.js
+init_fast_runner_ref_map();
 var INTERACTIVE_A11Y_TYPES = /* @__PURE__ */ new Set([
   "Button",
   "TextField",
@@ -74661,7 +74667,7 @@ function salientizeSnapshotData(data) {
       continue;
     const entry = {};
     if (n.ref)
-      entry.ref = n.ref;
+      entry.ref = pinnedElementRef(String(n.ref));
     if (type)
       entry.type = type;
     if (typeof n.label === "string" && n.label)
@@ -74728,7 +74734,7 @@ async function resolveTestIDViaSnapshot(testID) {
 function ambiguousTestIDFail(testID, refs) {
   return failResult(`testID "${testID}" matches ${refs.length} elements \u2014 refusing to guess-tap`, "AMBIGUOUS_TESTID", {
     testID,
-    candidates: refs.slice(0, 5).map((r) => `@${r}`),
+    candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)),
     hint: "Make the testID unique, or target a specific @ref from device_snapshot instead."
   });
 }
@@ -74791,11 +74797,11 @@ async function executeStep(step, getClient2, abortSignal) {
           });
         }
         if (step.tap)
-          return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+          return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
         return okResult({
-          resolved: ref,
+          resolved: pinnedElementRef(ref),
           testID: step.testID,
-          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => `@${r}`) } : {},
+          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)) } : {},
           snapshotEnvelopePreviewBytes: envelope?.length ?? 0
         });
       }
@@ -74836,7 +74842,7 @@ async function executeStep(step, getClient2, abortSignal) {
             testID: step.testID
           });
         }
-        return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+        return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
       }
       if (step.ref) {
         const ref = step.ref.startsWith("@") ? step.ref : `@${step.ref}`;
@@ -96873,7 +96879,7 @@ trackedTool("device_find", 'Find a UI element by visible text and optionally int
   includeSystemUi: external_exports.boolean().optional().describe("Include Android system UI in matching (default false; may leave the app).")
 }, createDeviceFindHandler(getClient));
 trackedTool("device_press", 'Tap a UI element by its @ref from device_snapshot, or at explicit raw x/y coordinates. Exact raw control can operate without a managed Metro target and always labels meta.originAuthority as proven or not-proven; not-proven results are never strict source evidence. Pass exactly one target form. On iOS, a latest-snapshot Key/Keyboard ref is runner-validated against the current live keyboard and activated exactly once (meta.keyboardGuard="keyboard_target"); stale, forged, missing-keyboard, or raw-coordinate targets never receive that exemption. Ordinary app-content taps dismiss only through a safe native hide/dismiss control or optional JS tier, then refresh and uniquely re-resolve before one tap. Supports double-tap, repeated taps, long hold, and post-tap focus settle. Requires an open session. Stale ordinary app @refs self-heal by identity re-resolution (meta.reResolved); stale iOS Key/Keyboard refs refuse with KEYBOARD_TARGET_STALE and mutation:none. A command is never replayed after a possible dispatch; uncertain Android effects fail with one-attempt typed uncertainty. On Android the tap is scoped to the owned app window: a @ref belonging to another package (system navigation, IME, dialogs) is refused with OUTSIDE_APP_WINDOW \u2014 use device_find with includeSystemUi=true and action="click" for system UI.', {
-  ref: external_exports.string().optional().describe('Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y.'),
+  ref: external_exports.string().optional().describe('Snapshot element ref "@e3" ("e3" accepted). Omit when using x/y.'),
   x: external_exports.number().optional().describe("Raw tap X coordinate; requires y and no ref"),
   y: external_exports.number().optional().describe("Raw tap Y coordinate; requires x and no ref"),
   doubleTap: external_exports.boolean().optional().describe("Use double-tap gesture"),
@@ -97209,7 +97215,7 @@ trackedTool("device_batch", "Execute a sequence of exact-device UI interactions 
       "screenshot"
     ]).describe("Step action"),
     text: external_exports.string().optional().describe("(find) Visible text to match. (fill) Text to type into the field."),
-    ref: external_exports.string().optional().describe('(press/fill) Element ref from snapshot (e.g. "e5"). Beware: refs can go stale across step transitions; prefer testID for cross-step actions.'),
+    ref: external_exports.string().optional().describe('(press/fill) Snapshot ref "@e5" ("e5" accepted). Refs go stale across steps; prefer testID.'),
     x: external_exports.number().optional().describe("(press) Raw X coordinate; requires y and no ref/testID"),
     y: external_exports.number().optional().describe("(press) Raw Y coordinate; requires x and no ref/testID"),
     testID: external_exports.string().optional().describe("(find/press/fill) PREFERRED exact identity. Fill still requires text and calls the same exact-fill coordinator as device_fill."),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -20237,6 +20237,9 @@ function resolveScreenRect(entries) {
   }
   return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
 }
+function pinnedElementRef(ref) {
+  return /^e\d+$/.test(ref) ? `@${ref}` : ref;
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -27171,7 +27174,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const center = isRefMapFresh() ? refCenter(ref) : null;
         if (!center) {
@@ -27209,7 +27212,7 @@ function buildRunIOSArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const flagArgs = cliArgs.slice(3);
       const delayRaw = optionValue(flagArgs, "--delay-ms");
@@ -27427,7 +27430,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
   switch (cmd) {
     case "press":
     case "tap": {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith("@")) {
         const includeSystemUi = cliArgs.includes("--include-system-ui");
         const center = isRefMapFresh() ? refCenter(ref) : null;
@@ -27462,7 +27465,7 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
     }
     case "fill":
     case "type": {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? "";
       const atX = optionValue(cliArgs, "--at-x");
       const atY = optionValue(cliArgs, "--at-y");
@@ -27508,7 +27511,8 @@ function buildRunAndroidArgs(cliArgs, bundleId) {
       return args;
     }
     case "longpress": {
-      const [target, yOrDuration, durationMaybe] = positionals;
+      const [rawTarget, yOrDuration, durationMaybe] = positionals;
+      const target = rawTarget && pinnedElementRef(rawTarget);
       if (target?.startsWith("@")) {
         const duration3 = Number(yOrDuration);
         const center = isRefMapFresh() ? refCenter(target) : null;
@@ -27859,7 +27863,7 @@ function selfHealEnabled(env) {
   return v !== "0" && v !== "false";
 }
 function tapRetryPolicy(cliArgs, builtCommand, x, y, _opts) {
-  const ref = cliArgs[1];
+  const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
   const exactTarget = ref?.startsWith("@") ? getFreshRefTarget(ref) : null;
   const keyboardTarget = exactTarget?.snapshotElementType === "Key" || exactTarget?.snapshotElementType === "Keyboard" || cliArgs.includes(IME_KEY_FLAG);
   const verificationRequired = !keyboardTarget && RETRYABLE_TAP_COMMANDS.has(builtCommand) && !cliArgs.includes("--double-tap") && !cliArgs.includes("--count") && !cliArgs.includes("--hold-ms") && x !== void 0 && y !== void 0;
@@ -27934,7 +27938,8 @@ async function settleWithRetryIfNoChange(firstResult, _dispatch, ctx, policy, de
   return failClosed ? unverifiedInteractionResult(first.result, policy.targetKey, "no-ui-change") : flagNoUiChange(first.result, policy.targetKey);
 }
 function staleRefFail(ref, reason, cachedMetadata, candidates = []) {
-  const message = reason === "ambiguous" ? `Element at ref ${ref} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${ref} no longer hittable \u2014 UI re-rendered since snapshot`;
+  const pinned = pinnedElementRef(ref);
+  const message = reason === "ambiguous" ? `Element at ref ${pinned} is stale and re-resolution matched ${candidates.length} elements \u2014 refusing to guess-tap` : `Element at ref ${pinned} no longer hittable \u2014 UI re-rendered since snapshot`;
   const hint = reason === "ambiguous" ? "Multiple elements share the cached identity. The ref-map was refreshed by this call \u2014 pick the intended ref from `candidates` and retry." : reason === "snapshot-failed" ? "Snapshot infrastructure failed during re-resolution. Check cdp_status / reopen the device session, then retry." : "Element not re-resolvable by identity (it changed or unmounted). Call device_snapshot action=snapshot and re-find the target.";
   return failResult(message, "STALE_REF", {
     cachedMetadata,
@@ -31298,7 +31303,7 @@ import { execFile as execFileCb8 } from "node:child_process";
 import { promisify as promisify10 } from "node:util";
 function candidateFromNode(n) {
   return {
-    ref: n.ref,
+    ref: pinnedElementRef(n.ref),
     label: n.label,
     testID: n.identifier,
     type: n.type,
@@ -77313,7 +77318,7 @@ function salientizeSnapshotData(data) {
       continue;
     const entry = {};
     if (n.ref)
-      entry.ref = n.ref;
+      entry.ref = pinnedElementRef(String(n.ref));
     if (type)
       entry.type = type;
     if (typeof n.label === "string" && n.label)
@@ -77380,7 +77385,7 @@ async function resolveTestIDViaSnapshot(testID) {
 function ambiguousTestIDFail(testID, refs) {
   return failResult(`testID "${testID}" matches ${refs.length} elements \u2014 refusing to guess-tap`, "AMBIGUOUS_TESTID", {
     testID,
-    candidates: refs.slice(0, 5).map((r) => `@${r}`),
+    candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)),
     hint: "Make the testID unique, or target a specific @ref from device_snapshot instead."
   });
 }
@@ -77442,11 +77447,11 @@ async function executeStep(step, getClient2, abortSignal) {
           });
         }
         if (step.tap)
-          return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+          return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
         return okResult({
-          resolved: ref,
+          resolved: pinnedElementRef(ref),
           testID: step.testID,
-          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => `@${r}`) } : {},
+          ...refs.length > 1 ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)) } : {},
           snapshotEnvelopePreviewBytes: envelope?.length ?? 0
         });
       }
@@ -77487,7 +77492,7 @@ async function executeStep(step, getClient2, abortSignal) {
             testID: step.testID
           });
         }
-        return guardedBatchPress(["press", `@${ref}`], stepSettleOpts(step), getClient2);
+        return guardedBatchPress(["press", pinnedElementRef(ref)], stepSettleOpts(step), getClient2);
       }
       if (step.ref) {
         const ref = step.ref.startsWith("@") ? step.ref : `@${step.ref}`;
@@ -77728,6 +77733,7 @@ var init_device_batch = __esm({
     init_utils();
     init_keyboard_guard();
     init_device_list();
+    init_fast_runner_ref_map();
     INTERACTIVE_A11Y_TYPES = /* @__PURE__ */ new Set([
       "Button",
       "TextField",
@@ -99361,7 +99367,7 @@ var init_index = __esm({
       includeSystemUi: external_exports.boolean().optional().describe("Include Android system UI in matching (default false; may leave the app).")
     }, createDeviceFindHandler(getClient));
     trackedTool("device_press", 'Tap a UI element by its @ref from device_snapshot, or at explicit raw x/y coordinates. Exact raw control can operate without a managed Metro target and always labels meta.originAuthority as proven or not-proven; not-proven results are never strict source evidence. Pass exactly one target form. On iOS, a latest-snapshot Key/Keyboard ref is runner-validated against the current live keyboard and activated exactly once (meta.keyboardGuard="keyboard_target"); stale, forged, missing-keyboard, or raw-coordinate targets never receive that exemption. Ordinary app-content taps dismiss only through a safe native hide/dismiss control or optional JS tier, then refresh and uniquely re-resolve before one tap. Supports double-tap, repeated taps, long hold, and post-tap focus settle. Requires an open session. Stale ordinary app @refs self-heal by identity re-resolution (meta.reResolved); stale iOS Key/Keyboard refs refuse with KEYBOARD_TARGET_STALE and mutation:none. A command is never replayed after a possible dispatch; uncertain Android effects fail with one-attempt typed uncertainty. On Android the tap is scoped to the owned app window: a @ref belonging to another package (system navigation, IME, dialogs) is refused with OUTSIDE_APP_WINDOW \u2014 use device_find with includeSystemUi=true and action="click" for system UI.', {
-      ref: external_exports.string().optional().describe('Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y.'),
+      ref: external_exports.string().optional().describe('Snapshot element ref "@e3" ("e3" accepted). Omit when using x/y.'),
       x: external_exports.number().optional().describe("Raw tap X coordinate; requires y and no ref"),
       y: external_exports.number().optional().describe("Raw tap Y coordinate; requires x and no ref"),
       doubleTap: external_exports.boolean().optional().describe("Use double-tap gesture"),
@@ -99613,7 +99619,7 @@ var init_index = __esm({
           "screenshot"
         ]).describe("Step action"),
         text: external_exports.string().optional().describe("(find) Visible text to match. (fill) Text to type into the field."),
-        ref: external_exports.string().optional().describe('(press/fill) Element ref from snapshot (e.g. "e5"). Beware: refs can go stale across step transitions; prefer testID for cross-step actions.'),
+        ref: external_exports.string().optional().describe('(press/fill) Snapshot ref "@e5" ("e5" accepted). Refs go stale across steps; prefer testID.'),
         x: external_exports.number().optional().describe("(press) Raw X coordinate; requires y and no ref/testID"),
         y: external_exports.number().optional().describe("(press) Raw Y coordinate; requires x and no ref/testID"),
         testID: external_exports.string().optional().describe("(find/press/fill) PREFERRED exact identity. Fill still requires text and calls the same exact-fill coordinator as device_fill."),

--- a/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
+++ b/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
@@ -42,6 +42,7 @@ import {
   getLastSnapshotHash,
   getLastSnapshotHashForPackage,
   invalidateLastSnapshotHash,
+  pinnedElementRef,
   type FlatNode,
   type RefreshOutcome,
 } from './fast-runner-ref-map.js';
@@ -507,7 +508,7 @@ export function buildRunIOSArgs(
   switch (cmd) {
     case 'press':
     case 'tap': {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith('@')) {
         const center = isRefMapFresh() ? refCenter(ref) : null;
         if (!center) {
@@ -561,7 +562,7 @@ export function buildRunIOSArgs(
       // attached by runNative's exact-target decoration), proves focus, and
       // types in one native operation. Shape: [verb, ref, rawText, ...flags] —
       // text is a raw slot so leading '-' values are never eaten as flags.
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? '';
       const flagArgs = cliArgs.slice(3);
       const delayRaw = optionValue(flagArgs, '--delay-ms');
@@ -806,7 +807,7 @@ export function buildRunAndroidArgs(
   switch (cmd) {
     case 'press':
     case 'tap': {
-      const ref = positionals[0];
+      const ref = positionals[0] && pinnedElementRef(positionals[0]);
       if (ref && ref.startsWith('@')) {
         const includeSystemUi = cliArgs.includes('--include-system-ui');
         const center = isRefMapFresh() ? refCenter(ref) : null;
@@ -845,7 +846,7 @@ export function buildRunAndroidArgs(
     }
     case 'fill':
     case 'type': {
-      const ref = cliArgs[1];
+      const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
       const text = cliArgs[2] ?? '';
       // Story 04 (#385) M2 guard — mirrors buildRunIOSArgs: a --at-x/--at-y pin
       // bypasses @ref re-resolution so a settle-refreshed map can't retarget.
@@ -902,7 +903,8 @@ export function buildRunAndroidArgs(
     }
 
     case 'longpress': {
-      const [target, yOrDuration, durationMaybe] = positionals;
+      const [rawTarget, yOrDuration, durationMaybe] = positionals;
+      const target = rawTarget && pinnedElementRef(rawTarget);
       if (target?.startsWith('@')) {
         const duration = Number(yOrDuration);
         // Final-review fix (#386): mirrors the tap/type cases in this same
@@ -1584,7 +1586,7 @@ export function tapRetryPolicy(
   y: number | undefined,
   _opts: { retryIfNoChange?: boolean },
 ): TapRetryPolicy {
-  const ref = cliArgs[1];
+  const ref = cliArgs[1] && pinnedElementRef(cliArgs[1]);
   const exactTarget = ref?.startsWith('@') ? getFreshRefTarget(ref) : null;
   // 'Key'/'Keyboard' are iOS XCUIElement type names; an Android IME key carries
   // a Java class name instead, so device_focus_next marks its verified
@@ -1737,10 +1739,11 @@ function staleRefFail(
   cachedMetadata: ReturnType<typeof getCachedMetadata>,
   candidates: FlatNode[] = [],
 ): ToolResult {
+  const pinned = pinnedElementRef(ref);
   const message =
     reason === 'ambiguous'
-      ? `Element at ref ${ref} is stale and re-resolution matched ${candidates.length} elements — refusing to guess-tap`
-      : `Element at ref ${ref} no longer hittable — UI re-rendered since snapshot`;
+      ? `Element at ref ${pinned} is stale and re-resolution matched ${candidates.length} elements — refusing to guess-tap`
+      : `Element at ref ${pinned} no longer hittable — UI re-rendered since snapshot`;
   const hint =
     reason === 'ambiguous'
       ? 'Multiple elements share the cached identity. The ref-map was refreshed by this call — pick the intended ref from `candidates` and retry.'

--- a/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
+++ b/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
@@ -203,6 +203,11 @@ export function updateRefMap(nodes: SnapshotNode[]): void {
   lastUpdated = Date.now();
 }
 
+/** Printed form for a snapshot id: `e3` → `@e3`; testIDs pass through. */
+export function pinnedElementRef(ref: string): string {
+  return /^e\d+$/.test(ref) ? `@${ref}` : ref;
+}
+
 export function lookupRef(ref: string): ElementRect | null {
   const clean = ref.startsWith('@') ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -2388,7 +2388,7 @@ trackedTool(
     ref: z
       .string()
       .optional()
-      .describe('Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y.'),
+      .describe('Snapshot element ref "@e3" ("e3" accepted). Omit when using x/y.'),
     x: z.number().optional().describe('Raw tap X coordinate; requires y and no ref'),
     y: z.number().optional().describe('Raw tap Y coordinate; requires x and no ref'),
     doubleTap: z.boolean().optional().describe('Use double-tap gesture'),
@@ -3161,7 +3161,7 @@ trackedTool(
             .string()
             .optional()
             .describe(
-              '(press/fill) Element ref from snapshot (e.g. "e5"). Beware: refs can go stale across step transitions; prefer testID for cross-step actions.',
+              '(press/fill) Snapshot ref "@e5" ("e5" accepted). Refs go stale across steps; prefer testID.',
             ),
           x: z
             .number()

--- a/packages/rn-dev-agent-core/src/tools/device-batch.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-batch.ts
@@ -16,6 +16,7 @@ import {
   surfaceKeyboardGuard,
 } from '../runners/keyboard-guard.js';
 import { captureAndResizeScreenshot } from './device-list.js';
+import { pinnedElementRef } from '../fast-runner-ref-map.js';
 
 export interface BatchStep {
   action:
@@ -126,7 +127,7 @@ export function salientizeSnapshotData(data: unknown): unknown {
     // alone would strand the agent ("nothing to tap here") on a real control.
     if (!INTERACTIVE_A11Y_TYPES.has(type) && !identifier) continue;
     const entry: Record<string, unknown> = {};
-    if (n.ref) entry.ref = n.ref;
+    if (n.ref) entry.ref = pinnedElementRef(String(n.ref));
     if (type) entry.type = type;
     if (typeof n.label === 'string' && n.label) entry.label = n.label;
     if (identifier) entry.identifier = identifier;
@@ -248,7 +249,7 @@ function ambiguousTestIDFail(testID: string, refs: string[]): ToolResult {
     'AMBIGUOUS_TESTID',
     {
       testID,
-      candidates: refs.slice(0, 5).map((r) => `@${r}`),
+      candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)),
       hint: 'Make the testID unique, or target a specific @ref from device_snapshot instead.',
     },
   );
@@ -353,12 +354,16 @@ async function executeStep(
           );
         }
         if (step.tap)
-          return guardedBatchPress(['press', `@${ref}`], stepSettleOpts(step), getClient);
+          return guardedBatchPress(
+            ['press', pinnedElementRef(ref)],
+            stepSettleOpts(step),
+            getClient,
+          );
         return okResult({
-          resolved: ref,
+          resolved: pinnedElementRef(ref),
           testID: step.testID,
           ...(refs.length > 1
-            ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => `@${r}`) }
+            ? { ambiguous: true, candidates: refs.slice(0, 5).map((r) => pinnedElementRef(r)) }
             : {}),
           snapshotEnvelopePreviewBytes: envelope?.length ?? 0,
         });
@@ -405,7 +410,7 @@ async function executeStep(
             },
           );
         }
-        return guardedBatchPress(['press', `@${ref}`], stepSettleOpts(step), getClient);
+        return guardedBatchPress(['press', pinnedElementRef(ref)], stepSettleOpts(step), getClient);
       }
       if (step.ref) {
         const ref = step.ref.startsWith('@') ? step.ref : `@${step.ref}`;

--- a/packages/rn-dev-agent-core/src/tools/device-interact.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-interact.ts
@@ -39,6 +39,7 @@ import {
   getCachedSignature,
   isRefMapFresh,
   lookupRef,
+  pinnedElementRef,
   refCenter,
   type RefSignature,
 } from '../fast-runner-ref-map.js';
@@ -76,7 +77,7 @@ export interface FindCandidate {
 
 function candidateFromNode(n: SnapshotNode): FindCandidate {
   return {
-    ref: n.ref,
+    ref: pinnedElementRef(n.ref),
     label: n.label,
     testID: n.identifier,
     type: n.type,

--- a/packages/rn-dev-agent-core/test/unit/gh-979-element-ref-format.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-979-element-ref-format.test.ts
@@ -1,0 +1,117 @@
+// GH #979: snapshot/find surfaces printed bare `eN` refs while candidate/diff
+// lists printed pinned `@eN`. A press of the bare form never attached the
+// frame-authorised pin fields, so the runner refused a copy-paste from the
+// surface agents read most often.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  clearRefMap,
+  pinnedElementRef,
+  updateRefMapFromFlat,
+} from '../../dist/fast-runner-ref-map.js';
+import {
+  buildRunAndroidArgs,
+  buildRunIOSArgs,
+  healStaleRef,
+  _setActiveSessionForTest,
+  _setRunAgentDeviceForTest,
+} from '../../dist/agent-device-wrapper.js';
+import { createDeviceBatchHandler, salientizeSnapshotData } from '../../dist/tools/device-batch.js';
+import { okResult } from '../../dist/utils.js';
+
+const node = {
+  ref: '@e0',
+  type: 'Button',
+  label: 'Save',
+  identifier: 'save-btn',
+  rect: { x: 10, y: 20, width: 100, height: 40 },
+};
+
+test('GH-979: pinnedElementRef is the single printed form', () => {
+  assert.equal(pinnedElementRef('e3'), '@e3');
+  assert.equal(pinnedElementRef('@e3'), '@e3');
+  assert.equal(pinnedElementRef('save-btn'), 'save-btn');
+});
+
+test('GH-979: a bare positional press attaches the same pin fields as @eN', () => {
+  clearRefMap();
+  updateRefMapFromFlat([node], { snapshotGeneration: 41, keyboardVisible: false });
+  const pinned = buildRunIOSArgs(['press', '@e0']);
+  const bare = buildRunIOSArgs(['press', 'e0']);
+  assert.equal(bare.snapshotGeneration, 41);
+  assert.deepEqual(bare, pinned);
+});
+
+test('GH-979: Android bare positional press resolves like @eN', () => {
+  clearRefMap();
+  updateRefMapFromFlat([node], { snapshotGeneration: 7, keyboardVisible: false });
+  assert.deepEqual(buildRunAndroidArgs(['press', 'e0']), buildRunAndroidArgs(['press', '@e0']));
+});
+
+test('GH-979: salient snapshot output pins bare positional refs', () => {
+  const out = salientizeSnapshotData({
+    nodes: [
+      { ref: 'e2', type: 'Button', label: 'Submit', identifier: 'submit-btn' },
+      { ref: '@e3', type: 'TextField', identifier: 'email' },
+    ],
+  }) as { nodes: Array<{ ref: string }> };
+  assert.deepEqual(
+    out.nodes.map((n) => n.ref),
+    ['@e2', '@e3'],
+  );
+});
+
+test('GH-979: batch find prints resolved in the same pinned form as candidates', async () => {
+  _setActiveSessionForTest({ platform: 'ios', deviceId: 'TEST-UDID', appId: 'com.test' });
+  _setRunAgentDeviceForTest(async (cliArgs) => {
+    if (cliArgs[0] === 'snapshot') {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              ok: true,
+              data: {
+                nodes: [
+                  { ref: '@e0', identifier: 'row' },
+                  { ref: '@e1', identifier: 'row' },
+                ],
+              },
+            }),
+          },
+        ],
+      };
+    }
+    return okResult({});
+  });
+  try {
+    const result = await createDeviceBatchHandler()({
+      steps: [{ action: 'find', testID: 'row' }],
+      screenshotOn: 'none',
+    });
+    const env = JSON.parse(result.content[0].text) as {
+      data?: { results?: Array<{ data?: { resolved?: string; candidates?: string[] } }> };
+      meta?: { results?: Array<{ data?: { resolved?: string; candidates?: string[] } }> };
+    };
+    const step = env.data?.results?.[0] ?? env.meta?.results?.[0];
+    assert.equal(step?.data?.resolved, '@e0');
+    assert.deepEqual(step?.data?.candidates, ['@e0', '@e1']);
+  } finally {
+    _setRunAgentDeviceForTest(null);
+    _setActiveSessionForTest(null);
+  }
+});
+
+test('GH-979: STALE_REF refusal echoes the pinned form even when the caller used eN', async () => {
+  clearRefMap();
+  updateRefMapFromFlat([node], { snapshotGeneration: 1, keyboardVisible: false });
+  const out = await healStaleRef('e0', async () =>
+    okResult({
+      nodes: [{ ref: '@e0', type: 'Other', rect: { x: 0, y: 0, width: 10, height: 10 } }],
+    }),
+  );
+  assert.equal(out.kind, 'failed');
+  const env = JSON.parse(out.result.content[0].text) as { code?: string; error?: string };
+  assert.equal(env.code, 'STALE_REF');
+  assert.match(env.error ?? '', /Element at ref @e0 /);
+});

--- a/packages/rn-dev-agent-core/test/unit/story-05-batch-unique-testid.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-05-batch-unique-testid.test.ts
@@ -104,7 +104,7 @@ test('batch find WITHOUT tap returns first match + ambiguity info instead of ref
     const env = JSON.parse(result.content[0].text);
     const step = batchResults(env)[0];
     assert.equal(step.success, true);
-    assert.equal(step.data.resolved, 'e0');
+    assert.equal(step.data.resolved, '@e0');
     assert.equal(step.data.ambiguous, true);
     assert.deepEqual(step.data.candidates, ['@e0', '@e1']);
   } finally {


### PR DESCRIPTION
## Summary
- Snapshot, find, and batch surfaces printed bare `eN` while candidates printed `@eN`, so a copied press never attached pin fields and was refused (~120 ms). Print `@eN` as the single agent-visible form.
- Accept a copied bare `eN` at the argv boundary so both spellings attach the same pin fields. `findRefByTestID` stays bare internally (GH #396 / `@@eN`).
- `STALE_REF` echoes `@eN` in the error even when the caller sent `e3`. Closes #979.

## Test plan
- [x] `node --test packages/rn-dev-agent-core/test/unit/gh-979-element-ref-format.test.ts` (print form, iOS/Android pin-field parity, salient nodes, batch `resolved`/`candidates`, STALE_REF echo)
- [x] Related: `story-05-batch-unique-testid`, `device-batch-testid`, heal/stale, `audit-b2-device-dispatch`
- [x] `corepack yarn format:check`
- [ ] CI `Build & Test` on this PR