### PR TITLE
fix(core): keep the Expo dev-menu onboarding popup off managed dev-client launches

### DIFF
--- a/.changeset/dev-menu-onboarding-disabled-at-launch.md
+++ b/.changeset/dev-menu-onboarding-disabled-at-launch.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Append `disableOnboarding=1` to every managed dev-client launch and relaunch URL, and pass the Android dev-launcher no-auto-launch intent extra on managed `am start` launches, so the Expo dev menu never auto-opens over a native segment or after a reload on a fresh install (GH #1004).

--- a/.changeset/dev-menu-onboarding-disabled-at-launch.md
+++ b/.changeset/dev-menu-onboarding-disabled-at-launch.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-core": patch
 ---
 
-Append `disableOnboarding=1` to every managed dev-client launch and relaunch URL, and pass the Android dev-launcher no-auto-launch intent extra on managed `am start` launches, so the Expo dev menu never auto-opens over a native segment or after a reload on a fresh install (GH #1004).
+Managed dev-client launches and relaunches now keep the Expo dev-menu onboarding tutorial and launch-time sheet from auto-opening over a native segment or after a reload on a fresh install, on by default and configurable per target class with `autoHideDevMenu` in `.rn-agent/config.json` (GH #1004).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,9 @@ alive for such callers.
   `postInstall`, the embedded `rn-session-adapter.cjs` copy in
   `package-integration.ts`, `pinExactDevClient`, `relaunchSessionRuntime`) goes
   through `withDevMenuOnboardingDisabled` (`src/session/dev-client-onboarding.ts`),
-  and managed Android `am start` launches add `DEV_MENU_NO_AUTO_LAUNCH_EXTRAS`.
+  managed Android `am start` launches add `DEV_MENU_NO_AUTO_LAUNCH_EXTRAS`, and
+  managed iOS simulator launches first run `iosSimulatorDevMenuDefaultsArgs`; all
+  three are gated per target class by `resolveAutoHideDevMenu` (`autoHideDevMenu`).
   `EXPO_PACKAGER_PROXY_URL` and `managedMetroProxyUrl` stay unflagged: Expo CLI
   derives the manifest `hostUri` from them and a query there corrupts bundle URLs.
 - `managedMetroExitAttribution` (`src/session/managed-metro.ts`) runs in a later

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,13 @@ alive for such callers.
   mirrored in the generated adapter) are diagnostics on launch data; never
   reintroduce a pre-install manifest, port-parity, or origin-scan guard that can
   grant or deny authority.
+- Every dev-client launch or relaunch URL rn-dev-agent constructs (build-adapter
+  `postInstall`, the embedded `rn-session-adapter.cjs` copy in
+  `package-integration.ts`, `pinExactDevClient`, `relaunchSessionRuntime`) goes
+  through `withDevMenuOnboardingDisabled` (`src/session/dev-client-onboarding.ts`),
+  and managed Android `am start` launches add `DEV_MENU_NO_AUTO_LAUNCH_EXTRAS`.
+  `EXPO_PACKAGER_PROXY_URL` and `managedMetroProxyUrl` stay unflagged: Expo CLI
+  derives the manifest `hostUri` from them and a query there corrupts bundle URLs.
 - `managedMetroExitAttribution` (`src/session/managed-metro.ts`) runs in a later
   process than `startManagedMetro`, so it has none of the `credentialRedactions`
   the startup path builds from the managed child environment. It must therefore

--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -417,11 +417,14 @@ Use `cdp_reload` — triggers a full reload with automatic reconnect and target 
 navigation, take a fresh `device_snapshot`. If it reports
 `meta.foregroundSurface: "expo_dev_menu"`, call
 `cdp_dev_settings({ action: "hideDevMenu" })`, then take another fresh snapshot
-and require the app surface. This remedy is only for the Expo Developer Menu,
-not the React Native core dev menu, Expo `Development servers` picker, system
-dialogs, or app-owned native overlays. Follow `/rn-dev-agent:check-env` for
-their separate routes; never substitute coordinates, screen-wide label search,
-raw shell UI, or a generic native-window action.
+and require the app surface. Every managed launch and relaunch already
+disables the Expo dev-menu onboarding tutorial, so `hideDevMenu` is for
+gesture-opened menus and the one-time shows-at-launch menu only. This remedy
+is only for the Expo Developer Menu, not the React Native core dev menu, Expo
+`Development servers` picker, system dialogs, or app-owned native overlays.
+Follow `/rn-dev-agent:check-env` for their separate routes; never substitute
+coordinates, screen-wide label search, raw shell UI, or a generic
+native-window action.
 
 #### "I need to manage device permissions"
 - **Query:** `device_permission(action="query", permission="notifications")`

--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -417,9 +417,10 @@ Use `cdp_reload` — triggers a full reload with automatic reconnect and target 
 navigation, take a fresh `device_snapshot`. If it reports
 `meta.foregroundSurface: "expo_dev_menu"`, call
 `cdp_dev_settings({ action: "hideDevMenu" })`, then take another fresh snapshot
-and require the app surface. Every managed launch and relaunch already
-disables the Expo dev-menu onboarding tutorial, so `hideDevMenu` is for
-gesture-opened menus and the one-time shows-at-launch menu only. This remedy
+and require the app surface. With `autoHideDevMenu` on (the default in
+`.rn-agent/config.json`), every managed launch and relaunch already suppresses
+the Expo dev-menu onboarding tutorial and the launch-time menu sheet, so
+`hideDevMenu` is for gesture-opened menus. This remedy
 is only for the Expo Developer Menu, not the React Native core dev menu, Expo
 `Development servers` picker, system dialogs, or app-owned native overlays.
 Follow `/rn-dev-agent:check-env` for their separate routes; never substitute
@@ -607,6 +608,7 @@ the runner's settle engine.
 | Verifying against stale code with Metro running | `rn_session(action="status")`, then `cdp_status` | Session Metro or signed bundle does not match the worktree | Restart through the integrated package script and re-pin with `cdp_connect` |
 | `cdp_interact accessibilityLabel="..."` fails (label matching is fuzzy) | Prefer testID-keyed calls: `cdp_interact(testID="...")` or `device_batch` with `testID=` field. Fall back to `device_snapshot` + `device_press(ref="@eN")` only when no testID exists. | Label matching unreliable; testID matching is exact and fiber-tree-resolved | — |
 | "Disconnected due to opening a second DevTools window" / React Native DevTools keeps getting kicked | `RN_CDP_AUTOCONNECT` and `.rn-agent/config.json` | RN allows one debugger frontend per app; bridge auto-reconnects by default (agent-first) | Set `RN_CDP_AUTOCONNECT=0` or `.rn-agent/config.json` → `{ "cdp": { "autoConnect": false } }`. `cdp_status` stays passive; `cdp_connect` and gated CDP tools reclaim the authority-bound seat when needed. |
+| Expo dev-menu sheet or onboarding tutorial covers the app after a managed launch | `.rn-agent/config.json` → `autoHideDevMenu` | The setting is off for that target class (`simulators`: iOS simulators and Android emulators; `devices`: physical Android, a no-op on iPhones because no managed iOS device launch exists) | Remove the key or set `{ "autoHideDevMenu": true }` (or a per-target object such as `{ "autoHideDevMenu": { "simulators": true, "devices": false } }`), then relaunch through the managed path. `cdp_dev_settings(action="hideDevMenu")` closes a menu that is already open. |
 
 ### Authentication & Permission Pre-flight
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 13
 ---
 
-Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. For reload with auto-reconnect, use cdp_reload instead.
+Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.
 
 ## Parameters
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 13
 ---
 
-Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.
+Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. With autoHideDevMenu on (default in .rn-agent/config.json), managed launches and relaunches suppress the Expo dev-menu onboarding tutorial and launch-time menu sheet, so hideDevMenu is for gesture-opened menus. For reload with auto-reconnect, use cdp_reload instead.
 
 ## Parameters
 

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -42,6 +42,10 @@ Close React Native DevTools, Flipper, or Chrome DevTools — only one debugger c
 
 The bridge auto-reconnects by default and evicts the visual React Native DevTools from the single debugger seat. Set `RN_CDP_AUTOCONNECT=0` (or `.rn-agent/config.json` → `{ "cdp": { "autoConnect": false } }`) to let DevTools hold the seat — the bridge then connects only when a CDP tool runs. Full guide: [React Native DevTools coexistence](/rn-dev-agent/guides/devtools-coexistence/).
 
+### Expo dev-menu sheet or onboarding tutorial covers the app after a managed launch
+
+`autoHideDevMenu` in `.rn-agent/config.json` is off for that target class. It defaults to hidden on every target: managed launches add `disableOnboarding=1` to the launch URL, pass the Android `EXDevMenuDisableAutoLaunch` intent extra, and on iOS simulators persist `EXDevMenuShowsAtLaunch=NO` and `EXDevMenuIsOnboardingFinished=YES` before launching. Remove the key or set `{ "autoHideDevMenu": true }`, or a per-target object such as `{ "autoHideDevMenu": { "simulators": true, "devices": false } }` (`simulators`: iOS simulators and Android emulators; `devices`: physical Android, a no-op on iPhones). `cdp_dev_settings` with `hideDevMenu` closes a menu that is already open.
+
 ### CDP connection lost after reload
 
 This is normal. `cdp_reload` reconnects the authority-bound target within 15

--- a/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
@@ -417,11 +417,14 @@ Use `cdp_reload` — triggers a full reload with automatic reconnect and target 
 navigation, take a fresh `device_snapshot`. If it reports
 `meta.foregroundSurface: "expo_dev_menu"`, call
 `cdp_dev_settings({ action: "hideDevMenu" })`, then take another fresh snapshot
-and require the app surface. This remedy is only for the Expo Developer Menu,
-not the React Native core dev menu, Expo `Development servers` picker, system
-dialogs, or app-owned native overlays. Follow `/rn-dev-agent:check-env` for
-their separate routes; never substitute coordinates, screen-wide label search,
-raw shell UI, or a generic native-window action.
+and require the app surface. Every managed launch and relaunch already
+disables the Expo dev-menu onboarding tutorial, so `hideDevMenu` is for
+gesture-opened menus and the one-time shows-at-launch menu only. This remedy
+is only for the Expo Developer Menu, not the React Native core dev menu, Expo
+`Development servers` picker, system dialogs, or app-owned native overlays.
+Follow `/rn-dev-agent:check-env` for their separate routes; never substitute
+coordinates, screen-wide label search, raw shell UI, or a generic
+native-window action.
 
 #### "I need to manage device permissions"
 - **Query:** `device_permission(action="query", permission="notifications")`

--- a/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
@@ -417,9 +417,10 @@ Use `cdp_reload` — triggers a full reload with automatic reconnect and target 
 navigation, take a fresh `device_snapshot`. If it reports
 `meta.foregroundSurface: "expo_dev_menu"`, call
 `cdp_dev_settings({ action: "hideDevMenu" })`, then take another fresh snapshot
-and require the app surface. Every managed launch and relaunch already
-disables the Expo dev-menu onboarding tutorial, so `hideDevMenu` is for
-gesture-opened menus and the one-time shows-at-launch menu only. This remedy
+and require the app surface. With `autoHideDevMenu` on (the default in
+`.rn-agent/config.json`), every managed launch and relaunch already suppresses
+the Expo dev-menu onboarding tutorial and the launch-time menu sheet, so
+`hideDevMenu` is for gesture-opened menus. This remedy
 is only for the Expo Developer Menu, not the React Native core dev menu, Expo
 `Development servers` picker, system dialogs, or app-owned native overlays.
 Follow `/rn-dev-agent:check-env` for their separate routes; never substitute
@@ -607,6 +608,7 @@ the runner's settle engine.
 | Verifying against stale code with Metro running | `rn_session(action="status")`, then `cdp_status` | Session Metro or signed bundle does not match the worktree | Restart through the integrated package script and re-pin with `cdp_connect` |
 | `cdp_interact accessibilityLabel="..."` fails (label matching is fuzzy) | Prefer testID-keyed calls: `cdp_interact(testID="...")` or `device_batch` with `testID=` field. Fall back to `device_snapshot` + `device_press(ref="@eN")` only when no testID exists. | Label matching unreliable; testID matching is exact and fiber-tree-resolved | — |
 | "Disconnected due to opening a second DevTools window" / React Native DevTools keeps getting kicked | `RN_CDP_AUTOCONNECT` and `.rn-agent/config.json` | RN allows one debugger frontend per app; bridge auto-reconnects by default (agent-first) | Set `RN_CDP_AUTOCONNECT=0` or `.rn-agent/config.json` → `{ "cdp": { "autoConnect": false } }`. `cdp_status` stays passive; `cdp_connect` and gated CDP tools reclaim the authority-bound seat when needed. |
+| Expo dev-menu sheet or onboarding tutorial covers the app after a managed launch | `.rn-agent/config.json` → `autoHideDevMenu` | The setting is off for that target class (`simulators`: iOS simulators and Android emulators; `devices`: physical Android, a no-op on iPhones because no managed iOS device launch exists) | Remove the key or set `{ "autoHideDevMenu": true }` (or a per-target object such as `{ "autoHideDevMenu": { "simulators": true, "devices": false } }`), then relaunch through the managed path. `cdp_dev_settings(action="hideDevMenu")` closes a menu that is already open. |
 
 ### Authentication & Permission Pre-flight
 

--- a/packages/claude-plugin/commands/check-env.md
+++ b/packages/claude-plugin/commands/check-env.md
@@ -24,7 +24,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action` |
+| Expo first-run tutorial | Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/claude-plugin/commands/check-env.md
+++ b/packages/claude-plugin/commands/check-env.md
@@ -24,7 +24,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
+| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/claude-plugin/commands/check-env.md
+++ b/packages/claude-plugin/commands/check-env.md
@@ -24,7 +24,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
+| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. With `autoHideDevMenu` on (default in `.rn-agent/config.json`), every managed launch and relaunch prevents it and the launch-time menu sheet; if either still appears, the setting is off for that target class or the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/claude-plugin/commands/doctor.md
+++ b/packages/claude-plugin/commands/doctor.md
@@ -36,6 +36,8 @@ because mirroring has a screenshot fallback.
 For runner provenance, inspect the runner artifact/state metadata documented by
 `rn-setup`. For helpers, use a narrow gated CDP read. For CDP auto-reconnect,
 resolve `RN_CDP_AUTOCONNECT` over `.rn-agent/config.json`, then the default.
+In the same row, print the resolved `autoHideDevMenu` (`simulators`, `devices`,
+source `config` or `default`, default hidden on both), read-only.
 
 For plugin-version or Vercel-rule drift, report the documented command but do
 not execute it. Offline version checks do not fail the plugin.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -62864,6 +62864,29 @@ function assertStableExpoAndroidDevice(initial, immediatePreSpawn) {
   return immediatePreSpawn;
 }
 
+// packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js
+var DEV_CLIENT_HOST = "expo-development-client";
+var DEV_MENU_NO_AUTO_LAUNCH_EXTRAS = [
+  "--ez",
+  "EXDevMenuDisableAutoLaunch",
+  "true"
+];
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === DEV_CLIENT_HOST ? parsed.searchParams.get("url") : null;
+  if (inner !== null) {
+    parsed.searchParams.set("url", withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set("disableOnboarding", "1");
+  }
+  return parsed.toString();
+}
+
 // packages/rn-dev-agent-core/dist/session/build-adapter.js
 function conflict(flag) {
   throw new Error(`SESSION_BUILD_IDENTITY_CONFLICT: ${flag} contradicts the active session`);
@@ -63014,7 +63037,7 @@ function createBuildLaunchPlan(input) {
       input.session.deviceId,
       input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
       "--initialUrl",
-      managedMetroProxyUrl(input.session)
+      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
     ],
     timeoutMs: 3e4
   } : void 0;
@@ -69119,6 +69142,21 @@ function authorityBoundReverseTunnel(binding) {
     && reverse.local === exact
     && reverse.remote === exact;
 }
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === 'expo-development-client' ? parsed.searchParams.get('url') : null;
+  if (inner !== null) {
+    parsed.searchParams.set('url', withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set('disableOnboarding', '1');
+  }
+  return parsed.toString();
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -69294,9 +69332,10 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
+    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
-      ' with --initialUrl ' + expoProxyUrl + '\n'
+      ' with --initialUrl ' + launchUrl + '\n'
     );
     const startup = spawnSync('xcrun', [
       'simctl',
@@ -69305,7 +69344,7 @@ function managedMetroProxyUrl(binding) {
       session.deviceId,
       session.appId,
       '--initialUrl',
-      expoProxyUrl,
+      launchUrl,
     ], {
       cwd: process.cwd(),
       env: authorityEnvironment,
@@ -87005,7 +87044,7 @@ async function openIosDeeplink(url, deviceId) {
 function posixSingleQuote2(s) {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
-function androidDeeplinkCommandArgs(url, packageName, deviceId) {
+function androidDeeplinkCommandArgs(url, packageName, deviceId, extras = []) {
   if (!deviceId)
     throw new Error("DEVICE_AUTHORITY_MISMATCH: exact Android deviceId is required");
   const serial = ["-s", deviceId];
@@ -87018,7 +87057,8 @@ function androidDeeplinkCommandArgs(url, packageName, deviceId) {
     "-a",
     "android.intent.action.VIEW",
     "-d",
-    quotedUrl
+    quotedUrl,
+    ...extras
   ];
   if (packageName)
     args.push("-n", packageName);
@@ -95456,12 +95496,12 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? managedMetroProxyUrl(input) : void 0;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, input.devClientUrl, input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
@@ -96369,7 +96409,7 @@ async function pinSessionDevClient(status, options, commitBundle) {
         if (platform === "ios") {
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -96554,7 +96594,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      `http://127.0.0.1:${String(metroPort)}`
+      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -96563,7 +96603,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(boundDevClientUrl, void 0, deviceId),
+    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
     "-p",
     appId
   ]);
