### PR TITLE
ci: render GitHub release notes from the plugin changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,10 @@ jobs:
       - name: Core dist contract unit test
         run: bash scripts/test/check-core-dist-contract.test.sh
 
+      # Release notes for runner-artifacts.yml render from the plugin CHANGELOG.
+      - name: Release-notes renderer unit test
+        run: bash scripts/test/release-notes-from-changelog.test.sh
+
       # GH#377: convert-gif must mkdir an explicit gifPath's parent before ffmpeg.
       - name: record_proof convert-gif output-dir guard
         run: bash scripts/test/record-proof-convert-gif.test.sh

--- a/.github/workflows/runner-artifacts.yml
+++ b/.github/workflows/runner-artifacts.yml
@@ -140,9 +140,11 @@ jobs:
           VERSION: ${{ steps.v.outputs.version }}
         run: |
           if ! gh release view "v$VERSION" >/dev/null 2>&1; then
+            # Notes from this version's CHANGELOG section; falls back to the fixed one-liner.
+            bash scripts/release-notes-from-changelog.sh "$VERSION" > release-notes.md
             gh release create "v$VERSION" \
               --title "v$VERSION" \
-              --notes "Prebuilt runner artifacts for v$VERSION (rn-fast-runner iOS, rn-android-runner)."
+              --notes-file release-notes.md
           fi
 
   build-ios:

--- a/packages/rn-dev-agent-core/test/unit/runner-manifest-publication.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/runner-manifest-publication.test.ts
@@ -302,7 +302,11 @@ function createFixture(options: FixtureOptions = {}): Fixture {
   }
   // Unrelated tracked file: a manifest commit must never carry anything else.
   write(seed, 'README.md', 'unrelated repository content\n');
-  for (const script of ['build-runner-manifest.mts', 'runner-manifest-publication.mts']) {
+  for (const script of [
+    'build-runner-manifest.mts',
+    'runner-manifest-publication.mts',
+    'release-notes-from-changelog.sh',
+  ]) {
     mkdirSync(join(seed, 'scripts'), { recursive: true });
     copyFileSync(join(repoRoot, 'scripts', script), join(seed, 'scripts', script));
   }

--- a/scripts/release-notes-from-changelog.sh
+++ b/scripts/release-notes-from-changelog.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Render GitHub release notes for one plugin version from its CHANGELOG section.
+# Usage: release-notes-from-changelog.sh <version> [changelog-path]
+# Falls back to the fixed runner-artifacts one-liner when the section is missing
+# or empty, so a release is never blocked by the changelog.
+set -uo pipefail
+
+VERSION="${1:?usage: $0 <version> [changelog-path]}"
+CHANGELOG="${2:-$(cd "$(dirname "$0")/.." && pwd)/packages/claude-plugin/CHANGELOG.md}"
+FOOTER="Prebuilt runner artifacts for v$VERSION (rn-fast-runner iOS, rn-android-runner)."
+
+entries=""
+if [ -f "$CHANGELOG" ]; then
+  entries="$(awk -v v="$VERSION" '
+    /^## / { on = ($2 == v); next }
+    !on { next }
+    /^### / { next }
+    /^- Updated dependencies/ { skip = 1; next }
+    skip && /^[[:space:]]/ { next }
+    { skip = 0 }
+    /^- [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]: / { sub(/^- [0-9a-f]+: /, "- ") }
+    { line[++n] = $0; if ($0 ~ /[^[:space:]]/) { if (!first) first = n; last = n } }
+    END { for (i = first; i > 0 && i <= last; i++) print line[i] }
+  ' "$CHANGELOG")"
+fi
+
+if [ -z "$entries" ]; then
+  printf '%s\n' "$FOOTER"
+  exit 0
+fi
+
+printf "## What's changed\n\n%s\n\n%s\n" "$entries" "$FOOTER"

--- a/scripts/test/release-notes-from-changelog.test.sh
+++ b/scripts/test/release-notes-from-changelog.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Guard for the release-notes renderer used by runner-artifacts.yml: the
+# CHANGELOG section for a version must become the notes body (hashes and
+# "Updated dependencies" dropped), and a missing section must fall back to the
+# fixed one-liner so a release is never blocked.
+#
+# Run: bash scripts/test/release-notes-from-changelog.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/release-notes-from-changelog.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/CHANGELOG.md" <<'MD'
+# rn-dev-agent-plugin
+
+## 1.0.8
+
+### Patch Changes
+
+- f1d414e: Print snapshot and find element refs as `@eN`, matching the pinned form the current frame authorises for press, and accept a copied bare `eN` at the argv boundary (GH #979).
+- fa2cd21: Refuse managed-dev-client replay of flows that clear app state, and make login-path refusals name the actual next step.
+- bc86d57: Add the `rn-pr-qa` agent and `/qa-pr` workflow so a GitHub PR can be device-tested on iOS simulator, Android emulator, and physical device.
+- Updated dependencies [f1d414e]
+- Updated dependencies [fa2cd21]
+  - rn-dev-agent-core@1.0.8
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [b352043]
+  - rn-dev-agent-core@1.0.7
+MD
+
+expected_108="## What's changed
+
+- Print snapshot and find element refs as \`@eN\`, matching the pinned form the current frame authorises for press, and accept a copied bare \`eN\` at the argv boundary (GH #979).
+- Refuse managed-dev-client replay of flows that clear app state, and make login-path refusals name the actual next step.
+- Add the \`rn-pr-qa\` agent and \`/qa-pr\` workflow so a GitHub PR can be device-tested on iOS simulator, Android emulator, and physical device.
+
+Prebuilt runner artifacts for v1.0.8 (rn-fast-runner iOS, rn-android-runner)."
+
+fail=0
+check() {
+  local label="$1" version="$2" expected="$3" actual
+  actual="$(bash "$SCRIPT" "$version" "$tmp/CHANGELOG.md")"
+  if [ "$actual" = "$expected" ]; then
+    echo "ok: $label"
+  else
+    echo "FAIL: $label"
+    diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual")
+    fail=1
+  fi
+}
+
+check "1.0.8 section renders under What's changed with hashes and dependency noise dropped" \
+  1.0.8 "$expected_108"
+check "section with only dependency bumps falls back to the one-liner" \
+  1.0.7 "Prebuilt runner artifacts for v1.0.7 (rn-fast-runner iOS, rn-android-runner)."
+check "missing section falls back to the one-liner" \
+  2.0.0 "Prebuilt runner artifacts for v2.0.0 (rn-fast-runner iOS, rn-android-runner)."
+
+actual="$(bash "$SCRIPT" 1.0.8 "$tmp/does-not-exist.md")"
+if [ "$actual" = "Prebuilt runner artifacts for v1.0.8 (rn-fast-runner iOS, rn-android-runner)." ]; then
+  echo "ok: missing changelog file falls back to the one-liner"
+else
+  echo "FAIL: missing changelog file"; fail=1
+fi
+
+exit $fail


### PR DESCRIPTION
## Summary

Every GitHub release currently gets the same fixed one-liner. The runner-artifacts release-creation step now renders the notes from the version's section of `packages/claude-plugin/CHANGELOG.md` (which the changesets version PR already writes):

- commit hashes are stripped from each entry
- `Updated dependencies` lines and their nested items are dropped
- the rest is kept verbatim under a `## What's changed` heading
- the runner-artifacts line stays as the footer
- a missing or empty section falls back to today's one-liner, so release creation is never blocked

The idempotent create-if-missing behavior, the schedule sweep and all other jobs are unchanged. Existing releases are not touched. CI-only change, so no changeset per `scripts/require-changeset.sh`.

## Rendered notes for 1.0.8

What the new step produces from the current changelog:

```markdown
## What's changed

- Print snapshot and find element refs as `@eN`, matching the pinned form the current frame authorises for press, and accept a copied bare `eN` at the argv boundary (GH #979).
- Refuse managed-dev-client replay of flows that clear app state, and make login-path refusals name the actual next step.
- Add the `rn-pr-qa` agent and `/qa-pr` workflow so a GitHub PR can be device-tested on iOS simulator, Android emulator, and physical device.

Prebuilt runner artifacts for v1.0.8 (rn-fast-runner iOS, rn-android-runner).
```

## Check

`bash scripts/test/release-notes-from-changelog.test.sh` renders a fixture changelog (the real 1.0.8 section plus a dependencies-only 1.0.7 section) and asserts the exact body, both fallbacks, and the missing-file case. Wired into `ci.yml` next to the other script guards.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes runner-artifact release creation to render notes from the matching Claude plugin changelog section, while retaining the existing fixed footer as a fallback.

- Adds a changelog parser that removes Changesets headings, commit prefixes, and dependency-only entries.
- Passes the generated Markdown file to `gh release create`.
- Adds fixture-based renderer coverage to the required CI workflow.
- The implementation and test are introduced as Bash despite the repository's TypeScript-only rule for new source and tests.

<h3>Confidence Score: 4/5</h3>

The release behavior appears sound, but the explicit TypeScript-only requirement for new source and tests must be satisfied before merging.

The workflow has the required checkout, version, permissions, and fallback behavior, and the parser matches the repository's current changelog format; the remaining issue is the confirmed repository-rule violation in both newly added Bash files.

**Files Needing Attention:** scripts/release-notes-from-changelog.sh, scripts/test/release-notes-from-changelog.test.sh

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/release-notes-from-changelog.sh | Adds the changelog-section renderer and fallback behavior, but violates the repository requirement that new source be TypeScript. |
| scripts/test/release-notes-from-changelog.test.sh | Covers detailed rendering and fallback cases, but violates the repository requirement that new tests be TypeScript. |
| .github/workflows/runner-artifacts.yml | Generates a notes file before creating a missing runner-artifacts release. |
| .github/workflows/ci.yml | Adds the release-notes renderer test to the required CI job. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resolve plugin version] --> B{Release already exists?}
  B -- Yes --> C[Leave existing release unchanged]
  B -- No --> D[Read matching CHANGELOG section]
  D --> E{Renderable entries remain?}
  E -- Yes --> F[Strip commit hashes and dependency updates]
  F --> G[Write detailed notes with artifact footer]
  E -- No --> H[Write fixed artifact footer]
  G --> I[Create GitHub release]
  H --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: render GitHub release notes from the..."](https://github.com/lykhoyda/rn-dev-agent/commit/1f85dae4312bf6f36e370f64fbaaf2da85855b3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63062134)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/lykhoyda/rn-dev-agent/blob/main/AGENTS.md))

<!-- /greptile_comment -->