@@ -96969,7 +97009,7 @@ trackedTool("cdp_mmkv", `Read/write the app's MMKV storage from Hermes. Closes t
   type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
   instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
 }, createMmkvHandler(getClient));
-trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. For reload with auto-reconnect, use cdp_reload instead.", {
+trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
   action: external_exports.enum([
     "reload",
     "toggleInspector",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -23891,6 +23891,23 @@ function resolveAutoConnect(deps = {}) {
   }
   return { enabled: true, source: "default" };
 }
+function resolveAutoHideDevMenu(deps = {}) {
+  const raw = (deps.readConfig ?? readRnAgentConfig)()?.autoHideDevMenu;
+  if (typeof raw === "boolean")
+    return { simulators: raw, devices: raw, source: "config" };
+  if (isPlainConfigObject(raw) && [raw.simulators, raw.devices].every((flag) => flag === void 0 || typeof flag === "boolean")) {
+    return {
+      simulators: raw.simulators !== false,
+      devices: raw.devices !== false,
+      source: "config"
+    };
+  }
+  if (raw !== void 0 && !warnedBadAutoHideDevMenu) {
+    warnedBadAutoHideDevMenu = true;
+    logger.warn("CONFIG", `.rn-agent/config.json autoHideDevMenu must be a boolean or { simulators, devices } booleans (got ${JSON.stringify(raw)}) \u2014 using the default (hidden)`);
+  }
+  return { simulators: true, devices: true, source: "default" };
+}
 function parsePort(raw) {
   if (!raw)
     return void 0;
@@ -23942,7 +23959,10 @@ function resolveMirrorConfig(deps = {}) {
     return { enabled: cfgEnabled, fps, firstFrameTimeoutMs, source: "config" };
   return { enabled: true, fps, firstFrameTimeoutMs, source: "default" };
 }
-var warnedBadConfig, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
+function isPlainConfigObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+var warnedBadConfig, warnedBadAutoHideDevMenu, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
 var init_project_config = __esm({
   "packages/rn-dev-agent-core/dist/project-config.js"() {
     "use strict";
@@ -23950,6 +23970,7 @@ var init_project_config = __esm({
     init_logger();
     init_sources();
     warnedBadConfig = false;
+    warnedBadAutoHideDevMenu = false;
     DEFAULT_OBSERVE_PORT = 7333;
     DEFAULT_MIRROR_FPS = 20;
     MIRROR_FPS_MIN = 5;
@@ -62871,6 +62892,15 @@ var DEV_MENU_NO_AUTO_LAUNCH_EXTRAS = [
   "EXDevMenuDisableAutoLaunch",
   "true"
 ];
+function autoHidesDevMenu(platform, deviceId, setting = { simulators: true, devices: true }) {
+  return platform === "ios" || /^emulator-\d+$/.test(deviceId) ? setting.simulators : setting.devices;
+}
+function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
+  return [
+    ["EXDevMenuShowsAtLaunch", "NO"],
+    ["EXDevMenuIsOnboardingFinished", "YES"]
+  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+}
 function withDevMenuOnboardingDisabled(url) {
   let parsed;
   try {
@@ -62983,6 +63013,23 @@ function commandKind(command) {
     return "bare-android";
   return null;
 }
+function simulatorPostInstall(session2, appId, hideDevMenu) {
+  const proxyUrl = managedMetroProxyUrl(session2);
+  return {
+    before: hideDevMenu ? iosSimulatorDevMenuDefaultsArgs(session2.deviceId, appId).map((args) => ["xcrun", ...args]) : [],
+    command: [
+      "xcrun",
+      "simctl",
+      "launch",
+      "--terminate-running-process",
+      session2.deviceId,
+      appId,
+      "--initialUrl",
+      hideDevMenu ? withDevMenuOnboardingDisabled(proxyUrl) : proxyUrl
+    ],
+    timeoutMs: 3e4
+  };
+}
 function createBuildLaunchPlan(input) {
   const command = [...input.command];
   if (!input.session)
@@ -63028,19 +63075,7 @@ function createBuildLaunchPlan(input) {
     ...kind === "expo" && input.platform === "android" ? { ANDROID_SERIAL: input.session.deviceId } : {},
     ...kind === "expo" ? { EXPO_PACKAGER_PROXY_URL: managedMetroProxyUrl(input.session) } : {}
   };
-  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? {
-    command: [
-      "xcrun",
-      "simctl",
-      "launch",
-      "--terminate-running-process",
-      input.session.deviceId,
-      input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
-      "--initialUrl",
-      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
-    ],
-    timeoutMs: 3e4
-  } : void 0;
+  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? simulatorPostInstall(input.session, input.session.appId ?? conflict("appId is required for simulator Dev Client startup"), autoHidesDevMenu("ios", input.session.deviceId, input.autoHideDevMenu)) : void 0;
   return {
     mode: "session",
     command,
@@ -69157,6 +69192,18 @@ function withDevMenuOnboardingDisabled(url) {
   }
   return parsed.toString();
 }
+function autoHideDevMenuOnSimulators() {
+  let setting;
+  try {
+    setting = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.rn-agent', 'config.json'), 'utf8')).autoHideDevMenu;
+  } catch {
+    return true;
+  }
+  if (typeof setting === 'boolean') return setting;
+  const valid = setting !== null && typeof setting === 'object' && !Array.isArray(setting)
+    && [setting.simulators, setting.devices].every((flag) => flag === undefined || typeof flag === 'boolean');
+  return !valid || setting.simulators !== false;
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -69332,7 +69379,20 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
-    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
+    const hideDevMenu = autoHideDevMenuOnSimulators();
+    const launchUrl = hideDevMenu ? withDevMenuOnboardingDisabled(expoProxyUrl) : expoProxyUrl;
+    for (const [key, value] of hideDevMenu ? [['EXDevMenuShowsAtLaunch', 'NO'], ['EXDevMenuIsOnboardingFinished', 'YES']] : []) {
+      const written = spawnSync('xcrun', ['simctl', 'spawn', session.deviceId, 'defaults', 'write', session.appId, key, '-bool', value], {
+        cwd: process.cwd(),
+        env: authorityEnvironment,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      if (written.error || written.status !== 0) {
+        const detail = written.error?.message || String(written.stderr).trim() || 'defaults write failed';
+        failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: dev-menu defaults for ' + key + ' could not be written: ' + detail);
+      }
+    }
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
       ' with --initialUrl ' + launchUrl + '\n'
@@ -95496,16 +95556,18 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
+  const hideDevMenu = autoHidesDevMenu(input.platform, input.deviceId, input.autoHideDevMenu);
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? launchUrl(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, launchUrl(input.devClientUrl), input.appId, hideDevMenu);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
-    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget);
+    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget, hideDevMenu);
   } else {
     await dependencies.launchExactApp(input.platform, input.deviceId, input.appId);
   }
@@ -96403,13 +96465,16 @@ async function pinSessionDevClient(status, options, commitBundle) {
       metroPort: metro.port,
       runtimeKind,
       ...devClientUrl ? { devClientUrl } : {},
-      signerCapability: secret.signerCapability
+      signerCapability: secret.signerCapability,
+      autoHideDevMenu: sessionAutoHideDevMenu(status)
     }, {
-      openUrl: async (platform, deviceId, url) => {
+      openUrl: async (platform, deviceId, url, appId, hideDevMenu) => {
         if (platform === "ios") {
+          if (hideDevMenu)
+            await writeIosSimulatorDevMenuDefaults(deviceId, appId);
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -96431,7 +96496,9 @@ async function pinSessionDevClient(status, options, commitBundle) {
           ]);
         }
       },
-      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl) => {
+      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl, hideDevMenu) => {
+        if (hideDevMenu)
+          await writeIosSimulatorDevMenuDefaults(deviceId, appId);
         await execFileP("xcrun", [
           "simctl",
           "launch",
@@ -96581,12 +96648,26 @@ var isSessionRuntimeAbsent = createSessionRuntimeAbsenceProbe({
   listTargets: (metroPort) => getClient().listTargetsExact(metroPort),
   execute: (file, args, options) => execFileP(file, args, options)
 });
+function sessionAutoHideDevMenu(status) {
+  return resolveAutoHideDevMenu({
+    readConfig: () => readRnAgentConfig(String(status.source.appRoot))
+  });
+}
+async function writeIosSimulatorDevMenuDefaults(deviceId, appId) {
+  for (const args of iosSimulatorDevMenuDefaultsArgs(deviceId, appId)) {
+    await execFileP("xcrun", args);
+  }
+}
 async function relaunchSessionRuntime(status, stopApp = true) {
   const { platform, deviceId, appId, metroPort, devClientUrl: boundDevClientUrl } = resolveManagedRuntimeLaunchBinding(status);
+  const hideDevMenu = autoHidesDevMenu(platform, deviceId, sessionAutoHideDevMenu(status));
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
   if (platform === "ios") {
     const current = getClient();
     await current.disconnect();
     setClient(createClient(metroPort));
+    if (hideDevMenu)
+      await writeIosSimulatorDevMenuDefaults(deviceId, appId);
     await execFileP("xcrun", [
       "simctl",
       "launch",
@@ -96594,7 +96675,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
+      launchUrl(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -96603,7 +96684,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
+    ...androidDeeplinkCommandArgs(launchUrl(boundDevClientUrl), void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []),
     "-p",
     appId
   ]);
@@ -97009,7 +97090,7 @@ trackedTool("cdp_mmkv", `Read/write the app's MMKV storage from Hermes. Closes t
   type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
   instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
 }, createMmkvHandler(getClient));
-trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
+trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. With autoHideDevMenu on (default in .rn-agent/config.json), managed launches and relaunches suppress the Expo dev-menu onboarding tutorial and launch-time menu sheet, so hideDevMenu is for gesture-opened menus. For reload with auto-reconnect, use cdp_reload instead.", {
   action: external_exports.enum([
     "reload",
     "toggleInspector",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -62899,7 +62899,17 @@ function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
   return [
     ["EXDevMenuShowsAtLaunch", "NO"],
     ["EXDevMenuIsOnboardingFinished", "YES"]
-  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+  ].map(([key, value]) => [
+    "simctl",
+    "spawn",
+    deviceId,
+    "defaults",
+    "write",
+    appId,
+    key,
+    "-bool",
+    value
+  ]);
 }
 function withDevMenuOnboardingDisabled(url) {
   let parsed;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -13874,7 +13874,17 @@ function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
   return [
     ["EXDevMenuShowsAtLaunch", "NO"],
     ["EXDevMenuIsOnboardingFinished", "YES"]
-  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+  ].map(([key, value]) => [
+    "simctl",
+    "spawn",
+    deviceId,
+    "defaults",
+    "write",
+    appId,
+    key,
+    "-bool",
+    value
+  ]);
 }
 function withDevMenuOnboardingDisabled(url) {
   let parsed;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -13867,6 +13867,15 @@ var init_expo_android_device = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js
+function autoHidesDevMenu(platform, deviceId, setting = { simulators: true, devices: true }) {
+  return platform === "ios" || /^emulator-\d+$/.test(deviceId) ? setting.simulators : setting.devices;
+}
+function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
+  return [
+    ["EXDevMenuShowsAtLaunch", "NO"],
+    ["EXDevMenuIsOnboardingFinished", "YES"]
+  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+}
 function withDevMenuOnboardingDisabled(url) {
   let parsed;
   try {
@@ -13991,6 +14000,23 @@ function commandKind(command) {
     return "bare-android";
   return null;
 }
+function simulatorPostInstall(session2, appId, hideDevMenu) {
+  const proxyUrl = managedMetroProxyUrl(session2);
+  return {
+    before: hideDevMenu ? iosSimulatorDevMenuDefaultsArgs(session2.deviceId, appId).map((args) => ["xcrun", ...args]) : [],
+    command: [
+      "xcrun",
+      "simctl",
+      "launch",
+      "--terminate-running-process",
+      session2.deviceId,
+      appId,
+      "--initialUrl",
+      hideDevMenu ? withDevMenuOnboardingDisabled(proxyUrl) : proxyUrl
+    ],
+    timeoutMs: 3e4
+  };
+}
 function createBuildLaunchPlan(input) {
   const command = [...input.command];
   if (!input.session)
@@ -14036,19 +14062,7 @@ function createBuildLaunchPlan(input) {
     ...kind === "expo" && input.platform === "android" ? { ANDROID_SERIAL: input.session.deviceId } : {},
     ...kind === "expo" ? { EXPO_PACKAGER_PROXY_URL: managedMetroProxyUrl(input.session) } : {}
   };
-  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? {
-    command: [
-      "xcrun",
-      "simctl",
-      "launch",
-      "--terminate-running-process",
-      input.session.deviceId,
-      input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
-      "--initialUrl",
-      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
-    ],
-    timeoutMs: 3e4
-  } : void 0;
+  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? simulatorPostInstall(input.session, input.session.appId ?? conflict("appId is required for simulator Dev Client startup"), autoHidesDevMenu("ios", input.session.deviceId, input.autoHideDevMenu)) : void 0;
   return {
     mode: "session",
     command,
@@ -16355,6 +16369,23 @@ function resolveAutoConnect(deps = {}) {
   }
   return { enabled: true, source: "default" };
 }
+function resolveAutoHideDevMenu(deps = {}) {
+  const raw = (deps.readConfig ?? readRnAgentConfig)()?.autoHideDevMenu;
+  if (typeof raw === "boolean")
+    return { simulators: raw, devices: raw, source: "config" };
+  if (isPlainConfigObject(raw) && [raw.simulators, raw.devices].every((flag) => flag === void 0 || typeof flag === "boolean")) {
+    return {
+      simulators: raw.simulators !== false,
+      devices: raw.devices !== false,
+      source: "config"
+    };
+  }
+  if (raw !== void 0 && !warnedBadAutoHideDevMenu) {
+    warnedBadAutoHideDevMenu = true;
+    logger.warn("CONFIG", `.rn-agent/config.json autoHideDevMenu must be a boolean or { simulators, devices } booleans (got ${JSON.stringify(raw)}) \u2014 using the default (hidden)`);
+  }
+  return { simulators: true, devices: true, source: "default" };
+}
 function parsePort(raw) {
   if (!raw)
     return void 0;
@@ -16406,7 +16437,10 @@ function resolveMirrorConfig(deps = {}) {
     return { enabled: cfgEnabled, fps, firstFrameTimeoutMs, source: "config" };
   return { enabled: true, fps, firstFrameTimeoutMs, source: "default" };
 }
-var warnedBadConfig, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
+function isPlainConfigObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+var warnedBadConfig, warnedBadAutoHideDevMenu, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
 var init_project_config = __esm({
   "packages/rn-dev-agent-core/dist/project-config.js"() {
     "use strict";
@@ -16414,6 +16448,7 @@ var init_project_config = __esm({
     init_logger();
     init_sources();
     warnedBadConfig = false;
+    warnedBadAutoHideDevMenu = false;
     DEFAULT_OBSERVE_PORT = 7333;
     DEFAULT_MIRROR_FPS = 20;
     MIRROR_FPS_MIN = 5;
@@ -20066,6 +20101,18 @@ function withDevMenuOnboardingDisabled(url) {
   }
   return parsed.toString();
 }
+function autoHideDevMenuOnSimulators() {
+  let setting;
+  try {
+    setting = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.rn-agent', 'config.json'), 'utf8')).autoHideDevMenu;
+  } catch {
+    return true;
+  }
+  if (typeof setting === 'boolean') return setting;
+  const valid = setting !== null && typeof setting === 'object' && !Array.isArray(setting)
+    && [setting.simulators, setting.devices].every((flag) => flag === undefined || typeof flag === 'boolean');
+  return !valid || setting.simulators !== false;
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -20241,7 +20288,20 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
-    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
+    const hideDevMenu = autoHideDevMenuOnSimulators();
+    const launchUrl = hideDevMenu ? withDevMenuOnboardingDisabled(expoProxyUrl) : expoProxyUrl;
+    for (const [key, value] of hideDevMenu ? [['EXDevMenuShowsAtLaunch', 'NO'], ['EXDevMenuIsOnboardingFinished', 'YES']] : []) {
+      const written = spawnSync('xcrun', ['simctl', 'spawn', session.deviceId, 'defaults', 'write', session.appId, key, '-bool', value], {
+        cwd: process.cwd(),
+        env: authorityEnvironment,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      if (written.error || written.status !== 0) {
+        const detail = written.error?.message || String(written.stderr).trim() || 'defaults write failed';
+        failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: dev-menu defaults for ' + key + ' could not be written: ' + detail);
+      }
+    }
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
       ' with --initialUrl ' + launchUrl + '\n'
@@ -97696,16 +97756,18 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
+  const hideDevMenu = autoHidesDevMenu(input.platform, input.deviceId, input.autoHideDevMenu);
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? launchUrl(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, launchUrl(input.devClientUrl), input.appId, hideDevMenu);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
-    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget);
+    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget, hideDevMenu);
   } else {
     await dependencies.launchExactApp(input.platform, input.deviceId, input.appId);
   }
@@ -98244,13 +98306,16 @@ async function pinSessionDevClient(status, options, commitBundle) {
       metroPort: metro.port,
       runtimeKind,
       ...devClientUrl ? { devClientUrl } : {},
-      signerCapability: secret.signerCapability
+      signerCapability: secret.signerCapability,
+      autoHideDevMenu: sessionAutoHideDevMenu(status)
     }, {
-      openUrl: async (platform, deviceId, url) => {
+      openUrl: async (platform, deviceId, url, appId, hideDevMenu) => {
         if (platform === "ios") {
+          if (hideDevMenu)
+            await writeIosSimulatorDevMenuDefaults(deviceId, appId);
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -98272,7 +98337,9 @@ async function pinSessionDevClient(status, options, commitBundle) {
           ]);
         }
       },
-      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl) => {
+      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl, hideDevMenu) => {
+        if (hideDevMenu)
+          await writeIosSimulatorDevMenuDefaults(deviceId, appId);
         await execFileP("xcrun", [
           "simctl",
           "launch",
@@ -98411,12 +98478,26 @@ async function reconnectSessionRuntime(status, options) {
   const connection = await awaitWithSignal2(connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, readinessTimeoutMs));
   return stageAndroidRuntimeConnection(connection);
 }
+function sessionAutoHideDevMenu(status) {
+  return resolveAutoHideDevMenu({
+    readConfig: () => readRnAgentConfig(String(status.source.appRoot))
+  });
+}
+async function writeIosSimulatorDevMenuDefaults(deviceId, appId) {
+  for (const args of iosSimulatorDevMenuDefaultsArgs(deviceId, appId)) {
+    await execFileP("xcrun", args);
+  }
+}
 async function relaunchSessionRuntime(status, stopApp = true) {
   const { platform, deviceId, appId, metroPort, devClientUrl: boundDevClientUrl } = resolveManagedRuntimeLaunchBinding(status);
+  const hideDevMenu = autoHidesDevMenu(platform, deviceId, sessionAutoHideDevMenu(status));
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
   if (platform === "ios") {
     const current = getClient();
     await current.disconnect();
     setClient(createClient(metroPort));
+    if (hideDevMenu)
+      await writeIosSimulatorDevMenuDefaults(deviceId, appId);
     await execFileP("xcrun", [
       "simctl",
       "launch",
@@ -98424,7 +98505,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
+      launchUrl(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -98433,7 +98514,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
+    ...androidDeeplinkCommandArgs(launchUrl(boundDevClientUrl), void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []),
     "-p",
     appId
   ]);
@@ -99504,7 +99585,7 @@ var init_index = __esm({
       type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
       instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
     }, createMmkvHandler(getClient));
-    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
+    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. With autoHideDevMenu on (default in .rn-agent/config.json), managed launches and relaunches suppress the Expo dev-menu onboarding tutorial and launch-time menu sheet, so hideDevMenu is for gesture-opened menus. For reload with auto-reconnect, use cdp_reload instead.", {
       action: external_exports.enum([
         "reload",
         "toggleInspector",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -13866,6 +13866,35 @@ var init_expo_android_device = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === DEV_CLIENT_HOST ? parsed.searchParams.get("url") : null;
+  if (inner !== null) {
+    parsed.searchParams.set("url", withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set("disableOnboarding", "1");
+  }
+  return parsed.toString();
+}
+var DEV_CLIENT_HOST, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS;
+var init_dev_client_onboarding = __esm({
+  "packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js"() {
+    "use strict";
+    DEV_CLIENT_HOST = "expo-development-client";
+    DEV_MENU_NO_AUTO_LAUNCH_EXTRAS = [
+      "--ez",
+      "EXDevMenuDisableAutoLaunch",
+      "true"
+    ];
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/build-adapter.js
 function conflict(flag) {
   throw new Error(`SESSION_BUILD_IDENTITY_CONFLICT: ${flag} contradicts the active session`);
@@ -14016,7 +14045,7 @@ function createBuildLaunchPlan(input) {
       input.session.deviceId,
       input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
       "--initialUrl",
-      managedMetroProxyUrl(input.session)
+      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
     ],
     timeoutMs: 3e4
   } : void 0;
@@ -14031,6 +14060,7 @@ var init_build_adapter = __esm({
   "packages/rn-dev-agent-core/dist/session/build-adapter.js"() {
     "use strict";
     init_expo_android_device();
+    init_dev_client_onboarding();
   }
 });
 
@@ -20021,6 +20051,21 @@ function authorityBoundReverseTunnel(binding) {
     && reverse.local === exact
     && reverse.remote === exact;
 }
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === 'expo-development-client' ? parsed.searchParams.get('url') : null;
+  if (inner !== null) {
+    parsed.searchParams.set('url', withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set('disableOnboarding', '1');
+  }
+  return parsed.toString();
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -20196,9 +20241,10 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
+    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
-      ' with --initialUrl ' + expoProxyUrl + '\n'
+      ' with --initialUrl ' + launchUrl + '\n'
     );
     const startup = spawnSync('xcrun', [
       'simctl',
@@ -20207,7 +20253,7 @@ function managedMetroProxyUrl(binding) {
       session.deviceId,
       session.appId,
       '--initialUrl',
-      expoProxyUrl,
+      launchUrl,
     ], {
       cwd: process.cwd(),
       env: authorityEnvironment,
@@ -89248,7 +89294,7 @@ async function openIosDeeplink(url, deviceId) {
 function posixSingleQuote2(s) {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
-function androidDeeplinkCommandArgs(url, packageName, deviceId) {
+function androidDeeplinkCommandArgs(url, packageName, deviceId, extras = []) {
   if (!deviceId)
     throw new Error("DEVICE_AUTHORITY_MISMATCH: exact Android deviceId is required");
   const serial = ["-s", deviceId];
@@ -89261,7 +89307,8 @@ function androidDeeplinkCommandArgs(url, packageName, deviceId) {
     "-a",
     "android.intent.action.VIEW",
     "-d",
-    quotedUrl
+    quotedUrl,
+    ...extras
   ];
   if (packageName)
     args.push("-n", packageName);
@@ -97649,12 +97696,12 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? managedMetroProxyUrl(input) : void 0;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, input.devClientUrl, input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
@@ -97728,6 +97775,7 @@ var init_dev_client_authority = __esm({
   "packages/rn-dev-agent-core/dist/session/dev-client-authority.js"() {
     "use strict";
     init_build_adapter();
+    init_dev_client_onboarding();
     init_metro_authority();
   }
 });
@@ -98202,7 +98250,7 @@ async function pinSessionDevClient(status, options, commitBundle) {
         if (platform === "ios") {
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -98376,7 +98424,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      `http://127.0.0.1:${String(metroPort)}`
+      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -98385,7 +98433,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(boundDevClientUrl, void 0, deviceId),
+    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
     "-p",
     appId
   ]);
@@ -98663,6 +98711,7 @@ var init_index = __esm({
     init_device_session();
     init_device_session();
     init_session_runtime_absence();
+    init_dev_client_onboarding();
     init_device_interact();
     init_ios_runtime();
     init_ios_proof_router();
@@ -99455,7 +99504,7 @@ var init_index = __esm({
       type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
       instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
     }, createMmkvHandler(getClient));
-    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. For reload with auto-reconnect, use cdp_reload instead.", {
+    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
       action: external_exports.enum([
         "reload",
         "toggleInspector",

--- a/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
@@ -417,11 +417,14 @@ Use `cdp_reload` — triggers a full reload with automatic reconnect and target 
 navigation, take a fresh `device_snapshot`. If it reports
 `meta.foregroundSurface: "expo_dev_menu"`, call
 `cdp_dev_settings({ action: "hideDevMenu" })`, then take another fresh snapshot
-and require the app surface. This remedy is only for the Expo Developer Menu,
-not the React Native core dev menu, Expo `Development servers` picker, system
-dialogs, or app-owned native overlays. Follow `/rn-dev-agent:check-env` for
-their separate routes; never substitute coordinates, screen-wide label search,
-raw shell UI, or a generic native-window action.
+and require the app surface. Every managed launch and relaunch already
+disables the Expo dev-menu onboarding tutorial, so `hideDevMenu` is for
+gesture-opened menus and the one-time shows-at-launch menu only. This remedy
+is only for the Expo Developer Menu, not the React Native core dev menu, Expo
+`Development servers` picker, system dialogs, or app-owned native overlays.
+Follow `/rn-dev-agent:check-env` for their separate routes; never substitute
+coordinates, screen-wide label search, raw shell UI, or a generic
+native-window action.
 
 #### "I need to manage device permissions"
 - **Query:** `device_permission(action="query", permission="notifications")`

--- a/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
@@ -417,9 +417,10 @@ Use `cdp_reload` — triggers a full reload with automatic reconnect and target 
 navigation, take a fresh `device_snapshot`. If it reports
 `meta.foregroundSurface: "expo_dev_menu"`, call
 `cdp_dev_settings({ action: "hideDevMenu" })`, then take another fresh snapshot
-and require the app surface. Every managed launch and relaunch already
-disables the Expo dev-menu onboarding tutorial, so `hideDevMenu` is for
-gesture-opened menus and the one-time shows-at-launch menu only. This remedy
+and require the app surface. With `autoHideDevMenu` on (the default in
+`.rn-agent/config.json`), every managed launch and relaunch already suppresses
+the Expo dev-menu onboarding tutorial and the launch-time menu sheet, so
+`hideDevMenu` is for gesture-opened menus. This remedy
 is only for the Expo Developer Menu, not the React Native core dev menu, Expo
 `Development servers` picker, system dialogs, or app-owned native overlays.
 Follow `/rn-dev-agent:check-env` for their separate routes; never substitute
@@ -607,6 +608,7 @@ the runner's settle engine.
 | Verifying against stale code with Metro running | `rn_session(action="status")`, then `cdp_status` | Session Metro or signed bundle does not match the worktree | Restart through the integrated package script and re-pin with `cdp_connect` |
 | `cdp_interact accessibilityLabel="..."` fails (label matching is fuzzy) | Prefer testID-keyed calls: `cdp_interact(testID="...")` or `device_batch` with `testID=` field. Fall back to `device_snapshot` + `device_press(ref="@eN")` only when no testID exists. | Label matching unreliable; testID matching is exact and fiber-tree-resolved | — |
 | "Disconnected due to opening a second DevTools window" / React Native DevTools keeps getting kicked | `RN_CDP_AUTOCONNECT` and `.rn-agent/config.json` | RN allows one debugger frontend per app; bridge auto-reconnects by default (agent-first) | Set `RN_CDP_AUTOCONNECT=0` or `.rn-agent/config.json` → `{ "cdp": { "autoConnect": false } }`. `cdp_status` stays passive; `cdp_connect` and gated CDP tools reclaim the authority-bound seat when needed. |
+| Expo dev-menu sheet or onboarding tutorial covers the app after a managed launch | `.rn-agent/config.json` → `autoHideDevMenu` | The setting is off for that target class (`simulators`: iOS simulators and Android emulators; `devices`: physical Android, a no-op on iPhones because no managed iOS device launch exists) | Remove the key or set `{ "autoHideDevMenu": true }` (or a per-target object such as `{ "autoHideDevMenu": { "simulators": true, "devices": false } }`), then relaunch through the managed path. `cdp_dev_settings(action="hideDevMenu")` closes a menu that is already open. |
 
 ### Authentication & Permission Pre-flight
 

--- a/packages/codex-plugin/commands/check-env.md
+++ b/packages/codex-plugin/commands/check-env.md
@@ -26,7 +26,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action` |
+| Expo first-run tutorial | Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/codex-plugin/commands/check-env.md
+++ b/packages/codex-plugin/commands/check-env.md
@@ -26,7 +26,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
+| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/codex-plugin/commands/check-env.md
+++ b/packages/codex-plugin/commands/check-env.md
@@ -26,7 +26,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
+| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. With `autoHideDevMenu` on (default in `.rn-agent/config.json`), every managed launch and relaunch prevents it and the launch-time menu sheet; if either still appears, the setting is off for that target class or the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -62864,6 +62864,29 @@ function assertStableExpoAndroidDevice(initial, immediatePreSpawn) {
   return immediatePreSpawn;
 }
 
+// packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js
+var DEV_CLIENT_HOST = "expo-development-client";
+var DEV_MENU_NO_AUTO_LAUNCH_EXTRAS = [
+  "--ez",
+  "EXDevMenuDisableAutoLaunch",
+  "true"
+];
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === DEV_CLIENT_HOST ? parsed.searchParams.get("url") : null;
+  if (inner !== null) {
+    parsed.searchParams.set("url", withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set("disableOnboarding", "1");
+  }
+  return parsed.toString();
+}
+
 // packages/rn-dev-agent-core/dist/session/build-adapter.js
 function conflict(flag) {
   throw new Error(`SESSION_BUILD_IDENTITY_CONFLICT: ${flag} contradicts the active session`);
@@ -63014,7 +63037,7 @@ function createBuildLaunchPlan(input) {
       input.session.deviceId,
       input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
       "--initialUrl",
-      managedMetroProxyUrl(input.session)
+      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
     ],
     timeoutMs: 3e4
   } : void 0;
@@ -69119,6 +69142,21 @@ function authorityBoundReverseTunnel(binding) {
     && reverse.local === exact
     && reverse.remote === exact;
 }
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === 'expo-development-client' ? parsed.searchParams.get('url') : null;
+  if (inner !== null) {
+    parsed.searchParams.set('url', withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set('disableOnboarding', '1');
+  }
+  return parsed.toString();
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -69294,9 +69332,10 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
+    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
-      ' with --initialUrl ' + expoProxyUrl + '\n'
+      ' with --initialUrl ' + launchUrl + '\n'
     );
     const startup = spawnSync('xcrun', [
       'simctl',
@@ -69305,7 +69344,7 @@ function managedMetroProxyUrl(binding) {
       session.deviceId,
       session.appId,
       '--initialUrl',
-      expoProxyUrl,
+      launchUrl,
     ], {
       cwd: process.cwd(),
       env: authorityEnvironment,
@@ -87005,7 +87044,7 @@ async function openIosDeeplink(url, deviceId) {
 function posixSingleQuote2(s) {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
-function androidDeeplinkCommandArgs(url, packageName, deviceId) {
+function androidDeeplinkCommandArgs(url, packageName, deviceId, extras = []) {
   if (!deviceId)
     throw new Error("DEVICE_AUTHORITY_MISMATCH: exact Android deviceId is required");
   const serial = ["-s", deviceId];
@@ -87018,7 +87057,8 @@ function androidDeeplinkCommandArgs(url, packageName, deviceId) {
     "-a",
     "android.intent.action.VIEW",
     "-d",
-    quotedUrl
+    quotedUrl,
+    ...extras
   ];
   if (packageName)
     args.push("-n", packageName);
@@ -95456,12 +95496,12 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? managedMetroProxyUrl(input) : void 0;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, input.devClientUrl, input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
@@ -96369,7 +96409,7 @@ async function pinSessionDevClient(status, options, commitBundle) {
         if (platform === "ios") {
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -96554,7 +96594,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      `http://127.0.0.1:${String(metroPort)}`
+      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -96563,7 +96603,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(boundDevClientUrl, void 0, deviceId),
+    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
     "-p",
     appId
   ]);
@@ -96969,7 +97009,7 @@ trackedTool("cdp_mmkv", `Read/write the app's MMKV storage from Hermes. Closes t
   type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
   instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
 }, createMmkvHandler(getClient));
-trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. For reload with auto-reconnect, use cdp_reload instead.", {
+trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
   action: external_exports.enum([
     "reload",
     "toggleInspector",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -23891,6 +23891,23 @@ function resolveAutoConnect(deps = {}) {
   }
   return { enabled: true, source: "default" };
 }
+function resolveAutoHideDevMenu(deps = {}) {
+  const raw = (deps.readConfig ?? readRnAgentConfig)()?.autoHideDevMenu;
+  if (typeof raw === "boolean")
+    return { simulators: raw, devices: raw, source: "config" };
+  if (isPlainConfigObject(raw) && [raw.simulators, raw.devices].every((flag) => flag === void 0 || typeof flag === "boolean")) {
+    return {
+      simulators: raw.simulators !== false,
+      devices: raw.devices !== false,
+      source: "config"
+    };
+  }
+  if (raw !== void 0 && !warnedBadAutoHideDevMenu) {
+    warnedBadAutoHideDevMenu = true;
+    logger.warn("CONFIG", `.rn-agent/config.json autoHideDevMenu must be a boolean or { simulators, devices } booleans (got ${JSON.stringify(raw)}) \u2014 using the default (hidden)`);
+  }
+  return { simulators: true, devices: true, source: "default" };
+}
 function parsePort(raw) {
   if (!raw)
     return void 0;
@@ -23942,7 +23959,10 @@ function resolveMirrorConfig(deps = {}) {
     return { enabled: cfgEnabled, fps, firstFrameTimeoutMs, source: "config" };
   return { enabled: true, fps, firstFrameTimeoutMs, source: "default" };
 }
-var warnedBadConfig, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
+function isPlainConfigObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+var warnedBadConfig, warnedBadAutoHideDevMenu, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
 var init_project_config = __esm({
   "packages/rn-dev-agent-core/dist/project-config.js"() {
     "use strict";
@@ -23950,6 +23970,7 @@ var init_project_config = __esm({
     init_logger();
     init_sources();
     warnedBadConfig = false;
+    warnedBadAutoHideDevMenu = false;
     DEFAULT_OBSERVE_PORT = 7333;
     DEFAULT_MIRROR_FPS = 20;
     MIRROR_FPS_MIN = 5;
@@ -62871,6 +62892,15 @@ var DEV_MENU_NO_AUTO_LAUNCH_EXTRAS = [
   "EXDevMenuDisableAutoLaunch",
   "true"
 ];
+function autoHidesDevMenu(platform, deviceId, setting = { simulators: true, devices: true }) {
+  return platform === "ios" || /^emulator-\d+$/.test(deviceId) ? setting.simulators : setting.devices;
+}
+function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
+  return [
+    ["EXDevMenuShowsAtLaunch", "NO"],
+    ["EXDevMenuIsOnboardingFinished", "YES"]
+  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+}
 function withDevMenuOnboardingDisabled(url) {
   let parsed;
   try {
@@ -62983,6 +63013,23 @@ function commandKind(command) {
     return "bare-android";
   return null;
 }
+function simulatorPostInstall(session2, appId, hideDevMenu) {
+  const proxyUrl = managedMetroProxyUrl(session2);
+  return {
+    before: hideDevMenu ? iosSimulatorDevMenuDefaultsArgs(session2.deviceId, appId).map((args) => ["xcrun", ...args]) : [],
+    command: [
+      "xcrun",
+      "simctl",
+      "launch",
+      "--terminate-running-process",
+      session2.deviceId,
+      appId,
+      "--initialUrl",
+      hideDevMenu ? withDevMenuOnboardingDisabled(proxyUrl) : proxyUrl
+    ],
+    timeoutMs: 3e4
+  };
+}
 function createBuildLaunchPlan(input) {
   const command = [...input.command];
   if (!input.session)
@@ -63028,19 +63075,7 @@ function createBuildLaunchPlan(input) {
     ...kind === "expo" && input.platform === "android" ? { ANDROID_SERIAL: input.session.deviceId } : {},
     ...kind === "expo" ? { EXPO_PACKAGER_PROXY_URL: managedMetroProxyUrl(input.session) } : {}
   };
-  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? {
-    command: [
-      "xcrun",
-      "simctl",
-      "launch",
-      "--terminate-running-process",
-      input.session.deviceId,
-      input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
-      "--initialUrl",
-      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
-    ],
-    timeoutMs: 3e4
-  } : void 0;
+  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? simulatorPostInstall(input.session, input.session.appId ?? conflict("appId is required for simulator Dev Client startup"), autoHidesDevMenu("ios", input.session.deviceId, input.autoHideDevMenu)) : void 0;
   return {
     mode: "session",
     command,
@@ -69157,6 +69192,18 @@ function withDevMenuOnboardingDisabled(url) {
   }
   return parsed.toString();
 }
+function autoHideDevMenuOnSimulators() {
+  let setting;
+  try {
+    setting = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.rn-agent', 'config.json'), 'utf8')).autoHideDevMenu;
+  } catch {
+    return true;
+  }
+  if (typeof setting === 'boolean') return setting;
+  const valid = setting !== null && typeof setting === 'object' && !Array.isArray(setting)
+    && [setting.simulators, setting.devices].every((flag) => flag === undefined || typeof flag === 'boolean');
+  return !valid || setting.simulators !== false;
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -69332,7 +69379,20 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
-    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
+    const hideDevMenu = autoHideDevMenuOnSimulators();
+    const launchUrl = hideDevMenu ? withDevMenuOnboardingDisabled(expoProxyUrl) : expoProxyUrl;
+    for (const [key, value] of hideDevMenu ? [['EXDevMenuShowsAtLaunch', 'NO'], ['EXDevMenuIsOnboardingFinished', 'YES']] : []) {
+      const written = spawnSync('xcrun', ['simctl', 'spawn', session.deviceId, 'defaults', 'write', session.appId, key, '-bool', value], {
+        cwd: process.cwd(),
+        env: authorityEnvironment,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      if (written.error || written.status !== 0) {
+        const detail = written.error?.message || String(written.stderr).trim() || 'defaults write failed';
+        failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: dev-menu defaults for ' + key + ' could not be written: ' + detail);
+      }
+    }
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
       ' with --initialUrl ' + launchUrl + '\n'
@@ -95496,16 +95556,18 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
+  const hideDevMenu = autoHidesDevMenu(input.platform, input.deviceId, input.autoHideDevMenu);
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? launchUrl(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, launchUrl(input.devClientUrl), input.appId, hideDevMenu);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
-    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget);
+    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget, hideDevMenu);
   } else {
     await dependencies.launchExactApp(input.platform, input.deviceId, input.appId);
   }
@@ -96403,13 +96465,16 @@ async function pinSessionDevClient(status, options, commitBundle) {
       metroPort: metro.port,
       runtimeKind,
       ...devClientUrl ? { devClientUrl } : {},
-      signerCapability: secret.signerCapability
+      signerCapability: secret.signerCapability,
+      autoHideDevMenu: sessionAutoHideDevMenu(status)
     }, {
-      openUrl: async (platform, deviceId, url) => {
+      openUrl: async (platform, deviceId, url, appId, hideDevMenu) => {
         if (platform === "ios") {
+          if (hideDevMenu)
+            await writeIosSimulatorDevMenuDefaults(deviceId, appId);
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -96431,7 +96496,9 @@ async function pinSessionDevClient(status, options, commitBundle) {
           ]);
         }
       },
-      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl) => {
+      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl, hideDevMenu) => {
+        if (hideDevMenu)
+          await writeIosSimulatorDevMenuDefaults(deviceId, appId);
         await execFileP("xcrun", [
           "simctl",
           "launch",
@@ -96581,12 +96648,26 @@ var isSessionRuntimeAbsent = createSessionRuntimeAbsenceProbe({
   listTargets: (metroPort) => getClient().listTargetsExact(metroPort),
   execute: (file, args, options) => execFileP(file, args, options)
 });
+function sessionAutoHideDevMenu(status) {
+  return resolveAutoHideDevMenu({
+    readConfig: () => readRnAgentConfig(String(status.source.appRoot))
+  });
+}
+async function writeIosSimulatorDevMenuDefaults(deviceId, appId) {
+  for (const args of iosSimulatorDevMenuDefaultsArgs(deviceId, appId)) {
+    await execFileP("xcrun", args);
+  }
+}
 async function relaunchSessionRuntime(status, stopApp = true) {
   const { platform, deviceId, appId, metroPort, devClientUrl: boundDevClientUrl } = resolveManagedRuntimeLaunchBinding(status);
+  const hideDevMenu = autoHidesDevMenu(platform, deviceId, sessionAutoHideDevMenu(status));
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
   if (platform === "ios") {
     const current = getClient();
     await current.disconnect();
     setClient(createClient(metroPort));
+    if (hideDevMenu)
+      await writeIosSimulatorDevMenuDefaults(deviceId, appId);
     await execFileP("xcrun", [
       "simctl",
       "launch",
@@ -96594,7 +96675,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
+      launchUrl(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -96603,7 +96684,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
+    ...androidDeeplinkCommandArgs(launchUrl(boundDevClientUrl), void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []),
     "-p",
     appId
   ]);
@@ -97009,7 +97090,7 @@ trackedTool("cdp_mmkv", `Read/write the app's MMKV storage from Hermes. Closes t
   type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
   instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
 }, createMmkvHandler(getClient));
-trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
+trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. With autoHideDevMenu on (default in .rn-agent/config.json), managed launches and relaunches suppress the Expo dev-menu onboarding tutorial and launch-time menu sheet, so hideDevMenu is for gesture-opened menus. For reload with auto-reconnect, use cdp_reload instead.", {
   action: external_exports.enum([
     "reload",
     "toggleInspector",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -62899,7 +62899,17 @@ function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
   return [
     ["EXDevMenuShowsAtLaunch", "NO"],
     ["EXDevMenuIsOnboardingFinished", "YES"]
-  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+  ].map(([key, value]) => [
+    "simctl",
+    "spawn",
+    deviceId,
+    "defaults",
+    "write",
+    appId,
+    key,
+    "-bool",
+    value
+  ]);
 }
 function withDevMenuOnboardingDisabled(url) {
   let parsed;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -13874,7 +13874,17 @@ function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
   return [
     ["EXDevMenuShowsAtLaunch", "NO"],
     ["EXDevMenuIsOnboardingFinished", "YES"]
-  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+  ].map(([key, value]) => [
+    "simctl",
+    "spawn",
+    deviceId,
+    "defaults",
+    "write",
+    appId,
+    key,
+    "-bool",
+    value
+  ]);
 }
 function withDevMenuOnboardingDisabled(url) {
   let parsed;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -13867,6 +13867,15 @@ var init_expo_android_device = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js
+function autoHidesDevMenu(platform, deviceId, setting = { simulators: true, devices: true }) {
+  return platform === "ios" || /^emulator-\d+$/.test(deviceId) ? setting.simulators : setting.devices;
+}
+function iosSimulatorDevMenuDefaultsArgs(deviceId, appId) {
+  return [
+    ["EXDevMenuShowsAtLaunch", "NO"],
+    ["EXDevMenuIsOnboardingFinished", "YES"]
+  ].map(([key, value]) => ["simctl", "spawn", deviceId, "defaults", "write", appId, key, "-bool", value]);
+}
 function withDevMenuOnboardingDisabled(url) {
   let parsed;
   try {
@@ -13991,6 +14000,23 @@ function commandKind(command) {
     return "bare-android";
   return null;
 }
+function simulatorPostInstall(session2, appId, hideDevMenu) {
+  const proxyUrl = managedMetroProxyUrl(session2);
+  return {
+    before: hideDevMenu ? iosSimulatorDevMenuDefaultsArgs(session2.deviceId, appId).map((args) => ["xcrun", ...args]) : [],
+    command: [
+      "xcrun",
+      "simctl",
+      "launch",
+      "--terminate-running-process",
+      session2.deviceId,
+      appId,
+      "--initialUrl",
+      hideDevMenu ? withDevMenuOnboardingDisabled(proxyUrl) : proxyUrl
+    ],
+    timeoutMs: 3e4
+  };
+}
 function createBuildLaunchPlan(input) {
   const command = [...input.command];
   if (!input.session)
@@ -14036,19 +14062,7 @@ function createBuildLaunchPlan(input) {
     ...kind === "expo" && input.platform === "android" ? { ANDROID_SERIAL: input.session.deviceId } : {},
     ...kind === "expo" ? { EXPO_PACKAGER_PROXY_URL: managedMetroProxyUrl(input.session) } : {}
   };
-  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? {
-    command: [
-      "xcrun",
-      "simctl",
-      "launch",
-      "--terminate-running-process",
-      input.session.deviceId,
-      input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
-      "--initialUrl",
-      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
-    ],
-    timeoutMs: 3e4
-  } : void 0;
+  const postInstall = kind === "expo" && input.platform === "ios" && input.session.simulator === true ? simulatorPostInstall(input.session, input.session.appId ?? conflict("appId is required for simulator Dev Client startup"), autoHidesDevMenu("ios", input.session.deviceId, input.autoHideDevMenu)) : void 0;
   return {
     mode: "session",
     command,
@@ -16355,6 +16369,23 @@ function resolveAutoConnect(deps = {}) {
   }
   return { enabled: true, source: "default" };
 }
+function resolveAutoHideDevMenu(deps = {}) {
+  const raw = (deps.readConfig ?? readRnAgentConfig)()?.autoHideDevMenu;
+  if (typeof raw === "boolean")
+    return { simulators: raw, devices: raw, source: "config" };
+  if (isPlainConfigObject(raw) && [raw.simulators, raw.devices].every((flag) => flag === void 0 || typeof flag === "boolean")) {
+    return {
+      simulators: raw.simulators !== false,
+      devices: raw.devices !== false,
+      source: "config"
+    };
+  }
+  if (raw !== void 0 && !warnedBadAutoHideDevMenu) {
+    warnedBadAutoHideDevMenu = true;
+    logger.warn("CONFIG", `.rn-agent/config.json autoHideDevMenu must be a boolean or { simulators, devices } booleans (got ${JSON.stringify(raw)}) \u2014 using the default (hidden)`);
+  }
+  return { simulators: true, devices: true, source: "default" };
+}
 function parsePort(raw) {
   if (!raw)
     return void 0;
@@ -16406,7 +16437,10 @@ function resolveMirrorConfig(deps = {}) {
     return { enabled: cfgEnabled, fps, firstFrameTimeoutMs, source: "config" };
   return { enabled: true, fps, firstFrameTimeoutMs, source: "default" };
 }
-var warnedBadConfig, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
+function isPlainConfigObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+var warnedBadConfig, warnedBadAutoHideDevMenu, DEFAULT_OBSERVE_PORT, DEFAULT_MIRROR_FPS, MIRROR_FPS_MIN, MIRROR_FPS_MAX, MIRROR_FIRST_FRAME_TIMEOUT_MIN_MS, MIRROR_FIRST_FRAME_TIMEOUT_MAX_MS, SESSION_CLI_TIMEOUT_MS;
 var init_project_config = __esm({
   "packages/rn-dev-agent-core/dist/project-config.js"() {
     "use strict";
@@ -16414,6 +16448,7 @@ var init_project_config = __esm({
     init_logger();
     init_sources();
     warnedBadConfig = false;
+    warnedBadAutoHideDevMenu = false;
     DEFAULT_OBSERVE_PORT = 7333;
     DEFAULT_MIRROR_FPS = 20;
     MIRROR_FPS_MIN = 5;
@@ -20066,6 +20101,18 @@ function withDevMenuOnboardingDisabled(url) {
   }
   return parsed.toString();
 }
+function autoHideDevMenuOnSimulators() {
+  let setting;
+  try {
+    setting = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.rn-agent', 'config.json'), 'utf8')).autoHideDevMenu;
+  } catch {
+    return true;
+  }
+  if (typeof setting === 'boolean') return setting;
+  const valid = setting !== null && typeof setting === 'object' && !Array.isArray(setting)
+    && [setting.simulators, setting.devices].every((flag) => flag === undefined || typeof flag === 'boolean');
+  return !valid || setting.simulators !== false;
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -20241,7 +20288,20 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
-    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
+    const hideDevMenu = autoHideDevMenuOnSimulators();
+    const launchUrl = hideDevMenu ? withDevMenuOnboardingDisabled(expoProxyUrl) : expoProxyUrl;
+    for (const [key, value] of hideDevMenu ? [['EXDevMenuShowsAtLaunch', 'NO'], ['EXDevMenuIsOnboardingFinished', 'YES']] : []) {
+      const written = spawnSync('xcrun', ['simctl', 'spawn', session.deviceId, 'defaults', 'write', session.appId, key, '-bool', value], {
+        cwd: process.cwd(),
+        env: authorityEnvironment,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      if (written.error || written.status !== 0) {
+        const detail = written.error?.message || String(written.stderr).trim() || 'defaults write failed';
+        failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: dev-menu defaults for ' + key + ' could not be written: ' + detail);
+      }
+    }
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
       ' with --initialUrl ' + launchUrl + '\n'
@@ -97696,16 +97756,18 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
+  const hideDevMenu = autoHidesDevMenu(input.platform, input.deviceId, input.autoHideDevMenu);
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? launchUrl(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, launchUrl(input.devClientUrl), input.appId, hideDevMenu);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
-    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget);
+    await dependencies.launchExactAppWithInitialUrl(input.deviceId, input.appId, derivedIosExpoLaunchTarget, hideDevMenu);
   } else {
     await dependencies.launchExactApp(input.platform, input.deviceId, input.appId);
   }
@@ -98244,13 +98306,16 @@ async function pinSessionDevClient(status, options, commitBundle) {
       metroPort: metro.port,
       runtimeKind,
       ...devClientUrl ? { devClientUrl } : {},
-      signerCapability: secret.signerCapability
+      signerCapability: secret.signerCapability,
+      autoHideDevMenu: sessionAutoHideDevMenu(status)
     }, {
-      openUrl: async (platform, deviceId, url) => {
+      openUrl: async (platform, deviceId, url, appId, hideDevMenu) => {
         if (platform === "ios") {
+          if (hideDevMenu)
+            await writeIosSimulatorDevMenuDefaults(deviceId, appId);
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -98272,7 +98337,9 @@ async function pinSessionDevClient(status, options, commitBundle) {
           ]);
         }
       },
-      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl) => {
+      launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl, hideDevMenu) => {
+        if (hideDevMenu)
+          await writeIosSimulatorDevMenuDefaults(deviceId, appId);
         await execFileP("xcrun", [
           "simctl",
           "launch",
@@ -98411,12 +98478,26 @@ async function reconnectSessionRuntime(status, options) {
   const connection = await awaitWithSignal2(connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, readinessTimeoutMs));
   return stageAndroidRuntimeConnection(connection);
 }
+function sessionAutoHideDevMenu(status) {
+  return resolveAutoHideDevMenu({
+    readConfig: () => readRnAgentConfig(String(status.source.appRoot))
+  });
+}
+async function writeIosSimulatorDevMenuDefaults(deviceId, appId) {
+  for (const args of iosSimulatorDevMenuDefaultsArgs(deviceId, appId)) {
+    await execFileP("xcrun", args);
+  }
+}
 async function relaunchSessionRuntime(status, stopApp = true) {
   const { platform, deviceId, appId, metroPort, devClientUrl: boundDevClientUrl } = resolveManagedRuntimeLaunchBinding(status);
+  const hideDevMenu = autoHidesDevMenu(platform, deviceId, sessionAutoHideDevMenu(status));
+  const launchUrl = (url) => hideDevMenu ? withDevMenuOnboardingDisabled(url) : url;
   if (platform === "ios") {
     const current = getClient();
     await current.disconnect();
     setClient(createClient(metroPort));
+    if (hideDevMenu)
+      await writeIosSimulatorDevMenuDefaults(deviceId, appId);
     await execFileP("xcrun", [
       "simctl",
       "launch",
@@ -98424,7 +98505,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
+      launchUrl(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -98433,7 +98514,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
+    ...androidDeeplinkCommandArgs(launchUrl(boundDevClientUrl), void 0, deviceId, hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : []),
     "-p",
     appId
   ]);
@@ -99504,7 +99585,7 @@ var init_index = __esm({
       type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
       instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
     }, createMmkvHandler(getClient));
-    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
+    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. With autoHideDevMenu on (default in .rn-agent/config.json), managed launches and relaunches suppress the Expo dev-menu onboarding tutorial and launch-time menu sheet, so hideDevMenu is for gesture-opened menus. For reload with auto-reconnect, use cdp_reload instead.", {
       action: external_exports.enum([
         "reload",
         "toggleInspector",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -13866,6 +13866,35 @@ var init_expo_android_device = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === DEV_CLIENT_HOST ? parsed.searchParams.get("url") : null;
+  if (inner !== null) {
+    parsed.searchParams.set("url", withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set("disableOnboarding", "1");
+  }
+  return parsed.toString();
+}
+var DEV_CLIENT_HOST, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS;
+var init_dev_client_onboarding = __esm({
+  "packages/rn-dev-agent-core/dist/session/dev-client-onboarding.js"() {
+    "use strict";
+    DEV_CLIENT_HOST = "expo-development-client";
+    DEV_MENU_NO_AUTO_LAUNCH_EXTRAS = [
+      "--ez",
+      "EXDevMenuDisableAutoLaunch",
+      "true"
+    ];
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/build-adapter.js
 function conflict(flag) {
   throw new Error(`SESSION_BUILD_IDENTITY_CONFLICT: ${flag} contradicts the active session`);
@@ -14016,7 +14045,7 @@ function createBuildLaunchPlan(input) {
       input.session.deviceId,
       input.session.appId ?? conflict("appId is required for simulator Dev Client startup"),
       "--initialUrl",
-      managedMetroProxyUrl(input.session)
+      withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session))
     ],
     timeoutMs: 3e4
   } : void 0;
@@ -14031,6 +14060,7 @@ var init_build_adapter = __esm({
   "packages/rn-dev-agent-core/dist/session/build-adapter.js"() {
     "use strict";
     init_expo_android_device();
+    init_dev_client_onboarding();
   }
 });
 
@@ -20021,6 +20051,21 @@ function authorityBoundReverseTunnel(binding) {
     && reverse.local === exact
     && reverse.remote === exact;
 }
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === 'expo-development-client' ? parsed.searchParams.get('url') : null;
+  if (inner !== null) {
+    parsed.searchParams.set('url', withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set('disableOnboarding', '1');
+  }
+  return parsed.toString();
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -20196,9 +20241,10 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
+    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
-      ' with --initialUrl ' + expoProxyUrl + '\n'
+      ' with --initialUrl ' + launchUrl + '\n'
     );
     const startup = spawnSync('xcrun', [
       'simctl',
@@ -20207,7 +20253,7 @@ function managedMetroProxyUrl(binding) {
       session.deviceId,
       session.appId,
       '--initialUrl',
-      expoProxyUrl,
+      launchUrl,
     ], {
       cwd: process.cwd(),
       env: authorityEnvironment,
@@ -89248,7 +89294,7 @@ async function openIosDeeplink(url, deviceId) {
 function posixSingleQuote2(s) {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
-function androidDeeplinkCommandArgs(url, packageName, deviceId) {
+function androidDeeplinkCommandArgs(url, packageName, deviceId, extras = []) {
   if (!deviceId)
     throw new Error("DEVICE_AUTHORITY_MISMATCH: exact Android deviceId is required");
   const serial = ["-s", deviceId];
@@ -89261,7 +89307,8 @@ function androidDeeplinkCommandArgs(url, packageName, deviceId) {
     "-a",
     "android.intent.action.VIEW",
     "-d",
-    quotedUrl
+    quotedUrl,
+    ...extras
   ];
   if (packageName)
     args.push("-n", packageName);
@@ -97649,12 +97696,12 @@ async function pinExactDevClient(input, dependencies) {
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65535) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable");
   }
-  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? managedMetroProxyUrl(input) : void 0;
+  const derivedIosExpoLaunchTarget = input.platform === "ios" && input.runtimeKind === "expo-dev-client" ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input)) : void 0;
   if (input.runtimeKind === "bare-react-native" && input.devClientUrl) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: launch kind contradicts the signed build provenance");
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, input.devClientUrl, input.appId);
+    await dependencies.openUrl(input.platform, input.deviceId, withDevMenuOnboardingDisabled(input.devClientUrl), input.appId);
     if (input.platform === "ios")
       await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
@@ -97728,6 +97775,7 @@ var init_dev_client_authority = __esm({
   "packages/rn-dev-agent-core/dist/session/dev-client-authority.js"() {
     "use strict";
     init_build_adapter();
+    init_dev_client_onboarding();
     init_metro_authority();
   }
 });
@@ -98202,7 +98250,7 @@ async function pinSessionDevClient(status, options, commitBundle) {
         if (platform === "ios") {
           await execFileP("xcrun", ["simctl", "openurl", deviceId, url]);
         } else {
-          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId));
+          await execFileP("adb", androidDeeplinkCommandArgs(url, void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS));
         }
       },
       launchExactApp: async (platform, deviceId, appId) => {
@@ -98376,7 +98424,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
       deviceId,
       appId,
       "--initialUrl",
-      `http://127.0.0.1:${String(metroPort)}`
+      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`)
     ]);
     await connectExactSessionTarget2({ metroPort, platform, appId, deviceId }, exactSessionTargetReadinessTimeoutMs(platform));
     return;
@@ -98385,7 +98433,7 @@ async function relaunchSessionRuntime(status, stopApp = true) {
     throw new Error("DEV_CLIENT_ENDPOINT_NOT_FOUND: managed Android replay requires the exact Dev Client URL");
   }
   await execFileP("adb", [
-    ...androidDeeplinkCommandArgs(boundDevClientUrl, void 0, deviceId),
+    ...androidDeeplinkCommandArgs(withDevMenuOnboardingDisabled(boundDevClientUrl), void 0, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
     "-p",
     appId
   ]);
@@ -98663,6 +98711,7 @@ var init_index = __esm({
     init_device_session();
     init_device_session();
     init_session_runtime_absence();
+    init_dev_client_onboarding();
     init_device_interact();
     init_ios_runtime();
     init_ios_proof_router();
@@ -99455,7 +99504,7 @@ var init_index = __esm({
       type: external_exports.enum(["string", "number", "boolean"]).optional().describe("Value type for get/set (default: string)"),
       instanceId: external_exports.string().optional().describe('MMKV instance id (default: "mmkv.default")')
     }, createMmkvHandler(getClient));
-    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. For reload with auto-reconnect, use cdp_reload instead.", {
+    trackedTool("cdp_dev_settings", "Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.", {
       action: external_exports.enum([
         "reload",
         "toggleInspector",

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -58,7 +58,9 @@ import {
 import { releaseDeviceLockForSession } from './tools/device-session.js';
 import { createSessionRuntimeAbsenceProbe } from './session/session-runtime-absence.js';
 import {
+  autoHidesDevMenu,
   DEV_MENU_NO_AUTO_LAUNCH_EXTRAS,
+  iosSimulatorDevMenuDefaultsArgs,
   withDevMenuOnboardingDisabled,
 } from './session/dev-client-onboarding.js';
 import {
@@ -186,7 +188,13 @@ import {
 import { buildStateRead } from './observability/state-read.js';
 import { autostartObserve } from './observability/autostart.js';
 import { removeObserveState } from './observability/observe-state.js';
-import { resolveObserveAutostart, resolveMirrorConfig } from './project-config.js';
+import {
+  readRnAgentConfig,
+  resolveAutoHideDevMenu,
+  resolveObserveAutostart,
+  resolveMirrorConfig,
+  type AutoHideDevMenuResolution,
+} from './project-config.js';
 import { MirrorManager } from './observability/mirror/manager.js';
 import { buildMirrorTargetResolver } from './observability/mirror/target.js';
 import {
@@ -928,15 +936,22 @@ async function pinSessionDevClient(
         runtimeKind,
         ...(devClientUrl ? { devClientUrl } : {}),
         signerCapability: secret.signerCapability,
+        autoHideDevMenu: sessionAutoHideDevMenu(status),
       },
       {
-        openUrl: async (platform, deviceId, url) => {
+        openUrl: async (platform, deviceId, url, appId, hideDevMenu) => {
           if (platform === 'ios') {
+            if (hideDevMenu) await writeIosSimulatorDevMenuDefaults(deviceId, appId);
             await execFileP('xcrun', ['simctl', 'openurl', deviceId, url]);
           } else {
             await execFileP(
               'adb',
-              androidDeeplinkCommandArgs(url, undefined, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
+              androidDeeplinkCommandArgs(
+                url,
+                undefined,
+                deviceId,
+                hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : [],
+              ),
             );
           }
         },
@@ -959,7 +974,8 @@ async function pinSessionDevClient(
             ]);
           }
         },
-        launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl) => {
+        launchExactAppWithInitialUrl: async (deviceId, appId, initialUrl, hideDevMenu) => {
+          if (hideDevMenu) await writeIosSimulatorDevMenuDefaults(deviceId, appId);
           await execFileP('xcrun', [
             'simctl',
             'launch',
@@ -1193,6 +1209,18 @@ const isSessionRuntimeAbsent = createSessionRuntimeAbsenceProbe({
   execute: (file, args, options) => execFileP(file, args, options),
 });
 
+function sessionAutoHideDevMenu(status: SessionStatus): AutoHideDevMenuResolution {
+  return resolveAutoHideDevMenu({
+    readConfig: () => readRnAgentConfig(String(status.source.appRoot)),
+  });
+}
+
+async function writeIosSimulatorDevMenuDefaults(deviceId: string, appId: string): Promise<void> {
+  for (const args of iosSimulatorDevMenuDefaultsArgs(deviceId, appId)) {
+    await execFileP('xcrun', args);
+  }
+}
+
 async function relaunchSessionRuntime(
   status: SessionStatus,
   stopApp = true,
@@ -1204,10 +1232,13 @@ async function relaunchSessionRuntime(
     metroPort,
     devClientUrl: boundDevClientUrl,
   } = resolveManagedRuntimeLaunchBinding(status);
+  const hideDevMenu = autoHidesDevMenu(platform, deviceId, sessionAutoHideDevMenu(status));
+  const launchUrl = (url: string) => (hideDevMenu ? withDevMenuOnboardingDisabled(url) : url);
   if (platform === 'ios') {
     const current = getClient();
     await current.disconnect();
     setClient(createClient(metroPort));
+    if (hideDevMenu) await writeIosSimulatorDevMenuDefaults(deviceId, appId);
     await execFileP('xcrun', [
       'simctl',
       'launch',
@@ -1215,7 +1246,7 @@ async function relaunchSessionRuntime(
       deviceId,
       appId,
       '--initialUrl',
-      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`),
+      launchUrl(`http://127.0.0.1:${String(metroPort)}`),
     ]);
     await connectExactSessionTarget(
       { metroPort, platform, appId, deviceId },
@@ -1231,10 +1262,10 @@ async function relaunchSessionRuntime(
   }
   await execFileP('adb', [
     ...androidDeeplinkCommandArgs(
-      withDevMenuOnboardingDisabled(boundDevClientUrl),
+      launchUrl(boundDevClientUrl),
       undefined,
       deviceId,
-      DEV_MENU_NO_AUTO_LAUNCH_EXTRAS,
+      hideDevMenu ? DEV_MENU_NO_AUTO_LAUNCH_EXTRAS : [],
     ),
     '-p',
     appId,
@@ -2119,7 +2150,7 @@ trackedTool(
 
 trackedTool(
   'cdp_dev_settings',
-  'Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.',
+  'Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. With autoHideDevMenu on (default in .rn-agent/config.json), managed launches and relaunches suppress the Expo dev-menu onboarding tutorial and launch-time menu sheet, so hideDevMenu is for gesture-opened menus. For reload with auto-reconnect, use cdp_reload instead.',
   {
     action: z
       .enum([

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -58,6 +58,10 @@ import {
 import { releaseDeviceLockForSession } from './tools/device-session.js';
 import { createSessionRuntimeAbsenceProbe } from './session/session-runtime-absence.js';
 import {
+  DEV_MENU_NO_AUTO_LAUNCH_EXTRAS,
+  withDevMenuOnboardingDisabled,
+} from './session/dev-client-onboarding.js';
+import {
   createDeviceFindHandler,
   fetchSnapshotNodesForSameScreenProof,
   createDevicePressHandler,
@@ -930,7 +934,10 @@ async function pinSessionDevClient(
           if (platform === 'ios') {
             await execFileP('xcrun', ['simctl', 'openurl', deviceId, url]);
           } else {
-            await execFileP('adb', androidDeeplinkCommandArgs(url, undefined, deviceId));
+            await execFileP(
+              'adb',
+              androidDeeplinkCommandArgs(url, undefined, deviceId, DEV_MENU_NO_AUTO_LAUNCH_EXTRAS),
+            );
           }
         },
         launchExactApp: async (platform, deviceId, appId) => {
@@ -1208,7 +1215,7 @@ async function relaunchSessionRuntime(
       deviceId,
       appId,
       '--initialUrl',
-      `http://127.0.0.1:${String(metroPort)}`,
+      withDevMenuOnboardingDisabled(`http://127.0.0.1:${String(metroPort)}`),
     ]);
     await connectExactSessionTarget(
       { metroPort, platform, appId, deviceId },
@@ -1223,7 +1230,12 @@ async function relaunchSessionRuntime(
     );
   }
   await execFileP('adb', [
-    ...androidDeeplinkCommandArgs(boundDevClientUrl, undefined, deviceId),
+    ...androidDeeplinkCommandArgs(
+      withDevMenuOnboardingDisabled(boundDevClientUrl),
+      undefined,
+      deviceId,
+      DEV_MENU_NO_AUTO_LAUNCH_EXTRAS,
+    ),
     '-p',
     appId,
   ]);
@@ -2107,7 +2119,7 @@ trackedTool(
 
 trackedTool(
   'cdp_dev_settings',
-  'Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. For reload with auto-reconnect, use cdp_reload instead.',
+  'Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses the React Native core dev menu gesture. hideDevMenu calls ExpoDevMenu hideMenu or closeMenu over CDP on iOS or Android, with at most one retry and a five-second bound per attempt; it verifies the foreground surface and returns hidden, no_menu_present, DEV_MENU_HIDE_FAILED when no close call was sent, or DEV_MENU_HIDE_UNVERIFIED when a sent call is not proven clean. Managed launches and relaunches disable the Expo dev-menu onboarding tutorial by construction, so hideDevMenu is for gesture-opened menus and the one-time shows-at-launch menu. For reload with auto-reconnect, use cdp_reload instead.',
   {
     action: z
       .enum([

--- a/packages/rn-dev-agent-core/src/project-config.ts
+++ b/packages/rn-dev-agent-core/src/project-config.ts
@@ -93,6 +93,7 @@ export function readExpoSlug(): string | null {
 }
 
 export interface RnAgentConfig {
+  autoHideDevMenu?: boolean | { simulators?: boolean; devices?: boolean };
   cdp?: { autoConnect?: boolean };
   observe?: {
     autoStart?: boolean;
@@ -144,6 +145,39 @@ export function resolveAutoConnect(
     return { enabled: cfg.cdp.autoConnect, source: 'config' };
   }
   return { enabled: true, source: 'default' };
+}
+
+export interface AutoHideDevMenuResolution {
+  simulators: boolean;
+  devices: boolean;
+  source: 'config' | 'default';
+}
+
+let warnedBadAutoHideDevMenu = false;
+
+export function resolveAutoHideDevMenu(
+  deps: { readConfig?: () => RnAgentConfig | null } = {},
+): AutoHideDevMenuResolution {
+  const raw: unknown = (deps.readConfig ?? readRnAgentConfig)()?.autoHideDevMenu;
+  if (typeof raw === 'boolean') return { simulators: raw, devices: raw, source: 'config' };
+  if (
+    isPlainConfigObject(raw) &&
+    [raw.simulators, raw.devices].every((flag) => flag === undefined || typeof flag === 'boolean')
+  ) {
+    return {
+      simulators: raw.simulators !== false,
+      devices: raw.devices !== false,
+      source: 'config',
+    };
+  }
+  if (raw !== undefined && !warnedBadAutoHideDevMenu) {
+    warnedBadAutoHideDevMenu = true;
+    logger.warn(
+      'CONFIG',
+      `.rn-agent/config.json autoHideDevMenu must be a boolean or { simulators, devices } booleans (got ${JSON.stringify(raw)}) — using the default (hidden)`,
+    );
+  }
+  return { simulators: true, devices: true, source: 'default' };
 }
 
 /**

--- a/packages/rn-dev-agent-core/src/session/build-adapter.ts
+++ b/packages/rn-dev-agent-core/src/session/build-adapter.ts
@@ -4,6 +4,7 @@ import {
   resolveExpoAndroidDevice,
   type ExpoAndroidDeviceBinding,
 } from './expo-android-device.js';
+import { withDevMenuOnboardingDisabled } from './dev-client-onboarding.js';
 
 export interface SessionBuildBinding {
   platform: 'ios' | 'android';
@@ -202,7 +203,7 @@ export function createBuildLaunchPlan(input: {
             input.session.deviceId,
             input.session.appId ?? conflict('appId is required for simulator Dev Client startup'),
             '--initialUrl',
-            managedMetroProxyUrl(input.session),
+            withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session)),
           ],
           timeoutMs: 30_000,
         }

--- a/packages/rn-dev-agent-core/src/session/build-adapter.ts
+++ b/packages/rn-dev-agent-core/src/session/build-adapter.ts
@@ -4,7 +4,11 @@ import {
   resolveExpoAndroidDevice,
   type ExpoAndroidDeviceBinding,
 } from './expo-android-device.js';
-import { withDevMenuOnboardingDisabled } from './dev-client-onboarding.js';
+import {
+  autoHidesDevMenu,
+  iosSimulatorDevMenuDefaultsArgs,
+  withDevMenuOnboardingDisabled,
+} from './dev-client-onboarding.js';
 
 export interface SessionBuildBinding {
   platform: 'ios' | 'android';
@@ -21,6 +25,7 @@ interface BuildLaunchPlan {
   command: string[];
   env: Record<string, string>;
   postInstall?: {
+    before: string[][];
     command: string[];
     timeoutMs: number;
   };
@@ -134,11 +139,36 @@ function commandKind(command: readonly string[]): 'expo' | 'bare-ios' | 'bare-an
   return null;
 }
 
+function simulatorPostInstall(
+  session: SessionBuildBinding,
+  appId: string,
+  hideDevMenu: boolean,
+): NonNullable<BuildLaunchPlan['postInstall']> {
+  const proxyUrl = managedMetroProxyUrl(session);
+  return {
+    before: hideDevMenu
+      ? iosSimulatorDevMenuDefaultsArgs(session.deviceId, appId).map((args) => ['xcrun', ...args])
+      : [],
+    command: [
+      'xcrun',
+      'simctl',
+      'launch',
+      '--terminate-running-process',
+      session.deviceId,
+      appId,
+      '--initialUrl',
+      hideDevMenu ? withDevMenuOnboardingDisabled(proxyUrl) : proxyUrl,
+    ],
+    timeoutMs: 30_000,
+  };
+}
+
 export function createBuildLaunchPlan(input: {
   platform: 'ios' | 'android';
   command: readonly string[];
   session: SessionBuildBinding | null;
   resolveExpoAndroidDevice?: (serial: string) => ExpoAndroidDeviceBinding;
+  autoHideDevMenu?: { simulators: boolean; devices: boolean };
 }): BuildLaunchPlan {
   const command = [...input.command];
   if (!input.session) return { mode: 'passthrough', command, env: {} };
@@ -194,19 +224,11 @@ export function createBuildLaunchPlan(input: {
   };
   const postInstall =
     kind === 'expo' && input.platform === 'ios' && input.session.simulator === true
-      ? {
-          command: [
-            'xcrun',
-            'simctl',
-            'launch',
-            '--terminate-running-process',
-            input.session.deviceId,
-            input.session.appId ?? conflict('appId is required for simulator Dev Client startup'),
-            '--initialUrl',
-            withDevMenuOnboardingDisabled(managedMetroProxyUrl(input.session)),
-          ],
-          timeoutMs: 30_000,
-        }
+      ? simulatorPostInstall(
+          input.session,
+          input.session.appId ?? conflict('appId is required for simulator Dev Client startup'),
+          autoHidesDevMenu('ios', input.session.deviceId, input.autoHideDevMenu),
+        )
       : undefined;
 
   return {

--- a/packages/rn-dev-agent-core/src/session/dev-client-authority.ts
+++ b/packages/rn-dev-agent-core/src/session/dev-client-authority.ts
@@ -1,4 +1,5 @@
 import { managedMetroProxyUrl } from './build-adapter.js';
+import { withDevMenuOnboardingDisabled } from './dev-client-onboarding.js';
 import type { MetroAuthorityBinding, MetroAuthorityMarker } from './metro-authority.js';
 import { verifyMetroAuthorityMarker } from './metro-authority.js';
 import type { SessionStatus } from './registry.js';
@@ -183,7 +184,7 @@ export async function pinExactDevClient(
   }
   const derivedIosExpoLaunchTarget =
     input.platform === 'ios' && input.runtimeKind === 'expo-dev-client'
-      ? managedMetroProxyUrl(input)
+      ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input))
       : undefined;
   if (input.runtimeKind === 'bare-react-native' && input.devClientUrl) {
     throw new Error(
@@ -191,7 +192,12 @@ export async function pinExactDevClient(
     );
   }
   if (input.devClientUrl) {
-    await dependencies.openUrl(input.platform, input.deviceId, input.devClientUrl, input.appId);
+    await dependencies.openUrl(
+      input.platform,
+      input.deviceId,
+      withDevMenuOnboardingDisabled(input.devClientUrl),
+      input.appId,
+    );
     if (input.platform === 'ios') await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
     await dependencies.launchExactAppWithInitialUrl(

--- a/packages/rn-dev-agent-core/src/session/dev-client-authority.ts
+++ b/packages/rn-dev-agent-core/src/session/dev-client-authority.ts
@@ -1,5 +1,5 @@
 import { managedMetroProxyUrl } from './build-adapter.js';
-import { withDevMenuOnboardingDisabled } from './dev-client-onboarding.js';
+import { autoHidesDevMenu, withDevMenuOnboardingDisabled } from './dev-client-onboarding.js';
 import type { MetroAuthorityBinding, MetroAuthorityMarker } from './metro-authority.js';
 import { verifyMetroAuthorityMarker } from './metro-authority.js';
 import type { SessionStatus } from './registry.js';
@@ -12,6 +12,7 @@ interface PinDevClientInput extends MetroAuthorityBinding {
   devClientUrl?: string;
   runtimeKind: 'bare-react-native' | 'expo-dev-client';
   signerCapability: string;
+  autoHideDevMenu?: { simulators: boolean; devices: boolean };
 }
 
 type ExactConnectionSummary = Pick<
@@ -20,9 +21,20 @@ type ExactConnectionSummary = Pick<
 >;
 
 interface PinDevClientDependencies {
-  openUrl(platform: 'ios' | 'android', deviceId: string, url: string, appId: string): Promise<void>;
+  openUrl(
+    platform: 'ios' | 'android',
+    deviceId: string,
+    url: string,
+    appId: string,
+    hideDevMenu: boolean,
+  ): Promise<void>;
   launchExactApp(platform: 'ios' | 'android', deviceId: string, appId: string): Promise<void>;
-  launchExactAppWithInitialUrl(deviceId: string, appId: string, initialUrl: string): Promise<void>;
+  launchExactAppWithInitialUrl(
+    deviceId: string,
+    appId: string,
+    initialUrl: string,
+    hideDevMenu: boolean,
+  ): Promise<void>;
   acceptIosOpenDialog(deviceId: string): Promise<void>;
   connectExact(input: {
     metroPort: number;
@@ -182,9 +194,11 @@ export async function pinExactDevClient(
   if (!Number.isSafeInteger(input.metroPort) || input.metroPort < 1 || input.metroPort > 65_535) {
     throw new Error('DEV_CLIENT_ENDPOINT_NOT_FOUND: authority-bound Metro port is unavailable');
   }
+  const hideDevMenu = autoHidesDevMenu(input.platform, input.deviceId, input.autoHideDevMenu);
+  const launchUrl = (url: string) => (hideDevMenu ? withDevMenuOnboardingDisabled(url) : url);
   const derivedIosExpoLaunchTarget =
     input.platform === 'ios' && input.runtimeKind === 'expo-dev-client'
-      ? withDevMenuOnboardingDisabled(managedMetroProxyUrl(input))
+      ? launchUrl(managedMetroProxyUrl(input))
       : undefined;
   if (input.runtimeKind === 'bare-react-native' && input.devClientUrl) {
     throw new Error(
@@ -195,8 +209,9 @@ export async function pinExactDevClient(
     await dependencies.openUrl(
       input.platform,
       input.deviceId,
-      withDevMenuOnboardingDisabled(input.devClientUrl),
+      launchUrl(input.devClientUrl),
       input.appId,
+      hideDevMenu,
     );
     if (input.platform === 'ios') await dependencies.acceptIosOpenDialog(input.deviceId);
   } else if (derivedIosExpoLaunchTarget) {
@@ -204,6 +219,7 @@ export async function pinExactDevClient(
       input.deviceId,
       input.appId,
       derivedIosExpoLaunchTarget,
+      hideDevMenu,
     );
   } else {
     await dependencies.launchExactApp(input.platform, input.deviceId, input.appId);

--- a/packages/rn-dev-agent-core/src/session/dev-client-onboarding.ts
+++ b/packages/rn-dev-agent-core/src/session/dev-client-onboarding.ts
@@ -1,0 +1,23 @@
+const DEV_CLIENT_HOST = 'expo-development-client';
+
+export const DEV_MENU_NO_AUTO_LAUNCH_EXTRAS: readonly string[] = [
+  '--ez',
+  'EXDevMenuDisableAutoLaunch',
+  'true',
+];
+
+export function withDevMenuOnboardingDisabled(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === DEV_CLIENT_HOST ? parsed.searchParams.get('url') : null;
+  if (inner !== null) {
+    parsed.searchParams.set('url', withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set('disableOnboarding', '1');
+  }
+  return parsed.toString();
+}

--- a/packages/rn-dev-agent-core/src/session/dev-client-onboarding.ts
+++ b/packages/rn-dev-agent-core/src/session/dev-client-onboarding.ts
@@ -6,6 +6,24 @@ export const DEV_MENU_NO_AUTO_LAUNCH_EXTRAS: readonly string[] = [
   'true',
 ];
 
+export function autoHidesDevMenu(
+  platform: 'ios' | 'android',
+  deviceId: string,
+  setting: { simulators: boolean; devices: boolean } = { simulators: true, devices: true },
+): boolean {
+  return platform === 'ios' || /^emulator-\d+$/.test(deviceId) ? setting.simulators : setting.devices;
+}
+
+// Persistent app domain, unlike launch arguments, so bare relaunches stay popup-free too.
+export function iosSimulatorDevMenuDefaultsArgs(deviceId: string, appId: string): string[][] {
+  return (
+    [
+      ['EXDevMenuShowsAtLaunch', 'NO'],
+      ['EXDevMenuIsOnboardingFinished', 'YES'],
+    ] as const
+  ).map(([key, value]) => ['simctl', 'spawn', deviceId, 'defaults', 'write', appId, key, '-bool', value]);
+}
+
 export function withDevMenuOnboardingDisabled(url: string): string {
   let parsed: URL;
   try {

--- a/packages/rn-dev-agent-core/src/session/dev-client-onboarding.ts
+++ b/packages/rn-dev-agent-core/src/session/dev-client-onboarding.ts
@@ -11,7 +11,9 @@ export function autoHidesDevMenu(
   deviceId: string,
   setting: { simulators: boolean; devices: boolean } = { simulators: true, devices: true },
 ): boolean {
-  return platform === 'ios' || /^emulator-\d+$/.test(deviceId) ? setting.simulators : setting.devices;
+  return platform === 'ios' || /^emulator-\d+$/.test(deviceId)
+    ? setting.simulators
+    : setting.devices;
 }
 
 // Persistent app domain, unlike launch arguments, so bare relaunches stay popup-free too.
@@ -21,7 +23,17 @@ export function iosSimulatorDevMenuDefaultsArgs(deviceId: string, appId: string)
       ['EXDevMenuShowsAtLaunch', 'NO'],
       ['EXDevMenuIsOnboardingFinished', 'YES'],
     ] as const
-  ).map(([key, value]) => ['simctl', 'spawn', deviceId, 'defaults', 'write', appId, key, '-bool', value]);
+  ).map(([key, value]) => [
+    'simctl',
+    'spawn',
+    deviceId,
+    'defaults',
+    'write',
+    appId,
+    key,
+    '-bool',
+    value,
+  ]);
 }
 
 export function withDevMenuOnboardingDisabled(url: string): string {

--- a/packages/rn-dev-agent-core/src/session/package-integration.ts
+++ b/packages/rn-dev-agent-core/src/session/package-integration.ts
@@ -3713,6 +3713,21 @@ function authorityBoundReverseTunnel(binding) {
     && reverse.local === exact
     && reverse.remote === exact;
 }
+function withDevMenuOnboardingDisabled(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const inner = parsed.host === 'expo-development-client' ? parsed.searchParams.get('url') : null;
+  if (inner !== null) {
+    parsed.searchParams.set('url', withDevMenuOnboardingDisabled(inner));
+  } else {
+    parsed.searchParams.set('disableOnboarding', '1');
+  }
+  return parsed.toString();
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -3888,9 +3903,10 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
+    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
-      ' with --initialUrl ' + expoProxyUrl + '\n'
+      ' with --initialUrl ' + launchUrl + '\n'
     );
     const startup = spawnSync('xcrun', [
       'simctl',
@@ -3899,7 +3915,7 @@ function managedMetroProxyUrl(binding) {
       session.deviceId,
       session.appId,
       '--initialUrl',
-      expoProxyUrl,
+      launchUrl,
     ], {
       cwd: process.cwd(),
       env: authorityEnvironment,

--- a/packages/rn-dev-agent-core/src/session/package-integration.ts
+++ b/packages/rn-dev-agent-core/src/session/package-integration.ts
@@ -3728,6 +3728,18 @@ function withDevMenuOnboardingDisabled(url) {
   }
   return parsed.toString();
 }
+function autoHideDevMenuOnSimulators() {
+  let setting;
+  try {
+    setting = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.rn-agent', 'config.json'), 'utf8')).autoHideDevMenu;
+  } catch {
+    return true;
+  }
+  if (typeof setting === 'boolean') return setting;
+  const valid = setting !== null && typeof setting === 'object' && !Array.isArray(setting)
+    && [setting.simulators, setting.devices].every((flag) => flag === undefined || typeof flag === 'boolean');
+  return !valid || setting.simulators !== false;
+}
 function managedMetroProxyUrl(binding) {
   if (binding.platform === 'ios') return 'http://127.0.0.1:' + binding.metroPort;
   if (/^emulator-\d+$/.test(binding.deviceId)) return 'http://10.0.2.2:' + binding.metroPort;
@@ -3903,7 +3915,20 @@ function managedMetroProxyUrl(binding) {
     if (installed.error || installed.status !== 0 || !String(installed.stdout).trim()) {
       failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: exact simulator app installation could not be proven');
     }
-    const launchUrl = withDevMenuOnboardingDisabled(expoProxyUrl);
+    const hideDevMenu = autoHideDevMenuOnSimulators();
+    const launchUrl = hideDevMenu ? withDevMenuOnboardingDisabled(expoProxyUrl) : expoProxyUrl;
+    for (const [key, value] of hideDevMenu ? [['EXDevMenuShowsAtLaunch', 'NO'], ['EXDevMenuIsOnboardingFinished', 'YES']] : []) {
+      const written = spawnSync('xcrun', ['simctl', 'spawn', session.deviceId, 'defaults', 'write', session.appId, key, '-bool', value], {
+        cwd: process.cwd(),
+        env: authorityEnvironment,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      if (written.error || written.status !== 0) {
+        const detail = written.error?.message || String(written.stderr).trim() || 'defaults write failed';
+        failBuild(2, 'DEV_CLIENT_STARTUP_UNCONFIRMED: dev-menu defaults for ' + key + ' could not be written: ' + detail);
+      }
+    }
     process.stdout.write(
       'rn-session-adapter: starting ' + session.appId + ' on simulator ' + session.deviceId +
       ' with --initialUrl ' + launchUrl + '\n'

--- a/packages/rn-dev-agent-core/src/tools/device-deeplink.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-deeplink.ts
@@ -72,6 +72,7 @@ export function androidDeeplinkCommandArgs(
   url: string,
   packageName?: string,
   deviceId?: string,
+  extras: readonly string[] = [],
 ): string[] {
   if (!deviceId) throw new Error('DEVICE_AUTHORITY_MISMATCH: exact Android deviceId is required');
   const serial = ['-s', deviceId];
@@ -85,6 +86,7 @@ export function androidDeeplinkCommandArgs(
     'android.intent.action.VIEW',
     '-d',
     quotedUrl,
+    ...extras,
   ];
   if (packageName) args.push('-n', packageName);
   return args;

--- a/packages/rn-dev-agent-core/test/integration/managed-metro-installed-expo-ios.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/managed-metro-installed-expo-ios.test.ts
@@ -630,7 +630,7 @@ async function writeMarker(buildGeneration) {
       assert.match(
         nativeOutput,
         new RegExp(
-          `starting ${appId} on simulator ${simulatorId} with --initialUrl http://127\\.0\\.0\\.1:${port}`,
+          `starting ${appId} on simulator ${simulatorId} with --initialUrl http://127\\.0\\.0\\.1:${port}/\\?disableOnboarding=1`,
         ),
       );
 

--- a/packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.js
+++ b/packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.js
@@ -6,7 +6,8 @@ import { tmpdir } from 'node:os';
 import { logger } from '../../dist/logger.js';
 import { readRnAgentConfig, resolveAutoHideDevMenu } from '../../dist/project-config.js';
 
-const resolveWith = (autoHideDevMenu) => resolveAutoHideDevMenu({ readConfig: () => ({ autoHideDevMenu }) });
+const resolveWith = (autoHideDevMenu) =>
+  resolveAutoHideDevMenu({ readConfig: () => ({ autoHideDevMenu }) });
 
 test('resolveAutoHideDevMenu: absent key hides on every target by default', () => {
   assert.deepEqual(resolveAutoHideDevMenu({ readConfig: () => null }), {

--- a/packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.js
+++ b/packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.js
@@ -1,0 +1,68 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { logger } from '../../dist/logger.js';
+import { readRnAgentConfig, resolveAutoHideDevMenu } from '../../dist/project-config.js';
+
+const resolveWith = (autoHideDevMenu) => resolveAutoHideDevMenu({ readConfig: () => ({ autoHideDevMenu }) });
+
+test('resolveAutoHideDevMenu: absent key hides on every target by default', () => {
+  assert.deepEqual(resolveAutoHideDevMenu({ readConfig: () => null }), {
+    simulators: true,
+    devices: true,
+    source: 'default',
+  });
+  assert.deepEqual(resolveWith(undefined), { simulators: true, devices: true, source: 'default' });
+});
+
+test('resolveAutoHideDevMenu: a boolean applies to both target classes', () => {
+  assert.deepEqual(resolveWith(false), { simulators: false, devices: false, source: 'config' });
+  assert.deepEqual(resolveWith(true), { simulators: true, devices: true, source: 'config' });
+});
+
+test('resolveAutoHideDevMenu: a partial object keeps missing target classes hidden', () => {
+  assert.deepEqual(resolveWith({ simulators: false }), {
+    simulators: false,
+    devices: true,
+    source: 'config',
+  });
+  assert.deepEqual(resolveWith({ devices: false }), {
+    simulators: true,
+    devices: false,
+    source: 'config',
+  });
+});
+
+test('resolveAutoHideDevMenu: a malformed value falls back to the default with a warning', () => {
+  const warn = mock.method(logger, 'warn', () => {});
+  try {
+    for (const malformed of ['off', 0, null, [false], { simulators: 'no' }]) {
+      assert.deepEqual(resolveWith(malformed), {
+        simulators: true,
+        devices: true,
+        source: 'default',
+      });
+    }
+    assert.equal(warn.mock.callCount(), 1);
+    assert.match(warn.mock.calls[0].arguments[1], /autoHideDevMenu/);
+  } finally {
+    warn.mock.restore();
+  }
+});
+
+test('resolveAutoHideDevMenu: an unreadable config file falls back to the default', () => {
+  const root = mkdtempSync(join(tmpdir(), 'rn-agent-cfg-'));
+  try {
+    mkdirSync(join(root, '.rn-agent'), { recursive: true });
+    writeFileSync(join(root, '.rn-agent', 'config.json'), '{ not json');
+    assert.deepEqual(resolveAutoHideDevMenu({ readConfig: () => readRnAgentConfig(root) }), {
+      simulators: true,
+      devices: true,
+      source: 'default',
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { logger } from '../../dist/logger.js';
 import { readRnAgentConfig, resolveAutoHideDevMenu } from '../../dist/project-config.js';
 
-const resolveWith = (autoHideDevMenu) =>
+const resolveWith = (autoHideDevMenu: unknown) =>
   resolveAutoHideDevMenu({ readConfig: () => ({ autoHideDevMenu }) });
 
 test('resolveAutoHideDevMenu: absent key hides on every target by default', () => {

--- a/packages/rn-dev-agent-core/test/unit/device-deeplink-target.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/device-deeplink-target.test.ts
@@ -25,6 +25,29 @@ test('device_deeplink command builders honor an explicit target', () => {
     '-d',
     "'proof://fixture'",
   ]);
+  assert.deepEqual(
+    androidDeeplinkCommandArgs('proof://fixture', 'dev.example', 'emulator-5556', [
+      '--ez',
+      'EXDevMenuDisableAutoLaunch',
+      'true',
+    ]),
+    [
+      '-s',
+      'emulator-5556',
+      'shell',
+      'am',
+      'start',
+      '-a',
+      'android.intent.action.VIEW',
+      '-d',
+      "'proof://fixture'",
+      '--ez',
+      'EXDevMenuDisableAutoLaunch',
+      'true',
+      '-n',
+      'dev.example',
+    ],
+  );
 });
 
 test('device_deeplink exposes explicit simulator or device selection through MCP', async () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-1004-dev-menu-onboarding-url.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-1004-dev-menu-onboarding-url.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { withDevMenuOnboardingDisabled } from '../../dist/session/dev-client-onboarding.js';
+
+test('plain Metro URL gets disableOnboarding=1', () => {
+  assert.equal(
+    withDevMenuOnboardingDisabled('http://127.0.0.1:8341'),
+    'http://127.0.0.1:8341/?disableOnboarding=1',
+  );
+});
+
+test('dev-client deep link flags the inner url parameter', () => {
+  const flagged = withDevMenuOnboardingDisabled(
+    'example://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8341',
+  );
+  const inner = new URL(flagged).searchParams.get('url');
+  assert.equal(new URL(flagged).host, 'expo-development-client');
+  assert.equal(inner, 'http://localhost:8341/?disableOnboarding=1');
+  assert.equal(new URL(flagged).searchParams.has('disableOnboarding'), false);
+});
+
+test('already-flagged input is unchanged', () => {
+  const once = withDevMenuOnboardingDisabled('http://10.0.2.2:8081/?a=b');
+  assert.equal(withDevMenuOnboardingDisabled(once), once);
+  const deepOnce = withDevMenuOnboardingDisabled(
+    'exp+app://expo-development-client/?url=http%3A%2F%2F192.168.1.2%3A8081',
+  );
+  assert.equal(withDevMenuOnboardingDisabled(deepOnce), deepOnce);
+});
+
+test('existing query items are preserved', () => {
+  const flagged = withDevMenuOnboardingDisabled('http://127.0.0.1:8341/?platform=ios&dev=true');
+  const params = new URL(flagged).searchParams;
+  assert.equal(params.get('platform'), 'ios');
+  assert.equal(params.get('dev'), 'true');
+  assert.equal(params.get('disableOnboarding'), '1');
+});
+
+test('unparsable input is returned untouched', () => {
+  assert.equal(withDevMenuOnboardingDisabled('not a url'), 'not a url');
+  assert.equal(withDevMenuOnboardingDisabled(''), '');
+});

--- a/packages/rn-dev-agent-core/test/unit/session/build-adapter.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/build-adapter.test.ts
@@ -67,7 +67,7 @@ test('Expo iOS launches through its exact managed Metro proxy without starting a
       iosSession.deviceId,
       iosSession.appId,
       '--initialUrl',
-      'http://127.0.0.1:8341',
+      'http://127.0.0.1:8341/?disableOnboarding=1',
     ],
     timeoutMs: 30_000,
   });

--- a/packages/rn-dev-agent-core/test/unit/session/build-adapter.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/build-adapter.test.ts
@@ -58,7 +58,23 @@ test('Expo iOS launches through its exact managed Metro proxy without starting a
     RN_DEV_AGENT_SESSION_ID: 'session-ios',
     EXPO_PACKAGER_PROXY_URL: 'http://127.0.0.1:8341',
   });
+  const defaultsWrite = (key: string, value: string) => [
+    'xcrun',
+    'simctl',
+    'spawn',
+    iosSession.deviceId,
+    'defaults',
+    'write',
+    iosSession.appId,
+    key,
+    '-bool',
+    value,
+  ];
   assert.deepEqual(plan.postInstall, {
+    before: [
+      defaultsWrite('EXDevMenuShowsAtLaunch', 'NO'),
+      defaultsWrite('EXDevMenuIsOnboardingFinished', 'YES'),
+    ],
     command: [
       'xcrun',
       'simctl',
@@ -71,6 +87,18 @@ test('Expo iOS launches through its exact managed Metro proxy without starting a
     ],
     timeoutMs: 30_000,
   });
+});
+
+test('autoHideDevMenu off for simulators launches the plain proxy URL without defaults writes', () => {
+  const plan = createBuildLaunchPlan({
+    platform: 'ios',
+    command: ['npx', 'expo', 'run:ios'],
+    session: iosSession,
+    autoHideDevMenu: { simulators: false, devices: true },
+  });
+
+  assert.deepEqual(plan.postInstall?.before, []);
+  assert.deepEqual(plan.postInstall?.command.slice(-2), ['--initialUrl', 'http://127.0.0.1:8341']);
 });
 
 test('recorded integrated Expo Android command pins launch, wait, and connect to the allocated port', () => {

--- a/packages/rn-dev-agent-core/test/unit/session/dev-client-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/dev-client-authority.test.ts
@@ -284,6 +284,58 @@ test('receipted iOS Expo pin launches through the authority-bound Metro without 
   assert.equal(binding.launchMethod, 'app');
 });
 
+async function recordPinLaunch(input: Record<string, unknown>) {
+  const calls = [];
+  await assert.rejects(
+    pinExactDevClient(
+      { ...expected, metroPort: 8341, signerCapability: 'signer', ...input },
+      {
+        openUrl: async (_platform, deviceId, url, _appId, hideDevMenu) =>
+          calls.push(['open', deviceId, url, hideDevMenu]),
+        launchExactApp: async () => assert.fail('Expo pin must not use a bare app launch'),
+        launchExactAppWithInitialUrl: async (deviceId, _appId, url, hideDevMenu) =>
+          calls.push(['launch-with-initial-url', deviceId, url, hideDevMenu]),
+        acceptIosOpenDialog: async () => {},
+        connectExact: async () => {
+          throw new Error('BUNDLE_HANDSHAKE_UNAVAILABLE: launch recorded');
+        },
+        readMarker: async () => null,
+      },
+    ),
+    /BUNDLE_HANDSHAKE_UNAVAILABLE/,
+  );
+  return calls;
+}
+
+test('autoHideDevMenu off for simulators launches the iOS Expo pin with the plain Metro URL', async () => {
+  const ios = { deviceId: 'IOS-UUID', runtimeKind: 'expo-dev-client' };
+  assert.deepEqual(await recordPinLaunch(ios), [
+    ['launch-with-initial-url', 'IOS-UUID', 'http://127.0.0.1:8341/?disableOnboarding=1', true],
+  ]);
+  assert.deepEqual(
+    await recordPinLaunch({ ...ios, autoHideDevMenu: { simulators: false, devices: true } }),
+    [['launch-with-initial-url', 'IOS-UUID', 'http://127.0.0.1:8341', false]],
+  );
+});
+
+test('autoHideDevMenu per-target object hides the Android dev menu only on its target class', async () => {
+  const devClientUrl = 'example://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8341';
+  const flaggedUrl =
+    'example://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8341%2F%3FdisableOnboarding%3D1';
+  const android = {
+    platform: 'android',
+    devClientUrl,
+    runtimeKind: 'expo-dev-client',
+    autoHideDevMenu: { simulators: true, devices: false },
+  };
+  assert.deepEqual(await recordPinLaunch({ ...android, deviceId: 'emulator-5554' }), [
+    ['open', 'emulator-5554', flaggedUrl, true],
+  ]);
+  assert.deepEqual(await recordPinLaunch({ ...android, deviceId: 'R5CT1234ABC' }), [
+    ['open', 'R5CT1234ABC', devClientUrl, false],
+  ]);
+});
+
 test('iOS Expo pin refuses when no authority-bound Metro port exists', async () => {
   await assert.rejects(
     pinExactDevClient(

--- a/packages/rn-dev-agent-core/test/unit/session/dev-client-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/dev-client-authority.test.ts
@@ -67,7 +67,10 @@ test('dev-client pin opens only the declared URL on the exact device and binds i
   );
 
   assert.equal(calls[0][2], 'IOS-UUID');
-  assert.equal(calls[0][3], binding.devClientUrl);
+  assert.equal(
+    calls[0][3],
+    'example://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8341%2F%3FdisableOnboarding%3D1',
+  );
   assert.equal(binding.targetId, 'target-a');
   assert.equal(binding.sourceFidelity, 'not-proven');
 });
@@ -196,7 +199,7 @@ test('dev-client endpoint is launch data and cannot bind without the signed bund
     ),
     /BUNDLE_HANDSHAKE_UNAVAILABLE/,
   );
-  assert.deepEqual(calls, [['open', 'example://foreign']]);
+  assert.deepEqual(calls, [['open', 'example://foreign?disableOnboarding=1']]);
 });
 
 test('bare RN pin launches the exact claimed app without inventing a dev-client URL', async () => {
@@ -269,7 +272,12 @@ test('receipted iOS Expo pin launches through the authority-bound Metro without 
   );
 
   assert.deepEqual(calls, [
-    ['launch-with-initial-url', 'IOS-UUID', 'com.example.app', 'http://127.0.0.1:8341'],
+    [
+      'launch-with-initial-url',
+      'IOS-UUID',
+      'com.example.app',
+      'http://127.0.0.1:8341/?disableOnboarding=1',
+    ],
   ]);
   assert.equal(binding.targetId, 'target-expo');
   assert.equal(binding.devClientUrl, undefined, 'a bare Metro URL is not a dev-client deep link');

--- a/packages/rn-dev-agent-core/test/unit/session/expo-cli-parser.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/expo-cli-parser.test.ts
@@ -145,7 +145,7 @@ test('generated adapter argv passes the shipped Expo CLI resolution end to end',
     chmodSync(join(binRoot, 'npx'), 0o755);
     writeFileSync(
       join(binRoot, 'xcrun'),
-      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.exit(0);}process.exit(12);\n",
+      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&args[1]==='spawn'&&args[3]==='defaults'){process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.exit(0);}process.exit(12);\n",
     );
     chmodSync(join(binRoot, 'xcrun'), 0o755);
     writeFileSync(

--- a/packages/rn-dev-agent-core/test/unit/session/expo-cli-parser.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/expo-cli-parser.test.ts
@@ -78,7 +78,7 @@ test('repaired build plan passes the shipped Expo CLI resolution with managed au
     assert.equal(plan.env.EXPO_PACKAGER_PROXY_URL, 'http://127.0.0.1:8248');
     assert.deepEqual(plan.postInstall?.command.slice(-2), [
       '--initialUrl',
-      'http://127.0.0.1:8248',
+      'http://127.0.0.1:8248/?disableOnboarding=1',
     ]);
   }
 });
@@ -176,7 +176,7 @@ test('generated adapter argv passes the shipped Expo CLI resolution end to end',
       'F66756F3-A867-47EB-97E1-2B85D1902D4E',
       'com.rndevagent.testapp',
       '--initialUrl',
-      'http://127.0.0.1:8248',
+      'http://127.0.0.1:8248/?disableOnboarding=1',
     ]);
   } finally {
     rmSync(root, { force: true, recursive: true });

--- a/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
@@ -3895,7 +3895,7 @@ test('copied adapter accepts build identity only from the package-local session 
     const fakeXcrun = join(binRoot, 'xcrun');
     writeFileSync(
       fakeXcrun,
-      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){if(process.env.ADAPTER_STARTUP_FAIL==='1'){process.stderr.write('launch refused\\n');process.exit(4);}fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.stdout.write('dev.example: 123\\n');process.exit(0);}process.exit(12);\n",
+      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&(args[1]==='spawn'||args[1]==='launch')){fs.appendFileSync(process.env.ADAPTER_STARTUP+'.calls',JSON.stringify(args.slice(1,4))+'\\n');}if(args[0]==='simctl'&&args[1]==='spawn'&&args[3]==='defaults'){process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){if(process.env.ADAPTER_STARTUP_FAIL==='1'){process.stderr.write('launch refused\\n');process.exit(4);}fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.stdout.write('dev.example: 123\\n');process.exit(0);}process.exit(12);\n",
     );
     chmodSync(fakeXcrun, 0o755);
     writeFileSync(
@@ -3960,6 +3960,46 @@ test('copied adapter accepts build identity only from the package-local session 
     ]);
     assert.match(result.stdout, /"receipt":true/);
     assert.equal(existsSync(abortPath), false);
+    const startupCalls = () => {
+      const calls = readFileSync(`${startupPath}.calls`, 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      rmSync(`${startupPath}.calls`);
+      return calls;
+    };
+    assert.deepEqual(startupCalls(), [
+      ['spawn', 'session-ios-device', 'defaults'],
+      ['spawn', 'session-ios-device', 'defaults'],
+      ['launch', '--terminate-running-process', 'session-ios-device'],
+    ]);
+
+    writeFileSync(
+      join(root, '.rn-agent', 'config.json'),
+      JSON.stringify({ autoHideDevMenu: { simulators: false } }),
+    );
+    const shownDevMenu = spawnSync(process.execPath, [adapterPath, 'ios'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${binRoot}:${process.env.PATH}`,
+        ADAPTER_RECORD: outputPath,
+        ADAPTER_COMPLETION: completionPath,
+        ADAPTER_STARTUP: startupPath,
+        ADAPTER_ABORT: abortPath,
+        ADAPTER_PREPARE: preparePath,
+      },
+    });
+    assert.equal(shownDevMenu.status, 0, shownDevMenu.stderr);
+    assert.deepEqual(startupCalls(), [
+      ['launch', '--terminate-running-process', 'session-ios-device'],
+    ]);
+    assert.deepEqual(JSON.parse(readFileSync(startupPath, 'utf8')).slice(-2), [
+      '--initialUrl',
+      'http://127.0.0.1:8341',
+    ]);
+    rmSync(join(root, '.rn-agent', 'config.json'));
 
     rmSync(completionPath);
     const failedStartup = spawnSync(process.execPath, [adapterPath, 'ios'], {
@@ -4061,7 +4101,7 @@ test('copied adapter aborts pending build authority on every pre-completion fail
     chmodSync(join(binRoot, 'npx'), 0o755);
     writeFileSync(
       join(binRoot, 'xcrun'),
-      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.stdout.write('dev.example: 123\\n');process.exit(0);}process.exit(12);\n",
+      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&args[1]==='spawn'&&args[3]==='defaults'){process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.stdout.write('dev.example: 123\\n');process.exit(0);}process.exit(12);\n",
     );
     chmodSync(join(binRoot, 'xcrun'), 0o755);
     writeFileSync(
@@ -4200,7 +4240,7 @@ test('copied adapter arms interruption recovery before build preparation', () =>
     chmodSync(join(binRoot, 'npx'), 0o755);
     writeFileSync(
       join(binRoot, 'xcrun'),
-      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.stdout.write('dev.example: 123\\n');process.exit(0);}process.exit(12);\n",
+      "#!/usr/bin/env node\nconst fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='simctl'&&args[1]==='get_app_container'){process.stdout.write('/tmp/exact.app\\n');process.exit(0);}if(args[0]==='simctl'&&args[1]==='spawn'&&args[3]==='defaults'){process.exit(0);}if(args[0]==='simctl'&&args[1]==='launch'){fs.writeFileSync(process.env.ADAPTER_STARTUP,JSON.stringify(args));process.stdout.write('dev.example: 123\\n');process.exit(0);}process.exit(12);\n",
     );
     chmodSync(join(binRoot, 'xcrun'), 0o755);
     writeFileSync(

--- a/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
@@ -3956,7 +3956,7 @@ test('copied adapter accepts build identity only from the package-local session 
       'session-ios-device',
       'dev.example',
       '--initialUrl',
-      'http://127.0.0.1:8341',
+      'http://127.0.0.1:8341/?disableOnboarding=1',
     ]);
     assert.match(result.stdout, /"receipt":true/);
     assert.equal(existsSync(abortPath), false);

--- a/packages/shared-agent-knowledge/commands/check-env.md
+++ b/packages/shared-agent-knowledge/commands/check-env.md
@@ -24,7 +24,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action` |
+| Expo first-run tutorial | Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/shared-agent-knowledge/commands/check-env.md
+++ b/packages/shared-agent-knowledge/commands/check-env.md
@@ -24,7 +24,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
+| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/shared-agent-knowledge/commands/check-env.md
+++ b/packages/shared-agent-knowledge/commands/check-env.md
@@ -24,7 +24,7 @@ supported point-of-need recommendation is
 |--------------------|---------------|
 | Expo Developer Menu sheet | `cdp_dev_settings(action="hideDevMenu")` |
 | Expo `Development servers` picker | `cdp_dismiss_dev_client_picker` |
-| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. Prevented at launch by every managed launch and relaunch; if it still appears the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
+| Expo first-run tutorial | Replay the compatible owned locked/helper action through `cdp_run_action`. With `autoHideDevMenu` on (default in `.rn-agent/config.json`), every managed launch and relaunch prevents it and the launch-time menu sheet; if either still appears, the setting is off for that target class or the app was launched outside the managed path (Expo CLI's first Android open, or a URL-less launch): see GH #1016. A reload never reopens the menu once onboarding is stored finished; a menu that reappears after reload means onboarding was never finished for that install |
 | React Native core dev menu | Stop: no authority-approved close remedy exists |
 | App | None |
 

--- a/packages/shared-agent-knowledge/commands/doctor.md
+++ b/packages/shared-agent-knowledge/commands/doctor.md
@@ -36,6 +36,8 @@ because mirroring has a screenshot fallback.
 For runner provenance, inspect the runner artifact/state metadata documented by
 `rn-setup`. For helpers, use a narrow gated CDP read. For CDP auto-reconnect,
 resolve `RN_CDP_AUTOCONNECT` over `.rn-agent/config.json`, then the default.
+In the same row, print the resolved `autoHideDevMenu` (`simulators`, `devices`,
+source `config` or `default`, default hidden on both), read-only.
 
 For plugin-version or Vercel-rule drift, report the documented command but do
 not execute it. Offline version checks do not fail the plugin.


### PR DESCRIPTION
## Intent

Take this issue next: https://github.com/Lykhoyda/rn-dev-agent/issues/1004

Issue 1004: on a fresh Expo dev-client install, the Expo Developer Menu onboarding popup reappears on every app launch until it is acknowledged once. rn-dev-agent relaunches the app in several places (rn_session pin_dev_client, the managed relaunch after a launchApp stage, and the WDA session start of a native segment inside cdp_run_action). cdp_dev_settings hideDevMenu closes the popup only for the current process, and while the popup is up it covers the screen for XCTest/WDA. So a native-segment replay after a relaunch fails with SELECTOR_NOT_FOUND on a fresh simulator. Make every managed launch popup-free by construction, with hideDevMenu kept for gesture-opened menus. A disableOnboarding=1 deep-link test did not appear to persist, while the Info.plist default EXDevMenuIsOnboardingFinished did; the product must not depend on the user's app config.

Later addition: take also in consideration that every reload re-opens the dev menu again, especially when we run actions. So double check this scenario as well.

## What Changed

- Every dev-client launch or relaunch URL that rn-dev-agent builds now goes through the new `withDevMenuOnboardingDisabled` helper in `src/session/dev-client-onboarding.ts`. That covers the build-adapter `postInstall`, the embedded `rn-session-adapter.cjs` copy in `package-integration.ts`, `pinExactDevClient` (`rn_session pin_dev_client`) and `relaunchSessionRuntime`. The helper adds `disableOnboarding=1`, including on the nested URL inside `expo-development-client` links. On iOS simulators, `EXDevMenuShowsAtLaunch=NO` and `EXDevMenuIsOnboardingFinished=YES` are written to the app's defaults domain before launch, so later bare relaunches and reloads also stay free of the popup. The generated adapter fails with `DEV_CLIENT_STARTUP_UNCONFIRMED` if either write fails. Managed Android `am start` launches pass the `EXDevMenuDisableAutoLaunch` intent extra, using a new `extras` parameter on `androidDeeplinkCommandArgs`. `EXPO_PACKAGER_PROXY_URL` and `managedMetroProxyUrl` keep their URLs unchanged, because Expo CLI derives the manifest `hostUri` from them.
- Adds an `autoHideDevMenu` setting to `.rn-agent/config.json`. `resolveAutoHideDevMenu` reads it as either a boolean or `{ simulators, devices }`. It defaults to hidden on both, and a malformed value logs one warning and falls back to the default. `autoHidesDevMenu` applies it per target class: iOS simulators and Android emulators follow `simulators`, physical Android follows `devices`. `cdp_dev_settings` `hideDevMenu` keeps its behavior and is now described as the tool for menus opened by gesture.
- Updates the `cdp_dev_settings` description, docs-site troubleshooting and tool pages, the CLAUDE-MD templates, the check-env/doctor command mirrors (doctor now prints the resolved `autoHideDevMenu`, read-only), and `AGENTS.md`. Also adds a patch changeset, rebuilds the Claude/Codex plugin runtime bundles, and adds or updates unit tests for URL rewriting, config resolution, per-target gating, the ordering of the simctl defaults writes and the launch, and Android intent extras.

## Verification scope

iOS is proven end to end on a fresh simulator (see Testing). Android is covered by unit tests on the adb argv and a native-source review only; device proof on an emulator and a physical phone (managed launch, bare relaunch, reload, and the `autoHideDevMenu` on/off and per-target cases) is pending independent QA before merge.

The Android first-run tutorial on launches rn-dev-agent does not construct (Expo CLI's own first open after `expo run:android`) is out of scope here and tracked in #1016.

## Risk Assessment

✅ Low: The change adds an idempotent URL flag (disableOnboarding=1, set on the nested dev-client url where needed) and the Android EXDevMenuDisableAutoLaunch extra at every rn-dev-agent-constructed launch or relaunch; the installed expo-dev-launcher and expo-dev-menu native code honor both and persist the onboarding-finished preference, which is the same state that stops reloads from reopening the menu. The fix-round doc edit restores the cdp_run_action route exactly as instructed, consistently across all three check-env mirrors.

## Testing

Ran the 139 focused unit tests for the config resolver, URL flagging, Android intent extras, build-adapter defaults-then-launch ordering, pin_dev_client gating and the embedded adapter copy; all passed. On a fresh iOS 26.5 simulator, a build with no `EXDevMenuIsOnboardingFinished` Info.plist key was launched through the real `createBuildLaunchPlan` output with default config. The managed launch, the bare relaunch (native-segment / WDA path) and a log-proven reload all show the app with no onboarding or dev-menu sheet, and EXDevMenuShowsAtLaunch=0 / EXDevMenuIsOnboardingFinished=1 stayed set throughout. With the opt-out config, the same build shows the issue's onboarding popup on the launch and again on the bare relaunch. Only the first Metro `/message` reload reached the app; later broadcasts never triggered a bundle fetch, so only one reload is proven. No Android on-device run was possible because no test-app APK exists. The simulator, Metro and temp files were torn down, and install and build outputs were removed from the worktree.

![Default config: fresh-install managed launch, no dev-menu popup](https://github.com/user-attachments/assets/fe49063f-1e1f-481b-ba53-36f517146cda)
![Default config: bare relaunch (native segment / WDA start path) stays clean](https://github.com/user-attachments/assets/7561cf99-132d-429f-9966-0613608c9dcb)
![Default config: after Metro reload #1 (bundle re-fetch proven in simulator log) stays clean](https://github.com/user-attachments/assets/af966b90-722d-45c6-ba7a-8e81f2398359)
![Opt-out config (autoHideDevMenu.simulators=false): onboarding popup on managed launch](https://github.com/user-attachments/assets/67359df1-b117-4993-b9af-79c81b8f9b8a)
![Opt-out config: popup returns on bare relaunch (the GH #1004 symptom)](https://github.com/user-attachments/assets/9d713983-c3c8-4630-9229-976e6f89933d)
<details>
<summary>Evidence: E2E transcript: config resolution, exact defaults-write/launch argv, persisted prefs per step</summary>

<code>default: config &lt;absent&gt; -&gt; {simulators:true,devices:true,source:default}&#10;default: before: xcrun simctl spawn &lt;sim&gt; defaults write com.rndevagent.testapp EXDevMenuShowsAtLaunch -bool NO&#10;default: before: xcrun simctl spawn &lt;sim&gt; defaults write com.rndevagent.testapp EXDevMenuIsOnboardingFinished -bool YES&#10;default: managed launch: xcrun simctl launch --terminate-running-process &lt;sim&gt; com.rndevagent.testapp --initialUrl http://127.0.0.1:8347/?disableOnboarding=1&#10;default: after launch / bare relaunch / reload: EXDevMenuShowsAtLaunch=0 EXDevMenuIsOnboardingFinished=1&#10;optout: config {autoHideDevMenu:{simulators:false}} -&gt; {simulators:false,devices:true,source:config}&#10;optout: managed launch: ... --initialUrl http://127.0.0.1:8347 (no defaults writes); prefs stay &lt;unset&gt;</code>

```text
[2026-09-11T19:47:37.288Z] default: .rn-agent/config.json=<absent> -> {"simulators":true,"devices":true,"source":"default"}
[2026-09-11T19:47:47.854Z] default: fresh install (prefs cleared); EXDevMenuShowsAtLaunch=<unset> EXDevMenuIsOnboardingFinished=<unset>
[2026-09-11T19:47:47.856Z] default: before: xcrun simctl spawn 3CEB2321-FF37-4113-90B1-FB9AA9207D98 defaults write com.rndevagent.testapp EXDevMenuShowsAtLaunch -bool NO
[2026-09-11T19:47:48.314Z] default: before: xcrun simctl spawn 3CEB2321-FF37-4113-90B1-FB9AA9207D98 defaults write com.rndevagent.testapp EXDevMenuIsOnboardingFinished -bool YES
[2026-09-11T19:47:48.761Z] default: managed launch: xcrun simctl launch --terminate-running-process 3CEB2321-FF37-4113-90B1-FB9AA9207D98 com.rndevagent.testapp --initialUrl http://127.0.0.1:8347/?disableOnboarding=1
[2026-09-11T19:48:18.844Z] default: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-default-1-managed-launch.png; EXDevMenuShowsAtLaunch=0 EXDevMenuIsOnboardingFinished=1
[2026-09-11T19:48:19.084Z] default: bare relaunch (native segment / WDA start path): simctl launch, no arguments
[2026-09-11T19:48:48.558Z] default: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-default-2-bare-relaunch.png; EXDevMenuShowsAtLaunch=0 EXDevMenuIsOnboardingFinished=1
[2026-09-11T19:48:48.559Z] default: reload #1: Metro /message {"method":"reload"}
[2026-09-11T19:49:18.154Z] default: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-default-3-after-reload-1.png; EXDevMenuShowsAtLaunch=0 EXDevMenuIsOnboardingFinished=1
[2026-09-11T19:49:18.155Z] default: reload #2: Metro /message {"method":"reload"}
[2026-09-11T19:49:47.743Z] default: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-default-4-after-reload-2.png; EXDevMenuShowsAtLaunch=0 EXDevMenuIsOnboardingFinished=1
target before 35244ecf10e1f4aa29d384c7d09831cbfa4580b3-1 com.rndevagent.testapp (nm1004-r2)
Error: Unexpected server response: 401
    at ClientRequest.<anonymous> (~/.no-mistakes/worktrees/3df3fd656078/01M28GABBRVN2WFY8K17DMKBJ1/node_modules/ws/lib/websocket.js:930:7)
    at ClientRequest.emit (node:events:514:20)
    at HTTPParser.parserOnIncomingClient (node:_http_client:973:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:125:17)
    at Socket.socketOnData (node:_http_client:808:22)
    at Socket.emit (node:events:514:20)
    at addChunk (node:internal/streams/readable:575:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:526:3)
    at Readable.push (node:internal/streams/readable:406:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:189:23)
target before 35244ecf10e1f4aa29d384c7d09831cbfa4580b3-1 com.rndevagent.testapp (nm1004-r2)
Error: timeout
    at Timeout._onTimeout (/private/tmp/nm1004r2-reloadprobe.cjs:13:29)
    at listOnTimeout (node:internal/timers:685:17)
    at process.processTimers (node:internal/timers:618:7)
[2026-09-11T19:53:56.960Z] optout: .rn-agent/config.json={"autoHideDevMenu":{"simulators":false}} -> {"simulators":false,"devices":true,"source":"config"}
[2026-09-11T19:54:09.579Z] optout: fresh install (prefs cleared); EXDevMenuShowsAtLaunch=<unset> EXDevMenuIsOnboardingFinished=<unset>
[2026-09-11T19:54:09.623Z] optout: managed launch: xcrun simctl launch --terminate-running-process 3CEB2321-FF37-4113-90B1-FB9AA9207D98 com.rndevagent.testapp --initialUrl http://127.0.0.1:8347
[2026-09-11T19:54:39.533Z] optout: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-optout-1-managed-launch.png; EXDevMenuShowsAtLaunch=<unset> EXDevMenuIsOnboardingFinished=<unset>
[2026-09-11T19:54:39.720Z] optout: bare relaunch (native segment / WDA start path): simctl launch, no arguments
[2026-09-11T19:55:09.182Z] optout: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-optout-2-bare-relaunch.png; EXDevMenuShowsAtLaunch=<unset> EXDevMenuIsOnboardingFinished=<unset>
[2026-09-11T19:55:09.183Z] optout: reload #1: Metro /message {"method":"reload"}
[2026-09-11T19:55:38.991Z] optout: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-optout-3-after-reload-1.png; EXDevMenuShowsAtLaunch=<unset> EXDevMenuIsOnboardingFinished=<unset>
[2026-09-11T19:55:38.992Z] optout: reload #2: Metro /message {"method":"reload"}
[2026-09-11T19:56:08.624Z] optout: screenshot ~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1/r2-optout-4-after-reload-2.png; EXDevMenuShowsAtLaunch=<unset> EXDevMenuIsOnboardingFinished=<unset>
```
</details>
<details>
<summary>Evidence: Reproducible e2e harness driving the committed createBuildLaunchPlan</summary>

```text
// GH #1004 round-2 e2e on committed target: config -> resolveAutoHideDevMenu -> createBuildLaunchPlan -> real simctl.
// Usage: SIM=<udid> APP=<.app> node nm1004r2-e2e.mjs <label> <none|off>
import { execFileSync } from 'node:child_process';
import { createRequire } from 'node:module';
import { appendFileSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
import { tmpdir } from 'node:os';
import { join } from 'node:path';
import { setTimeout as sleep } from 'node:timers/promises';

const CORE = '~/.no-mistakes/worktrees/3df3fd656078/01M28GABBRVN2WFY8K17DMKBJ1/packages/rn-dev-agent-core';
const EV = '~/.no-mistakes/evidence/01M28GABBRVN2WFY8K17DMKBJ1';
const WebSocket = createRequire(`${CORE}/package.json`)('ws');
const { createBuildLaunchPlan } = await import(`${CORE}/dist/session/build-adapter.js`);
const { readRnAgentConfig, resolveAutoHideDevMenu } = await import(`${CORE}/dist/project-config.js`);

const [label, configMode] = process.argv.slice(2);
const { SIM, APP } = process.env;
const PORT = 8347;
const APP_ID = 'com.rndevagent.testapp';
const log = (line) => {
  const text = `[${new Date().toISOString()}] ${label}: ${line}`;
  console.log(text);
  appendFileSync(`${EV}/r2-transcript.txt`, `${text}\n`);
};
const simctl = (...args) => execFileSync('xcrun', ['simctl', ...args], { encoding: 'utf8' }).trim();
const prefs = () =>
  ['EXDevMenuShowsAtLaunch', 'EXDevMenuIsOnboardingFinished']
    .map((key) => {
      try {
        return `${key}=${simctl('spawn', SIM, 'defaults', 'read', APP_ID, key)}`;
      } catch {
        return `${key}=<unset>`;
      }
    })
    .join(' ');
const shot = async (name) => {
  await sleep(28_000);
  const path = `${EV}/r2-${label}-${name}.png`;
  simctl('io', SIM, 'screenshot', path);
  log(`screenshot ${path}; ${prefs()}`);
};
const reload = () =>
  new Promise((resolve, reject) => {
    const socket = new WebSocket(`ws://127.0.0.1:${PORT}/message`);
    socket.on('open', () => {
      socket.send(JSON.stringify({ version: 2, method: 'reload' }));
      setTimeout(() => (socket.close(), resolve()), 500);
    });
    socket.on('error', reject);
  });

const appRoot = mkdtempSync(join(tmpdir(), 'nm1004r2-root-'));
if (configMode === 'off') {
  mkdirSync(join(appRoot, '.rn-agent'));
  writeFileSync(join(appRoot, '.rn-agent', 'config.json'), JSON.stringify({ autoHideDevMenu: { simulators: false } }));
}
const setting = resolveAutoHideDevMenu({ readConfig: () => readRnAgentConfig(appRoot) });
log(`.rn-agent/config.json=${configMode === 'off' ? '{"autoHideDevMenu":{"simulators":false}}' : '<absent>'} -> ${JSON.stringify(setting)}`);

simctl('uninstall', SIM, APP_ID);
try {
  simctl('spawn', SIM, 'defaults', 'delete', APP_ID);
} catch {}
simctl('install', SIM, APP);
log(`fresh install (prefs cleared); ${prefs()}`);

const plan = createBuildLaunchPlan({
  platform: 'ios',
  command: ['npx', 'expo', 'run:ios'],
  session: { platform: 'ios', deviceId: SIM, appId: APP_ID, metroPort: PORT, sessionId: 'nm1004-r2', simulator: true },
  autoHideDevMenu: setting,
});
for (const argv of plan.postInstall.before) {
  log(`before: ${argv.join(' ')}`);
  execFileSync(argv[0], argv.slice(1));
}
log(`managed launch: ${plan.postInstall.command.join(' ')}`);
execFileSync(plan.postInstall.command[0], plan.postInstall.command.slice(1));
await shot('1-managed-launch');

simctl('terminate', SIM, APP_ID);
log('bare relaunch (native segment / WDA start path): simctl launch, no arguments');
simctl('launch', SIM, APP_ID);
await shot('2-bare-relaunch');

for (const n of [1, 2]) {
  log(`reload #${n}: Metro /message {"method":"reload"}`);
  await reload();
  await shot(`${2 + n}-after-reload-${n}`);
}
```
</details>
- Outcome: ⚠️ 1 warning across 2 runs (1h0m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"abfd95f6be8058b722adc4578f2f53e0a52547f6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `packages/shared-agent-knowledge/commands/check-env.md:27` - The `Expo first-run tutorial` row used to give agents a route: &#34;Replay the compatible owned locked/helper action through `cdp_run_action`&#34;. This change replaces it with an explanation that ends in &#34;see GH #1016&#34;, so the agent is left with no tool route. The same row still says the tutorial can appear, for example on Expo CLI&#39;s first Android open during an rn-dev-agent session build, or after a URL-less launch. `foreground-surface-remedy.ts` still maps only `expo_dev_menu`, so `hideDevMenu` returns `first_run_tutorial, executed: false` there. An agent that follows check-env after a fresh Android build then has nothing to try. The intent asks for popup-free managed launches with hideDevMenu kept for gesture-opened menus. It does not ask to drop the existing tutorial fallback. Please confirm the removal is deliberate, or keep the prior cdp_run_action route alongside the new explanation until GH #1016 lands. The same text is mirrored in the claude-plugin and codex-plugin copies of check-env.md.

🔧 Fix: Restore cdp_run_action route for Expo first-run tutorial
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `packages/rn-dev-agent-core/src/session/build-adapter.ts:206` - Tested on a fresh iOS 26.5 simulator with the Expo 56 dev-client test app, launched with the branch&#39;s argv (`--initialUrl http://127.0.0.1:&lt;port&gt;/?disableOnboarding=1`). The first managed launch still shows the full Expo dev-menu sheet (Reload / Go home / Tools) over the app. It is not the onboarding tutorial. It comes from expo-dev-menu&#39;s `EXDevMenuShowsAtLaunch`, which defaults to true on iOS and is cleared only after one auto-open. Persisted prefs afterwards: `EXDevMenuIsOnboardingFinished=true`, `EXDevMenuShowsAtLaunch=false`. So a native segment or WDA snapshot run right after the first managed launch on a fresh install (e.g. build postInstall or pin with no relaunch in between) would still hit a covered screen. On Android the change passes the `EXDevMenuDisableAutoLaunch` intent extra; iOS gets no equivalent. I checked the obvious iOS counterpart: passing `-EXDevMenuDisableAutoLaunch YES` as a `simctl launch` argument makes the first launch clean, but `EXDevMenuShowsAtLaunch` stays true, so the sheet just moves to the next bare relaunch. The only non-arg fix I can see is to durably persist `EXDevMenuShowsAtLaunch=false` in the app&#39;s defaults (untested). The new `cdp_dev_settings` description and check-env text treat this one-time sheet as `hideDevMenu` territory, while the intent reserves `hideDevMenu` for gesture-opened menus. Please decide whether the one-time iOS shows-at-launch sheet is acceptable or should also be suppressed by construction. Evidence: fixed-1-managed-launch.png, probe-first-launch-with-disable-autolaunch-arg.png, probe-bare-relaunch-after-arg.png.
- <code>`yarn build` (rn-dev-agent-core) then `node --test test/unit/gh-1004-dev-menu-onboarding-url.test.ts test/unit/device-deeplink-target.test.ts test/unit/session/build-adapter.test.ts test/unit/session/dev-client-authority.test.ts test/unit/session/expo-cli-parser.test.ts test/unit/session/package-integration.test.ts`: 131/131 pass</code>
- <code>Manual e2e, baseline argv on a fresh dedicated iOS 26.5 simulator with the prebuilt Expo 56 dev-client (`com.rndevagent.testapp`, no `EXDevMenuIsOnboardingFinished` in Info.plist) served by Metro on :8347: `simctl launch --initialUrl http://127.0.0.1:8347`, then bare `simctl terminate` + `simctl launch`, then a Metro `/message` reload broadcast, screenshotting after each</code>
- <code>Manual e2e, fixed argv on a fresh reinstall: URL built with the branch&#39;s `withDevMenuOnboardingDisabled(managedMetroProxyUrl(...))` from dist (`http://127.0.0.1:8347/?disableOnboarding=1`), then the same bare relaunch and reload steps, screenshotting after each</code>
- <code>Read persisted prefs from the app data container with `plutil -p &lt;data&gt;/Library/Preferences/com.rndevagent.testapp.plist`</code>
- <code>Probe: fresh install with `-EXDevMenuDisableAutoLaunch YES` added to the launch, then a bare relaunch, to test a possible iOS remedy for the first-launch sheet</code>
- <code>Read expo-dev-launcher/expo-dev-menu 56.0.18 iOS source (`disableOnboardingPopupIfNeeded`, `updateAutoLaunchObserver`, `DevMenuPreferences.setup`) to explain the reload and shows-at-launch behavior</code>
- `Cleanup: stopped Metro, deleted the dedicated simulator, removed node_modules, dist and install-state from the worktree`

🔧 Fix: Add autoHideDevMenu config and iOS simulator dev-menu defaults
1 warning still open:

- ⚠️ `packages/rn-dev-agent-core/src/index.ts:1264` - The Android half of the fix has no on-device evidence. That half is `?disableOnboarding=1` on the adb deep link plus the `--ez EXDevMenuDisableAutoLaunch true` intent extra, used in pin_dev_client openUrl and the managed relaunch. Only unit tests covering the adb argv prove it. No test-app APK exists on this host: the Pixel_9_Pro AVD is available, but `test-app/android` has no build output. Producing one needs a Gradle build in the separate rn-dev-agent-workspace checkout, outside this worktree. iOS is proven end-to-end. Decide whether an Android emulator run (build the test app, then launch managed / bare relaunch / reload) is required before shipping, or whether unit coverage plus the native-source review from earlier rounds is enough.
- <code>`YARN_ENABLE_SCRIPTS=0 yarn install --immutable` + `yarn build` in packages/rn-dev-agent-core (setup only)</code>
- <code>`node --test test/unit/auto-hide-dev-menu-config.test.js test/unit/gh-1004-dev-menu-onboarding-url.test.ts test/unit/device-deeplink-target.test.ts test/unit/session/build-adapter.test.ts test/unit/session/dev-client-authority.test.ts test/unit/session/expo-cli-parser.test.ts test/unit/session/package-integration.test.ts` (139/139 pass)</code>
- <code>Checked that the committed claude-plugin and codex-plugin `dist/index.js` bundles contain the autoHideDevMenu / EXDevMenuShowsAtLaunch code and are byte-identical (`cmp`)</code>
- <code>Manual e2e on a fresh iOS 26.5 simulator with the Expo 56 test-app build that has no EXDevMenuIsOnboardingFinished Info.plist key, Metro on :8347. Chain: real `.rn-agent/config.json` → `resolveAutoHideDevMenu` → `createBuildLaunchPlan` → its `postInstall.before` defaults writes and launch argv run verbatim. Then a bare `simctl terminate`+`launch` (native-segment / WDA path) and Metro `/message` reloads, with screenshots and persisted prefs at each step (`r2-scenario.mjs default none`)</code>
- <code>Same scenario with `{&#34;autoHideDevMenu&#34;:{&#34;simulators&#34;:false}}` as an opt-out contrast (`r2-scenario.mjs optout off`)</code>
- <code>Confirmed from the simulator&#39;s `log show` that reload #1 re-fetched the full index.bundle (a real JS restart)</code>
- <code>Tried rn-dev-agent `cdp_status` / `rn_session bind_device` / `bind_metro` to drive `cdp_reload`. The external Metro could not be bound without a managed instance ID and build receipt, so reload proof fell back to the simulator logs</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces configurable suppression of Expo dev-menu onboarding and launch-time sheets across managed dev-client launch paths.
- Adds URL rewriting for plain and nested Expo development-client URLs.
- Persists iOS simulator dev-menu preferences before managed launches and adds Android intent extras.
- Resolves `autoHideDevMenu` per simulator/device target class and documents the behavior.
- Updates embedded and packaged host runtimes with focused launch, configuration, and command-generation tests.
- One repository-rule violation remains in the extension of a newly added test file.
</details>


<h3>Confidence Score: 4/5</h3>

The implementation appears behaviorally safe, but the new JavaScript test must be converted to TypeScript before merging to satisfy an explicit repository requirement.

No blocking launch or configuration failure was established; the sole accepted finding is the prohibited `.js` extension on newly added test code.

**Files Needing Attention:** packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.js

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/rn-dev-agent-core/src/session/dev-client-onboarding.ts | Centralizes target-class gating, nested URL rewriting, Android intent extras, and iOS simulator preference commands. |
| packages/rn-dev-agent-core/src/index.ts | Applies the resolved setting and platform-specific suppression to pin and relaunch operations. |
| packages/rn-dev-agent-core/src/project-config.ts | Adds validated boolean or per-target resolution for `autoHideDevMenu`, with safe defaults and malformed-value warnings. |
| packages/rn-dev-agent-core/src/session/package-integration.ts | Mirrors iOS launch suppression in the generated session adapter and fails startup when required preference writes fail. |
| packages/rn-dev-agent-core/test/unit/auto-hide-dev-menu-config.test.js | Adds focused configuration-resolution coverage but violates the repository requirement that new tests use TypeScript. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[".rn-agent/config.json"] --> R["resolve autoHideDevMenu"]
  R --> G{"Hide for target class?"}
  G -->|No| P["Launch with original URL"]
  G -->|Yes, iOS simulator| I["Write Expo dev-menu defaults"]
  G -->|Yes, Android| A["Add EXDevMenuDisableAutoLaunch extra"]
  I --> U["Add disableOnboarding=1 to launch URL"]
  A --> U
  U --> L["Managed launch or relaunch"]
  P --> L
```
</details>

<sub>Reviews (1): Last reviewed commit: ["no-mistakes(document): Format dev-menu o..."](https://github.com/lykhoyda/rn-dev-agent/commit/c1113b45d347460c91b1f65ffd09e8453bbcb73d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63238608)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/lykhoyda/rn-dev-agent/blob/main/AGENTS.md))

<!-- /greptile_comment -->
