### PR TITLE
fix(core): replay wrapped tab presses with scoped ownership

### DIFF
--- a/.changeset/single-host-replay-press.md
+++ b/.changeset/single-host-replay-press.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Fix saved-action presses through forwarding wrappers around one native host while preserving ambiguity refusal for separate controls.

--- a/.changeset/single-host-replay-press.md
+++ b/.changeset/single-host-replay-press.md
@@ -3,4 +3,4 @@
 'rn-dev-agent-plugin': patch
 ---
 
-Fix saved-action presses that forward one testID through wrappers around a single native host, while separate controls with distinct handlers still refuse as ambiguous. HELPERS_VERSION bumped to 63 so connected sessions re-inject.
+Fix saved-action presses that forward one testID through wrappers around a single native host, with HELPERS_VERSION bumped to 63 so connected sessions re-inject, while separate controls with distinct handlers still refuse as ambiguous.

--- a/.changeset/single-host-replay-press.md
+++ b/.changeset/single-host-replay-press.md
@@ -3,4 +3,4 @@
 'rn-dev-agent-plugin': patch
 ---
 
-Fix saved-action presses through forwarding wrappers around one native host while preserving ambiguity refusal for separate controls.
+Fix saved-action presses that forward one testID through wrappers around a single native host, while separate controls with distinct handlers still refuse as ambiguous.

--- a/.changeset/single-host-replay-press.md
+++ b/.changeset/single-host-replay-press.md
@@ -3,4 +3,4 @@
 'rn-dev-agent-plugin': patch
 ---
 
-Fix saved-action presses that forward one testID through wrappers around a single native host, while separate controls with distinct handlers still refuse as ambiguous.
+Fix saved-action presses that forward one testID through wrappers around a single native host, while separate controls with distinct handlers still refuse as ambiguous. HELPERS_VERSION bumped to 63 so connected sessions re-inject.

--- a/apps/docs-site/src/content/docs/actions/index.mdx
+++ b/apps/docs-site/src/content/docs/actions/index.mdx
@@ -203,9 +203,12 @@ that the next step does not consume fails the replay. A `tapOn` whose exact targ
 such an input and carries no `onPress` walks up to the nearest pressable ancestor within
 eight fibers and presses it, refusing when no ancestor exists, when several distinct
 pressables resolve, or when the walked-to pressable or any exact-ID fiber is disabled, hidden,
-or blocked by `pointerEvents` on its host view. Native WDA blindness is reported as
-`NATIVE_SURFACE_BLIND` only when a bounded same-screen native snapshot saw the selector WDA
-missed; runtime version alone is never proof, and ordinary selector misses stay ordinary.
+or blocked by `pointerEvents` on its host view. Wrappers that forward one `testID` around a
+single native host through inert views — a bottom-tab button, for example — are one control
+rather than an ambiguity: the press resolves to the nearest `onPress` above that host.
+Native WDA blindness is reported as `NATIVE_SURFACE_BLIND` only when a bounded same-screen
+native snapshot saw the selector WDA missed; runtime version alone is never proof, and
+ordinary selector misses stay ordinary.
 
 ## What actions are NOT
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -51658,7 +51658,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 62;
+var HELPERS_VERSION = 63;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -54586,21 +54586,7 @@ var INJECTED_HELPERS = `
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
-          if (!outer) return false;
-          var child = outer === a ? b : a;
-          var node = child.return;
-          var seen = new WeakSet();
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (seen.has(node)) return false;
-            seen.add(node);
-            if (!walkChildOf(node, child)) return false;
-            if (node.tag === 5 && !walkInertView(node)) return false;
-            if (node === outer) return true;
-            child = node;
-            node = node.return;
-          }
-          return false;
+          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -55963,7 +55963,7 @@ var INJECTED_HELPERS = `
 
   // React return chains may thread through either half of a fiber/alternate pair.
   function sameFiber(a, b) {
-    return a === b || (!!b && a === b.alternate);
+    return !!a && !!b && (a === b || a.alternate === b || b.alternate === a);
   }
 
   function isTestIdFrontmost(testID) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -54573,14 +54573,6 @@ var INJECTED_HELPERS = `
           }
           return true;
         };
-        var walkChildOf = function(parent, child) {
-          var node = parent.child;
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (node === child) return true;
-            node = node.sibling;
-          }
-          return false;
-        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
@@ -54632,7 +54624,6 @@ var INJECTED_HELPERS = `
           var node = host;
           while (node && lineage.length < 1000) {
             if (seen.has(node)) return null;
-            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
             seen.add(node);
             lineage.push(node);
             node = node.return;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -54540,6 +54540,7 @@ var INJECTED_HELPERS = `
 
     try {
       if (action === 'press' && opts.walkUp === true) {
+        // 8 levels covers ~2 JSX wrappers: one wrapper is ~3 fibers under NativeWind CssInterop.
         var WALK_UP_MAX = 8;
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
@@ -54593,7 +54594,7 @@ var INJECTED_HELPERS = `
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
-          walkOriginalCandidates.push(walkNode);
+          walkOriginalCandidates.push({ fiber: walkNode, hops: walkHops, source: walkSources[wi] });
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -54629,25 +54630,29 @@ var INJECTED_HELPERS = `
             node = node.return;
           }
           if (node) return null;
+          var lineageIndex = function(f) {
+            for (var li = 0; li < lineage.length; li++) {
+              if (sameFiber(f, lineage[li])) return li;
+            }
+            return -1;
+          };
           for (var si = 0; si < walkSources.length; si++) {
-            if (!seen.has(walkSources[si])) return null;
+            if (lineageIndex(walkSources[si]) < 0) return null;
           }
+          var hostTarget = null;
           var outermost = 0;
           for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
             var candidate = walkOriginalCandidates[ci];
-            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
-            outermost = Math.max(outermost, lineage.indexOf(candidate));
+            var candidateIndex = lineageIndex(candidate.fiber);
+            if (candidateIndex < 0 || candidate.fiber.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, candidateIndex);
+            if (candidate.source === host) hostTarget = candidate;
           }
+          if (!hostTarget) return null;
           for (var li = 1; li <= outermost; li++) {
             if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
           }
-          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
-            var p = lineage[hops].memoizedProps;
-            if (p && typeof p.onPress === 'function') {
-              return { fiber: lineage[hops], hops: hops, source: host };
-            }
-          }
-          return null;
+          return hostTarget;
         };
         if (walkCandidates.length > 1) {
           var witnessedTarget = walkSingleHostTarget();
@@ -55956,6 +55961,11 @@ var INJECTED_HELPERS = `
     return { eligible: true };
   }
 
+  // React return chains may thread through either half of a fiber/alternate pair.
+  function sameFiber(a, b) {
+    return a === b || (!!b && a === b.alternate);
+  }
+
   function isTestIdFrontmost(testID) {
     if (typeof testID !== 'string' || !testID) {
       return JSON.stringify({ visible: false, reason: 'testID is required' });
@@ -55999,12 +56009,10 @@ var INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
-      // React return chains may thread through either half of a fiber/alternate pair.
-      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor || current === ancestorAlternate) return true;
+        if (sameFiber(current, ancestor)) return true;
         current = current.return;
       }
       return false;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -54540,10 +54540,7 @@ var INJECTED_HELPERS = `
 
     try {
       if (action === 'press' && opts.walkUp === true) {
-        // GH #525 \u2014 nearest self-or-ancestor onPress within 8 fiber levels (one JSX wrapper is ~3 fibers under NativeWind CssInterop);
-        // candidates collapse only when they are the exact same fiber.
         var WALK_UP_MAX = 8;
-        // Host fibers carry a string type (e.g. 'RCTView') \u2014 same extraction as the ladder press path.
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
             ? f.type
@@ -54564,17 +54561,50 @@ var INJECTED_HELPERS = `
           }
           return false;
         };
-        // RN forwards testID and onPress down one element's composite/host stack; those fibers are
-        // the same logical target, so they collapse onto the outermost the way a direct press fires it.
+        var walkInertView = function(f) {
+          if (f.type !== 'RCTView') return false;
+          var p = f.memoizedProps || {};
+          if (p.accessible === true || p.focusable === true || (p.accessibilityRole && p.accessibilityRole !== 'none')
+            || (p.role && p.role !== 'none' && p.role !== 'presentation')) return false;
+          var keys = Object.keys(p);
+          for (var ki = 0; ki < keys.length; ki++) {
+            if (/^on(Press|LongPress|Click|DoubleClick|Touch|Responder|.*ShouldSetResponder|Pointer|Key|Accessibility|MagicTap)/.test(keys[ki])
+              && p[keys[ki]] != null) return false;
+          }
+          return true;
+        };
+        var walkChildOf = function(parent, child) {
+          var node = parent.child;
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (node === child) return true;
+            node = node.sibling;
+          }
+          return false;
+        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
+          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
+          if (!outer) return false;
+          var child = outer === a ? b : a;
+          var node = child.return;
+          var seen = new WeakSet();
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (seen.has(node)) return false;
+            seen.add(node);
+            if (!walkChildOf(node, child)) return false;
+            if (node.tag === 5 && !walkInertView(node)) return false;
+            if (node === outer) return true;
+            child = node;
+            node = node.return;
+          }
+          return false;
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];
+        var walkOriginalCandidates = [];
         for (var wi = 0; wi < walkSources.length; wi++) {
           var walkNode = walkSources[wi];
           var walkHops = 0;
@@ -54585,6 +54615,7 @@ var INJECTED_HELPERS = `
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
+          walkOriginalCandidates.push(walkNode);
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -54601,6 +54632,49 @@ var INJECTED_HELPERS = `
         }
         if (walkCandidates.length === 0) {
           return JSON.stringify({ error: 'Component has no onPress handler', component: walkFiberName(found), testID: selector, walkUpSearched: WALK_UP_MAX });
+        }
+        var walkSingleHostTarget = function() {
+          if (!opts.testID || findCycleDetected) return null;
+          var hosts = new Set();
+          for (var si = 0; si < walkSources.length; si++) {
+            if (walkSources[si].tag === 5) hosts.add(walkSources[si]);
+          }
+          if (hosts.size !== 1) return null;
+          var host = hosts.values().next().value;
+          var lineage = [];
+          var seen = new WeakSet();
+          var node = host;
+          while (node && lineage.length < 1000) {
+            if (seen.has(node)) return null;
+            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
+            seen.add(node);
+            lineage.push(node);
+            node = node.return;
+          }
+          if (node) return null;
+          for (var si = 0; si < walkSources.length; si++) {
+            if (!seen.has(walkSources[si])) return null;
+          }
+          var outermost = 0;
+          for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
+            var candidate = walkOriginalCandidates[ci];
+            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, lineage.indexOf(candidate));
+          }
+          for (var li = 1; li <= outermost; li++) {
+            if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
+          }
+          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
+            var p = lineage[hops].memoizedProps;
+            if (p && typeof p.onPress === 'function') {
+              return { fiber: lineage[hops], hops: hops, source: host };
+            }
+          }
+          return null;
+        };
+        if (walkCandidates.length > 1) {
+          var witnessedTarget = walkSingleHostTarget();
+          if (witnessedTarget) walkCandidates = [witnessedTarget];
         }
         if (walkCandidates.length > 1) {
           var walkDescriptors = [];

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -64483,7 +64483,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 62;
+    HELPERS_VERSION = 63;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -68788,7 +68788,7 @@ var init_injected_helpers = __esm({
 
   // React return chains may thread through either half of a fiber/alternate pair.
   function sameFiber(a, b) {
-    return a === b || (!!b && a === b.alternate);
+    return !!a && !!b && (a === b || a.alternate === b || b.alternate === a);
   }
 
   function isTestIdFrontmost(testID) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67365,6 +67365,7 @@ var init_injected_helpers = __esm({
 
     try {
       if (action === 'press' && opts.walkUp === true) {
+        // 8 levels covers ~2 JSX wrappers: one wrapper is ~3 fibers under NativeWind CssInterop.
         var WALK_UP_MAX = 8;
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
@@ -67418,7 +67419,7 @@ var init_injected_helpers = __esm({
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
-          walkOriginalCandidates.push(walkNode);
+          walkOriginalCandidates.push({ fiber: walkNode, hops: walkHops, source: walkSources[wi] });
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -67454,25 +67455,29 @@ var init_injected_helpers = __esm({
             node = node.return;
           }
           if (node) return null;
+          var lineageIndex = function(f) {
+            for (var li = 0; li < lineage.length; li++) {
+              if (sameFiber(f, lineage[li])) return li;
+            }
+            return -1;
+          };
           for (var si = 0; si < walkSources.length; si++) {
-            if (!seen.has(walkSources[si])) return null;
+            if (lineageIndex(walkSources[si]) < 0) return null;
           }
+          var hostTarget = null;
           var outermost = 0;
           for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
             var candidate = walkOriginalCandidates[ci];
-            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
-            outermost = Math.max(outermost, lineage.indexOf(candidate));
+            var candidateIndex = lineageIndex(candidate.fiber);
+            if (candidateIndex < 0 || candidate.fiber.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, candidateIndex);
+            if (candidate.source === host) hostTarget = candidate;
           }
+          if (!hostTarget) return null;
           for (var li = 1; li <= outermost; li++) {
             if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
           }
-          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
-            var p = lineage[hops].memoizedProps;
-            if (p && typeof p.onPress === 'function') {
-              return { fiber: lineage[hops], hops: hops, source: host };
-            }
-          }
-          return null;
+          return hostTarget;
         };
         if (walkCandidates.length > 1) {
           var witnessedTarget = walkSingleHostTarget();
@@ -68781,6 +68786,11 @@ var init_injected_helpers = __esm({
     return { eligible: true };
   }
 
+  // React return chains may thread through either half of a fiber/alternate pair.
+  function sameFiber(a, b) {
+    return a === b || (!!b && a === b.alternate);
+  }
+
   function isTestIdFrontmost(testID) {
     if (typeof testID !== 'string' || !testID) {
       return JSON.stringify({ visible: false, reason: 'testID is required' });
@@ -68824,12 +68834,10 @@ var init_injected_helpers = __esm({
       });
     }
     function containsFiber(ancestor, candidate) {
-      // React return chains may thread through either half of a fiber/alternate pair.
-      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor || current === ancestorAlternate) return true;
+        if (sameFiber(current, ancestor)) return true;
         current = current.return;
       }
       return false;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67365,10 +67365,7 @@ var init_injected_helpers = __esm({
 
     try {
       if (action === 'press' && opts.walkUp === true) {
-        // GH #525 \u2014 nearest self-or-ancestor onPress within 8 fiber levels (one JSX wrapper is ~3 fibers under NativeWind CssInterop);
-        // candidates collapse only when they are the exact same fiber.
         var WALK_UP_MAX = 8;
-        // Host fibers carry a string type (e.g. 'RCTView') \u2014 same extraction as the ladder press path.
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
             ? f.type
@@ -67389,17 +67386,50 @@ var init_injected_helpers = __esm({
           }
           return false;
         };
-        // RN forwards testID and onPress down one element's composite/host stack; those fibers are
-        // the same logical target, so they collapse onto the outermost the way a direct press fires it.
+        var walkInertView = function(f) {
+          if (f.type !== 'RCTView') return false;
+          var p = f.memoizedProps || {};
+          if (p.accessible === true || p.focusable === true || (p.accessibilityRole && p.accessibilityRole !== 'none')
+            || (p.role && p.role !== 'none' && p.role !== 'presentation')) return false;
+          var keys = Object.keys(p);
+          for (var ki = 0; ki < keys.length; ki++) {
+            if (/^on(Press|LongPress|Click|DoubleClick|Touch|Responder|.*ShouldSetResponder|Pointer|Key|Accessibility|MagicTap)/.test(keys[ki])
+              && p[keys[ki]] != null) return false;
+          }
+          return true;
+        };
+        var walkChildOf = function(parent, child) {
+          var node = parent.child;
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (node === child) return true;
+            node = node.sibling;
+          }
+          return false;
+        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
+          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
+          if (!outer) return false;
+          var child = outer === a ? b : a;
+          var node = child.return;
+          var seen = new WeakSet();
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (seen.has(node)) return false;
+            seen.add(node);
+            if (!walkChildOf(node, child)) return false;
+            if (node.tag === 5 && !walkInertView(node)) return false;
+            if (node === outer) return true;
+            child = node;
+            node = node.return;
+          }
+          return false;
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];
+        var walkOriginalCandidates = [];
         for (var wi = 0; wi < walkSources.length; wi++) {
           var walkNode = walkSources[wi];
           var walkHops = 0;
@@ -67410,6 +67440,7 @@ var init_injected_helpers = __esm({
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
+          walkOriginalCandidates.push(walkNode);
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -67426,6 +67457,49 @@ var init_injected_helpers = __esm({
         }
         if (walkCandidates.length === 0) {
           return JSON.stringify({ error: 'Component has no onPress handler', component: walkFiberName(found), testID: selector, walkUpSearched: WALK_UP_MAX });
+        }
+        var walkSingleHostTarget = function() {
+          if (!opts.testID || findCycleDetected) return null;
+          var hosts = new Set();
+          for (var si = 0; si < walkSources.length; si++) {
+            if (walkSources[si].tag === 5) hosts.add(walkSources[si]);
+          }
+          if (hosts.size !== 1) return null;
+          var host = hosts.values().next().value;
+          var lineage = [];
+          var seen = new WeakSet();
+          var node = host;
+          while (node && lineage.length < 1000) {
+            if (seen.has(node)) return null;
+            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
+            seen.add(node);
+            lineage.push(node);
+            node = node.return;
+          }
+          if (node) return null;
+          for (var si = 0; si < walkSources.length; si++) {
+            if (!seen.has(walkSources[si])) return null;
+          }
+          var outermost = 0;
+          for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
+            var candidate = walkOriginalCandidates[ci];
+            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, lineage.indexOf(candidate));
+          }
+          for (var li = 1; li <= outermost; li++) {
+            if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
+          }
+          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
+            var p = lineage[hops].memoizedProps;
+            if (p && typeof p.onPress === 'function') {
+              return { fiber: lineage[hops], hops: hops, source: host };
+            }
+          }
+          return null;
+        };
+        if (walkCandidates.length > 1) {
+          var witnessedTarget = walkSingleHostTarget();
+          if (witnessedTarget) walkCandidates = [witnessedTarget];
         }
         if (walkCandidates.length > 1) {
           var walkDescriptors = [];

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67398,14 +67398,6 @@ var init_injected_helpers = __esm({
           }
           return true;
         };
-        var walkChildOf = function(parent, child) {
-          var node = parent.child;
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (node === child) return true;
-            node = node.sibling;
-          }
-          return false;
-        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
@@ -67457,7 +67449,6 @@ var init_injected_helpers = __esm({
           var node = host;
           while (node && lineage.length < 1000) {
             if (seen.has(node)) return null;
-            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
             seen.add(node);
             lineage.push(node);
             node = node.return;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67411,21 +67411,7 @@ var init_injected_helpers = __esm({
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
-          if (!outer) return false;
-          var child = outer === a ? b : a;
-          var node = child.return;
-          var seen = new WeakSet();
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (seen.has(node)) return false;
-            seen.add(node);
-            if (!walkChildOf(node, child)) return false;
-            if (node.tag === 5 && !walkInertView(node)) return false;
-            if (node === outer) return true;
-            child = node;
-            node = node.return;
-          }
-          return false;
+          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -51658,7 +51658,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 62;
+var HELPERS_VERSION = 63;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -54586,21 +54586,7 @@ var INJECTED_HELPERS = `
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
-          if (!outer) return false;
-          var child = outer === a ? b : a;
-          var node = child.return;
-          var seen = new WeakSet();
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (seen.has(node)) return false;
-            seen.add(node);
-            if (!walkChildOf(node, child)) return false;
-            if (node.tag === 5 && !walkInertView(node)) return false;
-            if (node === outer) return true;
-            child = node;
-            node = node.return;
-          }
-          return false;
+          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -55963,7 +55963,7 @@ var INJECTED_HELPERS = `
 
   // React return chains may thread through either half of a fiber/alternate pair.
   function sameFiber(a, b) {
-    return a === b || (!!b && a === b.alternate);
+    return !!a && !!b && (a === b || a.alternate === b || b.alternate === a);
   }
 
   function isTestIdFrontmost(testID) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -54573,14 +54573,6 @@ var INJECTED_HELPERS = `
           }
           return true;
         };
-        var walkChildOf = function(parent, child) {
-          var node = parent.child;
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (node === child) return true;
-            node = node.sibling;
-          }
-          return false;
-        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
@@ -54632,7 +54624,6 @@ var INJECTED_HELPERS = `
           var node = host;
           while (node && lineage.length < 1000) {
             if (seen.has(node)) return null;
-            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
             seen.add(node);
             lineage.push(node);
             node = node.return;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -54540,6 +54540,7 @@ var INJECTED_HELPERS = `
 
     try {
       if (action === 'press' && opts.walkUp === true) {
+        // 8 levels covers ~2 JSX wrappers: one wrapper is ~3 fibers under NativeWind CssInterop.
         var WALK_UP_MAX = 8;
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
@@ -54593,7 +54594,7 @@ var INJECTED_HELPERS = `
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
-          walkOriginalCandidates.push(walkNode);
+          walkOriginalCandidates.push({ fiber: walkNode, hops: walkHops, source: walkSources[wi] });
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -54629,25 +54630,29 @@ var INJECTED_HELPERS = `
             node = node.return;
           }
           if (node) return null;
+          var lineageIndex = function(f) {
+            for (var li = 0; li < lineage.length; li++) {
+              if (sameFiber(f, lineage[li])) return li;
+            }
+            return -1;
+          };
           for (var si = 0; si < walkSources.length; si++) {
-            if (!seen.has(walkSources[si])) return null;
+            if (lineageIndex(walkSources[si]) < 0) return null;
           }
+          var hostTarget = null;
           var outermost = 0;
           for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
             var candidate = walkOriginalCandidates[ci];
-            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
-            outermost = Math.max(outermost, lineage.indexOf(candidate));
+            var candidateIndex = lineageIndex(candidate.fiber);
+            if (candidateIndex < 0 || candidate.fiber.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, candidateIndex);
+            if (candidate.source === host) hostTarget = candidate;
           }
+          if (!hostTarget) return null;
           for (var li = 1; li <= outermost; li++) {
             if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
           }
-          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
-            var p = lineage[hops].memoizedProps;
-            if (p && typeof p.onPress === 'function') {
-              return { fiber: lineage[hops], hops: hops, source: host };
-            }
-          }
-          return null;
+          return hostTarget;
         };
         if (walkCandidates.length > 1) {
           var witnessedTarget = walkSingleHostTarget();
@@ -55956,6 +55961,11 @@ var INJECTED_HELPERS = `
     return { eligible: true };
   }
 
+  // React return chains may thread through either half of a fiber/alternate pair.
+  function sameFiber(a, b) {
+    return a === b || (!!b && a === b.alternate);
+  }
+
   function isTestIdFrontmost(testID) {
     if (typeof testID !== 'string' || !testID) {
       return JSON.stringify({ visible: false, reason: 'testID is required' });
@@ -55999,12 +56009,10 @@ var INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
-      // React return chains may thread through either half of a fiber/alternate pair.
-      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor || current === ancestorAlternate) return true;
+        if (sameFiber(current, ancestor)) return true;
         current = current.return;
       }
       return false;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -54540,10 +54540,7 @@ var INJECTED_HELPERS = `
 
     try {
       if (action === 'press' && opts.walkUp === true) {
-        // GH #525 \u2014 nearest self-or-ancestor onPress within 8 fiber levels (one JSX wrapper is ~3 fibers under NativeWind CssInterop);
-        // candidates collapse only when they are the exact same fiber.
         var WALK_UP_MAX = 8;
-        // Host fibers carry a string type (e.g. 'RCTView') \u2014 same extraction as the ladder press path.
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
             ? f.type
@@ -54564,17 +54561,50 @@ var INJECTED_HELPERS = `
           }
           return false;
         };
-        // RN forwards testID and onPress down one element's composite/host stack; those fibers are
-        // the same logical target, so they collapse onto the outermost the way a direct press fires it.
+        var walkInertView = function(f) {
+          if (f.type !== 'RCTView') return false;
+          var p = f.memoizedProps || {};
+          if (p.accessible === true || p.focusable === true || (p.accessibilityRole && p.accessibilityRole !== 'none')
+            || (p.role && p.role !== 'none' && p.role !== 'presentation')) return false;
+          var keys = Object.keys(p);
+          for (var ki = 0; ki < keys.length; ki++) {
+            if (/^on(Press|LongPress|Click|DoubleClick|Touch|Responder|.*ShouldSetResponder|Pointer|Key|Accessibility|MagicTap)/.test(keys[ki])
+              && p[keys[ki]] != null) return false;
+          }
+          return true;
+        };
+        var walkChildOf = function(parent, child) {
+          var node = parent.child;
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (node === child) return true;
+            node = node.sibling;
+          }
+          return false;
+        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
+          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
+          if (!outer) return false;
+          var child = outer === a ? b : a;
+          var node = child.return;
+          var seen = new WeakSet();
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (seen.has(node)) return false;
+            seen.add(node);
+            if (!walkChildOf(node, child)) return false;
+            if (node.tag === 5 && !walkInertView(node)) return false;
+            if (node === outer) return true;
+            child = node;
+            node = node.return;
+          }
+          return false;
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];
+        var walkOriginalCandidates = [];
         for (var wi = 0; wi < walkSources.length; wi++) {
           var walkNode = walkSources[wi];
           var walkHops = 0;
@@ -54585,6 +54615,7 @@ var INJECTED_HELPERS = `
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
+          walkOriginalCandidates.push(walkNode);
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -54601,6 +54632,49 @@ var INJECTED_HELPERS = `
         }
         if (walkCandidates.length === 0) {
           return JSON.stringify({ error: 'Component has no onPress handler', component: walkFiberName(found), testID: selector, walkUpSearched: WALK_UP_MAX });
+        }
+        var walkSingleHostTarget = function() {
+          if (!opts.testID || findCycleDetected) return null;
+          var hosts = new Set();
+          for (var si = 0; si < walkSources.length; si++) {
+            if (walkSources[si].tag === 5) hosts.add(walkSources[si]);
+          }
+          if (hosts.size !== 1) return null;
+          var host = hosts.values().next().value;
+          var lineage = [];
+          var seen = new WeakSet();
+          var node = host;
+          while (node && lineage.length < 1000) {
+            if (seen.has(node)) return null;
+            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
+            seen.add(node);
+            lineage.push(node);
+            node = node.return;
+          }
+          if (node) return null;
+          for (var si = 0; si < walkSources.length; si++) {
+            if (!seen.has(walkSources[si])) return null;
+          }
+          var outermost = 0;
+          for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
+            var candidate = walkOriginalCandidates[ci];
+            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, lineage.indexOf(candidate));
+          }
+          for (var li = 1; li <= outermost; li++) {
+            if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
+          }
+          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
+            var p = lineage[hops].memoizedProps;
+            if (p && typeof p.onPress === 'function') {
+              return { fiber: lineage[hops], hops: hops, source: host };
+            }
+          }
+          return null;
+        };
+        if (walkCandidates.length > 1) {
+          var witnessedTarget = walkSingleHostTarget();
+          if (witnessedTarget) walkCandidates = [witnessedTarget];
         }
         if (walkCandidates.length > 1) {
           var walkDescriptors = [];

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -64483,7 +64483,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 62;
+    HELPERS_VERSION = 63;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -68788,7 +68788,7 @@ var init_injected_helpers = __esm({
 
   // React return chains may thread through either half of a fiber/alternate pair.
   function sameFiber(a, b) {
-    return a === b || (!!b && a === b.alternate);
+    return !!a && !!b && (a === b || a.alternate === b || b.alternate === a);
   }
 
   function isTestIdFrontmost(testID) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67365,6 +67365,7 @@ var init_injected_helpers = __esm({
 
     try {
       if (action === 'press' && opts.walkUp === true) {
+        // 8 levels covers ~2 JSX wrappers: one wrapper is ~3 fibers under NativeWind CssInterop.
         var WALK_UP_MAX = 8;
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
@@ -67418,7 +67419,7 @@ var init_injected_helpers = __esm({
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
-          walkOriginalCandidates.push(walkNode);
+          walkOriginalCandidates.push({ fiber: walkNode, hops: walkHops, source: walkSources[wi] });
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -67454,25 +67455,29 @@ var init_injected_helpers = __esm({
             node = node.return;
           }
           if (node) return null;
+          var lineageIndex = function(f) {
+            for (var li = 0; li < lineage.length; li++) {
+              if (sameFiber(f, lineage[li])) return li;
+            }
+            return -1;
+          };
           for (var si = 0; si < walkSources.length; si++) {
-            if (!seen.has(walkSources[si])) return null;
+            if (lineageIndex(walkSources[si]) < 0) return null;
           }
+          var hostTarget = null;
           var outermost = 0;
           for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
             var candidate = walkOriginalCandidates[ci];
-            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
-            outermost = Math.max(outermost, lineage.indexOf(candidate));
+            var candidateIndex = lineageIndex(candidate.fiber);
+            if (candidateIndex < 0 || candidate.fiber.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, candidateIndex);
+            if (candidate.source === host) hostTarget = candidate;
           }
+          if (!hostTarget) return null;
           for (var li = 1; li <= outermost; li++) {
             if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
           }
-          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
-            var p = lineage[hops].memoizedProps;
-            if (p && typeof p.onPress === 'function') {
-              return { fiber: lineage[hops], hops: hops, source: host };
-            }
-          }
-          return null;
+          return hostTarget;
         };
         if (walkCandidates.length > 1) {
           var witnessedTarget = walkSingleHostTarget();
@@ -68781,6 +68786,11 @@ var init_injected_helpers = __esm({
     return { eligible: true };
   }
 
+  // React return chains may thread through either half of a fiber/alternate pair.
+  function sameFiber(a, b) {
+    return a === b || (!!b && a === b.alternate);
+  }
+
   function isTestIdFrontmost(testID) {
     if (typeof testID !== 'string' || !testID) {
       return JSON.stringify({ visible: false, reason: 'testID is required' });
@@ -68824,12 +68834,10 @@ var init_injected_helpers = __esm({
       });
     }
     function containsFiber(ancestor, candidate) {
-      // React return chains may thread through either half of a fiber/alternate pair.
-      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor || current === ancestorAlternate) return true;
+        if (sameFiber(current, ancestor)) return true;
         current = current.return;
       }
       return false;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67365,10 +67365,7 @@ var init_injected_helpers = __esm({
 
     try {
       if (action === 'press' && opts.walkUp === true) {
-        // GH #525 \u2014 nearest self-or-ancestor onPress within 8 fiber levels (one JSX wrapper is ~3 fibers under NativeWind CssInterop);
-        // candidates collapse only when they are the exact same fiber.
         var WALK_UP_MAX = 8;
-        // Host fibers carry a string type (e.g. 'RCTView') \u2014 same extraction as the ladder press path.
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
             ? f.type
@@ -67389,17 +67386,50 @@ var init_injected_helpers = __esm({
           }
           return false;
         };
-        // RN forwards testID and onPress down one element's composite/host stack; those fibers are
-        // the same logical target, so they collapse onto the outermost the way a direct press fires it.
+        var walkInertView = function(f) {
+          if (f.type !== 'RCTView') return false;
+          var p = f.memoizedProps || {};
+          if (p.accessible === true || p.focusable === true || (p.accessibilityRole && p.accessibilityRole !== 'none')
+            || (p.role && p.role !== 'none' && p.role !== 'presentation')) return false;
+          var keys = Object.keys(p);
+          for (var ki = 0; ki < keys.length; ki++) {
+            if (/^on(Press|LongPress|Click|DoubleClick|Touch|Responder|.*ShouldSetResponder|Pointer|Key|Accessibility|MagicTap)/.test(keys[ki])
+              && p[keys[ki]] != null) return false;
+          }
+          return true;
+        };
+        var walkChildOf = function(parent, child) {
+          var node = parent.child;
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (node === child) return true;
+            node = node.sibling;
+          }
+          return false;
+        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
+          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
+          if (!outer) return false;
+          var child = outer === a ? b : a;
+          var node = child.return;
+          var seen = new WeakSet();
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (seen.has(node)) return false;
+            seen.add(node);
+            if (!walkChildOf(node, child)) return false;
+            if (node.tag === 5 && !walkInertView(node)) return false;
+            if (node === outer) return true;
+            child = node;
+            node = node.return;
+          }
+          return false;
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];
+        var walkOriginalCandidates = [];
         for (var wi = 0; wi < walkSources.length; wi++) {
           var walkNode = walkSources[wi];
           var walkHops = 0;
@@ -67410,6 +67440,7 @@ var init_injected_helpers = __esm({
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
+          walkOriginalCandidates.push(walkNode);
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -67426,6 +67457,49 @@ var init_injected_helpers = __esm({
         }
         if (walkCandidates.length === 0) {
           return JSON.stringify({ error: 'Component has no onPress handler', component: walkFiberName(found), testID: selector, walkUpSearched: WALK_UP_MAX });
+        }
+        var walkSingleHostTarget = function() {
+          if (!opts.testID || findCycleDetected) return null;
+          var hosts = new Set();
+          for (var si = 0; si < walkSources.length; si++) {
+            if (walkSources[si].tag === 5) hosts.add(walkSources[si]);
+          }
+          if (hosts.size !== 1) return null;
+          var host = hosts.values().next().value;
+          var lineage = [];
+          var seen = new WeakSet();
+          var node = host;
+          while (node && lineage.length < 1000) {
+            if (seen.has(node)) return null;
+            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
+            seen.add(node);
+            lineage.push(node);
+            node = node.return;
+          }
+          if (node) return null;
+          for (var si = 0; si < walkSources.length; si++) {
+            if (!seen.has(walkSources[si])) return null;
+          }
+          var outermost = 0;
+          for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
+            var candidate = walkOriginalCandidates[ci];
+            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, lineage.indexOf(candidate));
+          }
+          for (var li = 1; li <= outermost; li++) {
+            if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
+          }
+          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
+            var p = lineage[hops].memoizedProps;
+            if (p && typeof p.onPress === 'function') {
+              return { fiber: lineage[hops], hops: hops, source: host };
+            }
+          }
+          return null;
+        };
+        if (walkCandidates.length > 1) {
+          var witnessedTarget = walkSingleHostTarget();
+          if (witnessedTarget) walkCandidates = [witnessedTarget];
         }
         if (walkCandidates.length > 1) {
           var walkDescriptors = [];

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67398,14 +67398,6 @@ var init_injected_helpers = __esm({
           }
           return true;
         };
-        var walkChildOf = function(parent, child) {
-          var node = parent.child;
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (node === child) return true;
-            node = node.sibling;
-          }
-          return false;
-        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
@@ -67457,7 +67449,6 @@ var init_injected_helpers = __esm({
           var node = host;
           while (node && lineage.length < 1000) {
             if (seen.has(node)) return null;
-            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
             seen.add(node);
             lineage.push(node);
             node = node.return;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -67411,21 +67411,7 @@ var init_injected_helpers = __esm({
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
-          if (!outer) return false;
-          var child = outer === a ? b : a;
-          var node = child.return;
-          var seen = new WeakSet();
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (seen.has(node)) return false;
-            seen.add(node);
-            if (!walkChildOf(node, child)) return false;
-            if (node.tag === 5 && !walkInertView(node)) return false;
-            if (node === outer) return true;
-            child = node;
-            node = node.return;
-          }
-          return false;
+          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2885,10 +2885,7 @@ export const INJECTED_HELPERS = `
 
     try {
       if (action === 'press' && opts.walkUp === true) {
-        // GH #525 — nearest self-or-ancestor onPress within 8 fiber levels (one JSX wrapper is ~3 fibers under NativeWind CssInterop);
-        // candidates collapse only when they are the exact same fiber.
         var WALK_UP_MAX = 8;
-        // Host fibers carry a string type (e.g. 'RCTView') — same extraction as the ladder press path.
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
             ? f.type
@@ -2909,17 +2906,50 @@ export const INJECTED_HELPERS = `
           }
           return false;
         };
-        // RN forwards testID and onPress down one element's composite/host stack; those fibers are
-        // the same logical target, so they collapse onto the outermost the way a direct press fires it.
+        var walkInertView = function(f) {
+          if (f.type !== 'RCTView') return false;
+          var p = f.memoizedProps || {};
+          if (p.accessible === true || p.focusable === true || (p.accessibilityRole && p.accessibilityRole !== 'none')
+            || (p.role && p.role !== 'none' && p.role !== 'presentation')) return false;
+          var keys = Object.keys(p);
+          for (var ki = 0; ki < keys.length; ki++) {
+            if (/^on(Press|LongPress|Click|DoubleClick|Touch|Responder|.*ShouldSetResponder|Pointer|Key|Accessibility|MagicTap)/.test(keys[ki])
+              && p[keys[ki]] != null) return false;
+          }
+          return true;
+        };
+        var walkChildOf = function(parent, child) {
+          var node = parent.child;
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (node === child) return true;
+            node = node.sibling;
+          }
+          return false;
+        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
+          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
+          if (!outer) return false;
+          var child = outer === a ? b : a;
+          var node = child.return;
+          var seen = new WeakSet();
+          for (var steps = 0; node && steps < 1000; steps++) {
+            if (seen.has(node)) return false;
+            seen.add(node);
+            if (!walkChildOf(node, child)) return false;
+            if (node.tag === 5 && !walkInertView(node)) return false;
+            if (node === outer) return true;
+            child = node;
+            node = node.return;
+          }
+          return false;
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];
+        var walkOriginalCandidates = [];
         for (var wi = 0; wi < walkSources.length; wi++) {
           var walkNode = walkSources[wi];
           var walkHops = 0;
@@ -2930,6 +2960,7 @@ export const INJECTED_HELPERS = `
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
+          walkOriginalCandidates.push(walkNode);
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -2946,6 +2977,49 @@ export const INJECTED_HELPERS = `
         }
         if (walkCandidates.length === 0) {
           return JSON.stringify({ error: 'Component has no onPress handler', component: walkFiberName(found), testID: selector, walkUpSearched: WALK_UP_MAX });
+        }
+        var walkSingleHostTarget = function() {
+          if (!opts.testID || findCycleDetected) return null;
+          var hosts = new Set();
+          for (var si = 0; si < walkSources.length; si++) {
+            if (walkSources[si].tag === 5) hosts.add(walkSources[si]);
+          }
+          if (hosts.size !== 1) return null;
+          var host = hosts.values().next().value;
+          var lineage = [];
+          var seen = new WeakSet();
+          var node = host;
+          while (node && lineage.length < 1000) {
+            if (seen.has(node)) return null;
+            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
+            seen.add(node);
+            lineage.push(node);
+            node = node.return;
+          }
+          if (node) return null;
+          for (var si = 0; si < walkSources.length; si++) {
+            if (!seen.has(walkSources[si])) return null;
+          }
+          var outermost = 0;
+          for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
+            var candidate = walkOriginalCandidates[ci];
+            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, lineage.indexOf(candidate));
+          }
+          for (var li = 1; li <= outermost; li++) {
+            if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
+          }
+          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
+            var p = lineage[hops].memoizedProps;
+            if (p && typeof p.onPress === 'function') {
+              return { fiber: lineage[hops], hops: hops, source: host };
+            }
+          }
+          return null;
+        };
+        if (walkCandidates.length > 1) {
+          var witnessedTarget = walkSingleHostTarget();
+          if (witnessedTarget) walkCandidates = [witnessedTarget];
         }
         if (walkCandidates.length > 1) {
           var walkDescriptors = [];

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2931,21 +2931,7 @@ export const INJECTED_HELPERS = `
           if (!ap || !bp) return false;
           if (ap[matchField] !== selector || bp[matchField] !== selector) return false;
           if (ap.onPress !== bp.onPress) return false;
-          var outer = walkAncestorOf(a, b) ? a : (walkAncestorOf(b, a) ? b : null);
-          if (!outer) return false;
-          var child = outer === a ? b : a;
-          var node = child.return;
-          var seen = new WeakSet();
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (seen.has(node)) return false;
-            seen.add(node);
-            if (!walkChildOf(node, child)) return false;
-            if (node.tag === 5 && !walkInertView(node)) return false;
-            if (node === outer) return true;
-            child = node;
-            node = node.return;
-          }
-          return false;
+          return walkAncestorOf(a, b) || walkAncestorOf(b, a);
         };
         var walkSources = walkUpMatches.length > 0 ? walkUpMatches : [found];
         var walkCandidates = [];

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -4308,7 +4308,7 @@ export const INJECTED_HELPERS = `
 
   // React return chains may thread through either half of a fiber/alternate pair.
   function sameFiber(a, b) {
-    return a === b || (!!b && a === b.alternate);
+    return !!a && !!b && (a === b || a.alternate === b || b.alternate === a);
   }
 
   function isTestIdFrontmost(testID) {

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2885,6 +2885,7 @@ export const INJECTED_HELPERS = `
 
     try {
       if (action === 'press' && opts.walkUp === true) {
+        // 8 levels covers ~2 JSX wrappers: one wrapper is ~3 fibers under NativeWind CssInterop.
         var WALK_UP_MAX = 8;
         var walkFiberName = function(f) {
           return (f && f.type && (typeof f.type === 'string'
@@ -2938,7 +2939,7 @@ export const INJECTED_HELPERS = `
             walkHops++;
           }
           if (!walkNode || walkHops > WALK_UP_MAX) continue;
-          walkOriginalCandidates.push(walkNode);
+          walkOriginalCandidates.push({ fiber: walkNode, hops: walkHops, source: walkSources[wi] });
           var existing = null;
           for (var wj = 0; wj < walkCandidates.length; wj++) {
             if (walkCandidates[wj].fiber === walkNode || walkForwarded(walkCandidates[wj].fiber, walkNode)) {
@@ -2974,25 +2975,29 @@ export const INJECTED_HELPERS = `
             node = node.return;
           }
           if (node) return null;
+          var lineageIndex = function(f) {
+            for (var li = 0; li < lineage.length; li++) {
+              if (sameFiber(f, lineage[li])) return li;
+            }
+            return -1;
+          };
           for (var si = 0; si < walkSources.length; si++) {
-            if (!seen.has(walkSources[si])) return null;
+            if (lineageIndex(walkSources[si]) < 0) return null;
           }
+          var hostTarget = null;
           var outermost = 0;
           for (var ci = 0; ci < walkOriginalCandidates.length; ci++) {
             var candidate = walkOriginalCandidates[ci];
-            if (!seen.has(candidate) || candidate.memoizedProps.testID !== selector) return null;
-            outermost = Math.max(outermost, lineage.indexOf(candidate));
+            var candidateIndex = lineageIndex(candidate.fiber);
+            if (candidateIndex < 0 || candidate.fiber.memoizedProps.testID !== selector) return null;
+            outermost = Math.max(outermost, candidateIndex);
+            if (candidate.source === host) hostTarget = candidate;
           }
+          if (!hostTarget) return null;
           for (var li = 1; li <= outermost; li++) {
             if (lineage[li].tag === 5 && !walkInertView(lineage[li])) return null;
           }
-          for (var hops = 0; hops < lineage.length && hops <= WALK_UP_MAX; hops++) {
-            var p = lineage[hops].memoizedProps;
-            if (p && typeof p.onPress === 'function') {
-              return { fiber: lineage[hops], hops: hops, source: host };
-            }
-          }
-          return null;
+          return hostTarget;
         };
         if (walkCandidates.length > 1) {
           var witnessedTarget = walkSingleHostTarget();
@@ -4301,6 +4306,11 @@ export const INJECTED_HELPERS = `
     return { eligible: true };
   }
 
+  // React return chains may thread through either half of a fiber/alternate pair.
+  function sameFiber(a, b) {
+    return a === b || (!!b && a === b.alternate);
+  }
+
   function isTestIdFrontmost(testID) {
     if (typeof testID !== 'string' || !testID) {
       return JSON.stringify({ visible: false, reason: 'testID is required' });
@@ -4344,12 +4354,10 @@ export const INJECTED_HELPERS = `
       });
     }
     function containsFiber(ancestor, candidate) {
-      // React return chains may thread through either half of a fiber/alternate pair.
-      var ancestorAlternate = ancestor.alternate || null;
       var current = candidate;
       var guard = 0;
       while (current && guard++ < 1000) {
-        if (current === ancestor || current === ancestorAlternate) return true;
+        if (sameFiber(current, ancestor)) return true;
         current = current.return;
       }
       return false;

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2918,14 +2918,6 @@ export const INJECTED_HELPERS = `
           }
           return true;
         };
-        var walkChildOf = function(parent, child) {
-          var node = parent.child;
-          for (var steps = 0; node && steps < 1000; steps++) {
-            if (node === child) return true;
-            node = node.sibling;
-          }
-          return false;
-        };
         var walkForwarded = function(a, b) {
           var ap = a.memoizedProps, bp = b.memoizedProps;
           if (!ap || !bp) return false;
@@ -2977,7 +2969,6 @@ export const INJECTED_HELPERS = `
           var node = host;
           while (node && lineage.length < 1000) {
             if (seen.has(node)) return null;
-            if (lineage.length > 0 && !walkChildOf(node, lineage[lineage.length - 1])) return null;
             seen.add(node);
             lineage.push(node);
             node = node.return;

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 62;
+export const HELPERS_VERSION = 63;
 
 export const INJECTED_HELPERS = `
 (function() {

--- a/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
@@ -29,6 +29,7 @@ interface SandboxFiber {
   return: SandboxFiber | null;
   child: SandboxFiber | null;
   sibling: SandboxFiber | null;
+  alternate: SandboxFiber | null;
   stateNode: null;
 }
 
@@ -81,6 +82,7 @@ function buildFiber(spec: FiberSpec, parent: SandboxFiber | null = null): Sandbo
     return: parent,
     child: null,
     sibling: null,
+    alternate: null,
     stateNode: null,
   };
   if (spec.children && spec.children.length > 0) {
@@ -219,6 +221,18 @@ function assertTabAmbiguity(result: Record<string, unknown>, innerName = 'Animat
     hint: 'Multiple distinct pressable fibers resolve from this testID. Pass the testID of the exact pressable component instead.',
   });
 }
+
+test('#951 a bailout boundary inside the forwarding chain still resolves the host', () => {
+  const fixture = forwardedPressTree();
+  const animatedOld: SandboxFiber = { ...fixture.animated, alternate: fixture.animated };
+  fixture.animated.alternate = animatedOld;
+  fixture.pressable.return = animatedOld;
+  const result = pressFixture(fixture);
+  assert.equal(result.success, true, JSON.stringify(result));
+  assert.equal(result.component, 'Pressable');
+  assert.equal(result.walkUpLevels, 2);
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+});
 
 test('#951 repeated observations of the same mounted host still dispatch once', () => {
   const fixture = forwardedPressTree();

--- a/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
@@ -334,25 +334,6 @@ test('#951 siblings remain ambiguous with distinct or shared callbacks and host 
   }
 });
 
-test('#951 stale return pointers cannot hide a mounted independent responder host', () => {
-  const fixture = forwardedPressTree();
-  fixture.outerHost.memoizedProps.onResponderGrant = () => {};
-  fixture.animated.return = fixture.root;
-  assertTabAmbiguity(pressFixture(fixture));
-  assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
-});
-
-test('#951 a stale return pointer with one shared callback still dispatches once', () => {
-  const fixture = forwardedPressTree();
-  fixture.outerHost.memoizedProps.onResponderGrant = () => {};
-  fixture.animated.return = fixture.root;
-  fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
-  const result = pressFixture(fixture);
-  assert.equal(result.success, true, JSON.stringify(result));
-  assert.equal(result.component, 'BottomTabItem');
-  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
-});
-
 test('#951 unproven host semantics and incomplete ancestry preserve ambiguity metadata', async (t) => {
   const cases: Record<string, (fixture: ReturnType<typeof forwardedPressTree>) => void> = {
     'hostless distinct callbacks': (f) => {

--- a/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
@@ -273,19 +273,33 @@ test('#951 the single-host witness selects only within the existing eight-hop bo
   }
 });
 
-test('#951 distinct and shared callbacks cannot collapse separate nested host controls', async (t) => {
-  for (const shared of [false, true]) {
-    for (const outerHasId of [false, true]) {
-      await t.test(`shared=${shared}, outer host ID=${outerHasId}`, () => {
-        const fixture = forwardedPressTree();
-        fixture.outerHost.memoizedProps.onResponderGrant = () => {};
-        fixture.outerHost.memoizedProps.accessible = true;
-        if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
-        if (shared) fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
-        assertTabAmbiguity(pressFixture(fixture));
-        assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
-      });
-    }
+test('#951 distinct callbacks cannot collapse separate nested host controls', async (t) => {
+  for (const outerHasId of [false, true]) {
+    await t.test(`outer host ID=${outerHasId}`, () => {
+      const fixture = forwardedPressTree();
+      fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+      fixture.outerHost.memoizedProps.accessible = true;
+      if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
+      assertTabAmbiguity(pressFixture(fixture));
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+});
+
+test('#951 one callback shared across nested hosts keeps collapsing to a single dispatch', async (t) => {
+  for (const outerHasId of [false, true]) {
+    await t.test(`outer host ID=${outerHasId}`, () => {
+      const fixture = forwardedPressTree();
+      fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+      fixture.outerHost.memoizedProps.accessible = true;
+      if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
+      fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
+      const result = pressFixture(fixture);
+      assert.equal(result.success, true, JSON.stringify(result));
+      assert.equal(result.component, 'BottomTabItem');
+      assert.equal(result.walkUpLevels, undefined);
+      assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+    });
   }
 });
 
@@ -320,17 +334,23 @@ test('#951 siblings remain ambiguous with distinct or shared callbacks and host 
   }
 });
 
-test('#951 stale return pointers cannot hide a mounted independent responder host', async (t) => {
-  for (const shared of [false, true]) {
-    await t.test(`shared=${shared}`, () => {
-      const fixture = forwardedPressTree();
-      fixture.outerHost.memoizedProps.onResponderGrant = () => {};
-      fixture.animated.return = fixture.root;
-      if (shared) fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
-      assertTabAmbiguity(pressFixture(fixture));
-      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
-    });
-  }
+test('#951 stale return pointers cannot hide a mounted independent responder host', () => {
+  const fixture = forwardedPressTree();
+  fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+  fixture.animated.return = fixture.root;
+  assertTabAmbiguity(pressFixture(fixture));
+  assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+});
+
+test('#951 a stale return pointer with one shared callback still dispatches once', () => {
+  const fixture = forwardedPressTree();
+  fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+  fixture.animated.return = fixture.root;
+  fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
+  const result = pressFixture(fixture);
+  assert.equal(result.success, true, JSON.stringify(result));
+  assert.equal(result.component, 'BottomTabItem');
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
 });
 
 test('#951 unproven host semantics and incomplete ancestry preserve ambiguity metadata', async (t) => {

--- a/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-525-interact-walkup.test.ts
@@ -23,6 +23,7 @@ interface FiberSpec {
 }
 
 interface SandboxFiber {
+  tag: number;
   type: { displayName: string } | string | null;
   memoizedProps: Record<string, unknown>;
   return: SandboxFiber | null;
@@ -31,7 +32,7 @@ interface SandboxFiber {
   stateNode: null;
 }
 
-function createSandbox(opts: { fiberRoot?: SandboxFiber } = {}) {
+function createSandbox(opts: { fiberRoot?: SandboxFiber; repeatRoot?: boolean } = {}) {
   const sandbox: Record<string, unknown> = {
     Array,
     Object,
@@ -58,7 +59,13 @@ function createSandbox(opts: { fiberRoot?: SandboxFiber } = {}) {
     sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
       renderers: new Map([[1, {}]]),
       getFiberRoots: (id: number) =>
-        id === 1 ? new Set([{ current: opts.fiberRoot }]) : new Set(),
+        id === 1
+          ? new Set(
+              opts.repeatRoot
+                ? [{ current: opts.fiberRoot }, { current: opts.fiberRoot }]
+                : [{ current: opts.fiberRoot }],
+            )
+          : new Set(),
     };
   }
   vm.createContext(sandbox);
@@ -68,6 +75,7 @@ function createSandbox(opts: { fiberRoot?: SandboxFiber } = {}) {
 
 function buildFiber(spec: FiberSpec, parent: SandboxFiber | null = null): SandboxFiber {
   const fiber: SandboxFiber = {
+    tag: spec.host ? 5 : 0,
     type: spec.name ? (spec.host ? spec.name : { displayName: spec.name }) : null,
     memoizedProps: spec.props || {},
     return: parent,
@@ -115,6 +123,352 @@ test('#525 default (no walkUp): the refusal payload is byte-for-byte unchanged a
     '{"error":"Component has no onPress handler","component":"View","testID":"externalCoverageCard_1"}',
   );
   assert.equal(fired, 0);
+});
+
+function forwardedPressTree() {
+  const calls = { wrapper: 0, navigation: 0 };
+  const navigate = () => calls.navigation++;
+  const handlePress = () => {
+    calls.wrapper++;
+    navigate();
+  };
+  const root = buildFiber({
+    name: 'BottomTabItem',
+    props: { testID: 'tab-home', onPress: navigate },
+    children: [
+      {
+        name: 'RCTView',
+        host: true,
+        children: [
+          {
+            name: 'Animated(Pressable)',
+            props: { testID: 'tab-home', onPress: handlePress },
+            children: [
+              {
+                name: 'Pressable',
+                props: { testID: 'tab-home', onPress: handlePress },
+                children: [
+                  {
+                    name: 'View',
+                    props: { testID: 'tab-home' },
+                    children: [
+                      {
+                        name: 'RCTView',
+                        host: true,
+                        props: {
+                          testID: 'tab-home',
+                          accessible: true,
+                          accessibilityRole: 'button',
+                          onResponderGrant: () => {},
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  const outerHost = root.child;
+  const animated = outerHost?.child;
+  const pressable = animated?.child;
+  const view = pressable?.child;
+  const host = view?.child;
+  assert.ok(outerHost && animated && pressable && view && host);
+  return { root, outerHost, animated, pressable, view, host, calls };
+}
+
+test('#951 a single host witnesses distinct forwarding callbacks and dispatches the nearest once', () => {
+  const fixture = forwardedPressTree();
+  const sandbox = createSandbox({ fiberRoot: fixture.root });
+  const result = JSON.parse(
+    sandbox.__RN_AGENT.interact({
+      action: 'press',
+      testID: 'tab-home',
+      walkUp: true,
+    }),
+  );
+  assert.equal(result.success, true, JSON.stringify(result));
+  assert.equal(result.component, 'Pressable');
+  assert.equal(result.walkUpLevels, 2);
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+});
+
+function pressFixture(fixture: ReturnType<typeof forwardedPressTree>, repeatRoot = false) {
+  return JSON.parse(
+    createSandbox({ fiberRoot: fixture.root, repeatRoot }).__RN_AGENT.interact({
+      action: 'press',
+      testID: 'tab-home',
+      walkUp: true,
+    }),
+  );
+}
+
+function assertTabAmbiguity(result: Record<string, unknown>, innerName = 'Animated(Pressable)') {
+  assert.deepEqual(result, {
+    error: 'Ambiguous walkUp press target',
+    testID: 'tab-home',
+    count: 2,
+    candidates: [
+      { component: 'BottomTabItem', testID: 'tab-home' },
+      { component: innerName, testID: 'tab-home' },
+    ],
+    hint: 'Multiple distinct pressable fibers resolve from this testID. Pass the testID of the exact pressable component instead.',
+  });
+}
+
+test('#951 repeated observations of the same mounted host still dispatch once', () => {
+  const fixture = forwardedPressTree();
+  assert.equal(pressFixture(fixture, true).success, true);
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+});
+
+test('#951 the witness uses fiber and native host facts independently of composite names', () => {
+  const fixture = forwardedPressTree();
+  for (const fiber of [fixture.root, fixture.animated, fixture.pressable, fixture.view])
+    fiber.type = null;
+  fixture.host.memoizedProps.onPress = fixture.pressable.memoizedProps.onPress;
+  const result = pressFixture(fixture);
+  assert.equal(result.success, true);
+  assert.equal(result.component, 'RCTView');
+  assert.equal(result.walkUpLevels, undefined);
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+});
+
+test('#951 existing same-callback forwarding through an inert host keeps its original target', () => {
+  const fixture = forwardedPressTree();
+  fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
+  fixture.outerHost.memoizedProps.testID = 'tab-home';
+  const result = pressFixture(fixture);
+  assert.equal(result.success, true);
+  assert.equal(result.component, 'BottomTabItem');
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+});
+
+test('#951 the single-host witness selects only within the existing eight-hop bound', async (t) => {
+  for (const hops of [8, 9]) {
+    await t.test(`${hops} hops`, () => {
+      const fixture = forwardedPressTree();
+      let parent = fixture.view;
+      for (let index = 0; index < hops - 2; index++) {
+        const wrapper = buildFiber({ name: 'Wrapper' }, parent);
+        parent.child = wrapper;
+        parent = wrapper;
+      }
+      parent.child = fixture.host;
+      fixture.host.return = parent;
+      const result = pressFixture(fixture);
+      if (hops === 8) {
+        assert.equal(result.success, true);
+        assert.equal(result.walkUpLevels, 8);
+        assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+      } else {
+        assertTabAmbiguity(result);
+        assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+      }
+    });
+  }
+});
+
+test('#951 distinct and shared callbacks cannot collapse separate nested host controls', async (t) => {
+  for (const shared of [false, true]) {
+    for (const outerHasId of [false, true]) {
+      await t.test(`shared=${shared}, outer host ID=${outerHasId}`, () => {
+        const fixture = forwardedPressTree();
+        fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+        fixture.outerHost.memoizedProps.accessible = true;
+        if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
+        if (shared) fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
+        assertTabAmbiguity(pressFixture(fixture));
+        assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+      });
+    }
+  }
+});
+
+test('#951 siblings remain ambiguous with distinct or shared callbacks and host IDs', async (t) => {
+  for (const shared of [false, true]) {
+    await t.test(`shared=${shared}`, () => {
+      const fixture = forwardedPressTree();
+      const sibling = buildFiber({
+        name: 'OtherButton',
+        props: {
+          testID: 'tab-home',
+          onPress: shared
+            ? fixture.animated.memoizedProps.onPress
+            : () => fixture.calls.navigation++,
+        },
+        children: [{ name: 'RCTView', host: true, props: { testID: 'tab-home' } }],
+      });
+      fixture.root.sibling = sibling;
+      const result = pressFixture(fixture);
+      assert.equal(result.count, 3);
+      assert.deepEqual(result.candidates, [
+        { component: 'BottomTabItem', testID: 'tab-home' },
+        { component: 'Animated(Pressable)', testID: 'tab-home' },
+        { component: 'OtherButton', testID: 'tab-home' },
+      ]);
+      assert.equal(
+        result.hint,
+        'Multiple distinct pressable fibers resolve from this testID. Pass the testID of the exact pressable component instead.',
+      );
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+});
+
+test('#951 stale return pointers cannot hide a mounted independent responder host', async (t) => {
+  for (const shared of [false, true]) {
+    await t.test(`shared=${shared}`, () => {
+      const fixture = forwardedPressTree();
+      fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+      fixture.animated.return = fixture.root;
+      if (shared) fixture.root.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
+      assertTabAmbiguity(pressFixture(fixture));
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+});
+
+test('#951 unproven host semantics and incomplete ancestry preserve ambiguity metadata', async (t) => {
+  const cases: Record<string, (fixture: ReturnType<typeof forwardedPressTree>) => void> = {
+    'hostless distinct callbacks': (f) => {
+      f.host.tag = 0;
+    },
+    'unknown native host': (f) => {
+      f.outerHost.type = 'CustomNativeControl';
+    },
+    'click handler': (f) => {
+      f.outerHost.memoizedProps.onClick = () => {};
+    },
+    'touch handler': (f) => {
+      f.outerHost.memoizedProps.onTouchStart = () => {};
+    },
+    'responder negotiation': (f) => {
+      f.outerHost.memoizedProps.onStartShouldSetResponder = () => true;
+    },
+    'scroll responder negotiation': (f) => {
+      f.outerHost.memoizedProps.onScrollShouldSetResponder = () => true;
+    },
+    'accessible host': (f) => {
+      f.outerHost.memoizedProps.accessible = true;
+    },
+    'focusable host': (f) => {
+      f.outerHost.memoizedProps.focusable = true;
+    },
+    'host control role': (f) => {
+      f.outerHost.memoizedProps.accessibilityRole = 'button';
+    },
+    'return cycle': (f) => {
+      f.root.return = f.host;
+    },
+    'broken return': (f) => {
+      f.host.return = null;
+    },
+    'cyclic mounted traversal': (f) => {
+      f.host.child = f.animated;
+    },
+    'off-line exact-ID source': (f) => {
+      f.animated.sibling = buildFiber(
+        { name: 'OffLine', props: { testID: 'tab-home' } },
+        f.outerHost,
+      );
+    },
+  };
+  for (const [label, mutate] of Object.entries(cases)) {
+    await t.test(label, () => {
+      const fixture = forwardedPressTree();
+      mutate(fixture);
+      assertTabAmbiguity(pressFixture(fixture), label === 'return cycle' ? 'Pressable' : undefined);
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+});
+
+test('#951 incomplete match collection refuses without dispatching the witnessed host', () => {
+  const fixture = forwardedPressTree();
+  let tail = fixture.root;
+  for (let index = 0; index < 8000; index++) {
+    tail.sibling = buildFiber({ name: 'Unrelated' });
+    tail = tail.sibling;
+  }
+  const result = pressFixture(fixture);
+  assert.deepEqual(result, {
+    error: 'Resolution truncated',
+    truncated: true,
+    scanned: 8001,
+    hint: 'increase budget or scope with a container/anchor',
+  });
+  assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+});
+
+test('#951 an ancestor candidate with a different testID cannot join the witness', () => {
+  const fixture = forwardedPressTree();
+  fixture.root.memoizedProps.testID = 'outer-control';
+  const source = buildFiber({ name: 'Wrapper', props: { testID: 'tab-home' } }, fixture.root);
+  fixture.root.child = source;
+  source.child = fixture.outerHost;
+  fixture.outerHost.return = source;
+  const result = pressFixture(fixture);
+  assert.equal(result.count, 2);
+  assert.deepEqual(result.candidates, [
+    { component: 'BottomTabItem', testID: 'outer-control' },
+    { component: 'Animated(Pressable)', testID: 'tab-home' },
+  ]);
+  assert.equal(
+    result.hint,
+    'Multiple distinct pressable fibers resolve from this testID. Pass the testID of the exact pressable component instead.',
+  );
+  assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+});
+
+test('#951 a throwing nearest forwarding handler reports execution without calling navigation', () => {
+  const fixture = forwardedPressTree();
+  const throwOnPress = () => {
+    fixture.calls.wrapper++;
+    throw new Error('forwarding failure');
+  };
+  fixture.animated.memoizedProps.onPress = throwOnPress;
+  fixture.pressable.memoizedProps.onPress = throwOnPress;
+  const result = pressFixture(fixture);
+  assert.equal(result.success, false);
+  assert.equal(result.action_executed, true);
+  assert.equal(result.component, 'Pressable');
+  assert.equal(result.handler_error, 'forwarding failure');
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 0 });
+});
+
+test('#951 eligible sources are never selected by filtering away disabled or hidden duplicates', async (t) => {
+  for (const target of ['root', 'host', 'pressable'] as const) {
+    await t.test(`disabled ${target}`, () => {
+      const fixture = forwardedPressTree();
+      fixture[target].memoizedProps.disabled = true;
+      const result = pressFixture(fixture);
+      assert.equal(result.error, 'Component is disabled');
+      assert.equal(
+        result.reason,
+        target === 'pressable' ? 'disabled walk target' : 'disabled exact-ID fiber',
+      );
+      assert.equal(result.testID, 'tab-home');
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+  for (const props of [
+    { disabled: true },
+    { style: { display: 'none' } },
+    { pointerEvents: 'none' },
+  ]) {
+    await t.test(`ambiguous ${JSON.stringify(props)}`, () => {
+      const fixture = forwardedPressTree();
+      Object.assign(fixture.host.memoizedProps, props);
+      fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+      assertTabAmbiguity(pressFixture(fixture));
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
 });
 
 test('#525 default (no walkUp): direct press response stays byte-for-byte unchanged', () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-869-replay-tap-type-walkup.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-869-replay-tap-type-walkup.test.ts
@@ -134,6 +134,271 @@ function otpFixture() {
   return { root, app, pressable, pressableHost, inputComposite, calls, inputHost };
 }
 
+function tabFixture() {
+  const calls = { wrapper: 0, navigation: 0 };
+  const root = makeFiber('Root');
+  const navigate = () => calls.navigation++;
+  const handlePress = () => {
+    calls.wrapper++;
+    navigate();
+  };
+  const outer = appendChild(
+    root,
+    makeFiber(
+      { displayName: 'BottomTabItem' },
+      {
+        testID: 'tab-home',
+        onPress: navigate,
+      },
+    ),
+  );
+  const outerHost = appendChild(outer, makeFiber('RCTView'));
+  const animated = appendChild(
+    outerHost,
+    makeFiber(
+      { displayName: 'Animated(Pressable)' },
+      {
+        testID: 'tab-home',
+        onPress: handlePress,
+      },
+    ),
+  );
+  const pressable = appendChild(
+    animated,
+    makeFiber(
+      { displayName: 'Pressable' },
+      {
+        testID: 'tab-home',
+        onPress: handlePress,
+      },
+    ),
+  );
+  const host = appendChild(
+    pressable,
+    makeFiber('RCTView', {
+      testID: 'tab-home',
+      accessible: true,
+      accessibilityRole: 'button',
+      onResponderGrant: () => {},
+    }),
+  );
+  return { root, outer, outerHost, animated, pressable, host, calls };
+}
+
+test('#951 saved replay dispatches a wrapped navigator press through its native-path callback', async () => {
+  const fixture = tabFixture();
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'tab-home' } }],
+    {},
+    buildDeps(createAgent(fixture.root)),
+  );
+  assert.equal(result.passed, true, JSON.stringify(result));
+  assert.deepEqual(
+    result.steps.map(({ t, target, ok }) => ({ t, target, ok })),
+    [{ t: 'tap', target: 'tab-home', ok: true }],
+  );
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+});
+
+test('#951 replay refuses nested host controls including a shared callback and an outer host without ID', async (t) => {
+  for (const shared of [false, true]) {
+    for (const outerHasId of [false, true]) {
+      await t.test(`shared=${shared}, outer host ID=${outerHasId}`, async () => {
+        const fixture = tabFixture();
+        fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+        fixture.outerHost.memoizedProps.accessible = true;
+        if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
+        if (shared) fixture.outer.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
+        const result = await runCdpReplayCommands(
+          [{ tapOn: { id: 'tab-home' } }],
+          {},
+          buildDeps(createAgent(fixture.root)),
+        );
+        assert.equal(result.passed, false);
+        assert.equal(result.failedStepIndex, 0);
+        assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+        assert.deepEqual(result.failureMeta, {
+          hint: 'Multiple distinct pressable fibers resolve from this testID. Pass the testID of the exact pressable component instead.',
+          count: 2,
+          candidates: [
+            { component: 'BottomTabItem', testID: 'tab-home' },
+            { component: 'Animated(Pressable)', testID: 'tab-home' },
+          ],
+        });
+        assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+      });
+    }
+  }
+});
+
+test('#951 replay preserves frontmost ambiguity for sibling hosts with distinct or shared callbacks', async (t) => {
+  for (const shared of [false, true]) {
+    await t.test(`shared=${shared}`, async () => {
+      const fixture = tabFixture();
+      const sibling = appendChild(
+        fixture.root,
+        makeFiber(
+          { displayName: 'OtherButton' },
+          {
+            testID: 'tab-home',
+            onPress: shared
+              ? fixture.animated.memoizedProps.onPress
+              : () => fixture.calls.navigation++,
+          },
+        ),
+      );
+      appendChild(sibling, makeFiber('RCTView', { testID: 'tab-home' }));
+      const result = await runCdpReplayCommands(
+        [{ tapOn: { id: 'tab-home' } }],
+        {},
+        buildDeps(createAgent(fixture.root)),
+      );
+      assert.equal(result.passed, false);
+      assert.equal(result.failedStepIndex, 0);
+      assert.equal(result.failureCode, 'AMBIGUOUS_TESTID');
+      assert.deepEqual(result.failureMeta, { matchCount: 2 });
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+});
+
+test('#951 live eligibility rechecks every source after the replay proof', async (t) => {
+  const cases: Array<{
+    label: string;
+    mutate: (fixture: ReturnType<typeof tabFixture>) => void;
+    reason: string;
+  }> = [
+    {
+      label: 'disabled outer source',
+      mutate: (f) => {
+        f.outer.memoizedProps.disabled = true;
+      },
+      reason: 'disabled exact-ID fiber',
+    },
+    {
+      label: 'disabled host',
+      mutate: (f) => {
+        f.host.memoizedProps.disabled = true;
+      },
+      reason: 'disabled exact-ID fiber',
+    },
+    {
+      label: 'disabled ancestor target',
+      mutate: (f) => {
+        f.pressable.memoizedProps.disabled = true;
+      },
+      reason: 'disabled walk target',
+    },
+    {
+      label: 'pointer-blocked host',
+      mutate: (f) => {
+        f.host.memoizedProps.pointerEvents = 'none';
+      },
+      reason: 'exact-ID fiber has pointerEvents="none"',
+    },
+    {
+      label: 'pointer-blocked parent',
+      mutate: (f) => {
+        f.outerHost.memoizedProps.pointerEvents = 'box-only';
+      },
+      reason: 'exact-ID fiber is beneath pointerEvents="box-only"',
+    },
+    {
+      label: 'hidden host',
+      mutate: (f) => {
+        f.host.memoizedProps.style = { display: 'none' };
+      },
+      reason: 'hidden exact-ID subtree',
+    },
+  ];
+  for (const { label, mutate, reason } of cases) {
+    await t.test(label, async () => {
+      const fixture = tabFixture();
+      const agent = createAgent(fixture.root, (expression) => {
+        if (expression.startsWith('__RN_AGENT.interact(')) mutate(fixture);
+      });
+      const result = await runCdpReplayCommands(
+        [{ tapOn: { id: 'tab-home' } }],
+        {},
+        buildDeps(agent),
+      );
+      assert.equal(result.passed, false);
+      assert.equal(result.failedStepIndex, 0);
+      assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+      assert.deepEqual(result.failureMeta, { reason });
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+});
+
+test('#951 the existing modal gate refuses an occluded tab before dispatch', async () => {
+  const fixture = tabFixture();
+  const modal = appendChild(fixture.root, makeFiber('RCTView', { accessibilityViewIsModal: true }));
+  appendChild(modal, makeFiber('RCTText', { children: 'Blocking sheet' }));
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'tab-home' } }],
+    {},
+    buildDeps(createAgent(fixture.root)),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'ASSERTION_FAILED');
+  assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+});
+
+test('#951 a throwing forwarding handler preserves replay execution metadata', async () => {
+  const fixture = tabFixture();
+  const throwOnPress = () => {
+    fixture.calls.wrapper++;
+    throw new Error('forwarding failure');
+  };
+  fixture.animated.memoizedProps.onPress = throwOnPress;
+  fixture.pressable.memoizedProps.onPress = throwOnPress;
+  const result = await runCdpReplayCommands(
+    [{ tapOn: { id: 'tab-home' } }],
+    {},
+    buildDeps(createAgent(fixture.root)),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 0);
+  assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+  assert.deepEqual(result.failureMeta, {
+    actionExecuted: true,
+    handlerError: 'forwarding failure',
+    hint: 'The app handler raised an exception — the screen may be in an error state. Check cdp_error_log before continuing.',
+  });
+  assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 0 });
+});
+
+test('#951 replay preserves absence and bounded-search metadata', async (t) => {
+  await t.test('absent target', async () => {
+    const fixture = tabFixture();
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'missing-tab' } }],
+      {},
+      buildDeps(createAgent(fixture.root)),
+    );
+    assert.equal(result.passed, false);
+    assert.equal(result.failureCode, 'TESTID_NOT_FOUND');
+    assert.deepEqual(result.failureMeta, { failedSelector: 'missing-tab' });
+    assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+  });
+  await t.test('no handler', async () => {
+    const fixture = tabFixture();
+    for (const fiber of [fixture.outer, fixture.animated, fixture.pressable])
+      delete fiber.memoizedProps.onPress;
+    const result = await runCdpReplayCommands(
+      [{ tapOn: { id: 'tab-home' } }],
+      {},
+      buildDeps(createAgent(fixture.root)),
+    );
+    assert.equal(result.passed, false);
+    assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+    assert.deepEqual(result.failureMeta, { walkUpSearched: 8 });
+    assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+  });
+});
+
 test('#869 replay designates the Pressable-wrapped input by its exact testID, then types on that same input', async () => {
   const fixture = otpFixture();
   const deps = buildDeps(createAgent(fixture.root));

--- a/packages/rn-dev-agent-core/test/unit/gh-869-replay-tap-type-walkup.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-869-replay-tap-type-walkup.test.ts
@@ -200,34 +200,54 @@ test('#951 saved replay dispatches a wrapped navigator press through its native-
   assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
 });
 
-test('#951 replay refuses nested host controls including a shared callback and an outer host without ID', async (t) => {
-  for (const shared of [false, true]) {
-    for (const outerHasId of [false, true]) {
-      await t.test(`shared=${shared}, outer host ID=${outerHasId}`, async () => {
-        const fixture = tabFixture();
-        fixture.outerHost.memoizedProps.onResponderGrant = () => {};
-        fixture.outerHost.memoizedProps.accessible = true;
-        if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
-        if (shared) fixture.outer.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
-        const result = await runCdpReplayCommands(
-          [{ tapOn: { id: 'tab-home' } }],
-          {},
-          buildDeps(createAgent(fixture.root)),
-        );
-        assert.equal(result.passed, false);
-        assert.equal(result.failedStepIndex, 0);
-        assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
-        assert.deepEqual(result.failureMeta, {
-          hint: 'Multiple distinct pressable fibers resolve from this testID. Pass the testID of the exact pressable component instead.',
-          count: 2,
-          candidates: [
-            { component: 'BottomTabItem', testID: 'tab-home' },
-            { component: 'Animated(Pressable)', testID: 'tab-home' },
-          ],
-        });
-        assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+test('#951 replay refuses nested host controls with distinct callbacks', async (t) => {
+  for (const outerHasId of [false, true]) {
+    await t.test(`outer host ID=${outerHasId}`, async () => {
+      const fixture = tabFixture();
+      fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+      fixture.outerHost.memoizedProps.accessible = true;
+      if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
+      const result = await runCdpReplayCommands(
+        [{ tapOn: { id: 'tab-home' } }],
+        {},
+        buildDeps(createAgent(fixture.root)),
+      );
+      assert.equal(result.passed, false);
+      assert.equal(result.failedStepIndex, 0);
+      assert.equal(result.failureCode, 'INTERACTION_NOT_ACTUATED');
+      assert.deepEqual(result.failureMeta, {
+        hint: 'Multiple distinct pressable fibers resolve from this testID. Pass the testID of the exact pressable component instead.',
+        count: 2,
+        candidates: [
+          { component: 'BottomTabItem', testID: 'tab-home' },
+          { component: 'Animated(Pressable)', testID: 'tab-home' },
+        ],
       });
-    }
+      assert.deepEqual(fixture.calls, { wrapper: 0, navigation: 0 });
+    });
+  }
+});
+
+test('#951 replay dispatches one shared callback across nested hosts exactly once', async (t) => {
+  for (const outerHasId of [false, true]) {
+    await t.test(`outer host ID=${outerHasId}`, async () => {
+      const fixture = tabFixture();
+      fixture.outerHost.memoizedProps.onResponderGrant = () => {};
+      fixture.outerHost.memoizedProps.accessible = true;
+      if (outerHasId) fixture.outerHost.memoizedProps.testID = 'tab-home';
+      fixture.outer.memoizedProps.onPress = fixture.animated.memoizedProps.onPress;
+      const result = await runCdpReplayCommands(
+        [{ tapOn: { id: 'tab-home' } }],
+        {},
+        buildDeps(createAgent(fixture.root)),
+      );
+      assert.equal(result.passed, true, JSON.stringify(result));
+      assert.deepEqual(
+        result.steps.map((step) => ({ t: step.t, target: step.target, ok: step.ok })),
+        [{ t: 'tap', target: 'tab-home', ok: true }],
+      );
+      assert.deepEqual(fixture.calls, { wrapper: 1, navigation: 1 });
+    });
   }
 });
 


### PR DESCRIPTION
Saved actions pressing a bottom-tab `testID` can refuse while a direct press succeeds. Forwarding wrappers caused `INTERACTION_NOT_ACTUATED`; independent QA also exposed an earlier `ASSERTION_FAILED` because the shared visibility check treated an inactive destination provider as an inactive screen owner.

The press resolver now admits forwarding only with one mounted ID-bearing host, all candidates on that host's ancestry, and inert intervening Views. It chooses the nearest function-valued handler within the existing eight-hop bound. Exact-fiber deduplication, distinct-control refusals, eligibility guards, and failure metadata remain intact.

Visibility binds each destination item to its nearest enclosing navigator using exact descriptor-map identity, keyed local state, selected-descriptor focus, and navigator focus. Only matching transparent destination providers between that item and navigator are exempted. Owners below the item, above the navigator, and in richer scene/descriptor/context scopes remain checked. Paired route/navigation contexts work in either adjacent-provider order; unpaired route-like values are skipped. Invalid recognized ownership refuses, and an invalid present `getState` cannot fall back to the legacy getter.

Repeated observations of the same host are deduplicated by exact fiber identity. A testID on both the tab-button host and an inner host still refuses because they are two distinct hosts. The single-host and descriptor-shape requirements remain explicit coverage boundaries.

Helper version 70 triggers reinjection. Both packaged host runtimes are regenerated, the replay contract is documented, and the one-sentence changeset bumps core and plugin by a patch.

Validation:

- All 311 tests in the three touched unit suites passed, including provider-order compatibility, destination binding, inactive/richer/below-item owners, malformed getters, repeated-root dispatch, distinct controls, and refusal counters.
- The same synthetic bottom-tab tree, replayed through the real dependencies and dispatcher, reproduces the original ambiguity with helper 62 and dispatches exactly once with helper 70. Both shipped host payloads also dispatch once. An unfocused owning scene still refuses with zero callbacks.
- No-mistakes review, tests, documentation, formatting, lint, and TypeScript checks passed. All 25 CI checks passed on `025805a5`, including the required Build & Test check.

<details>
<summary>Synthetic replay evidence</summary>

| Case | Result | Wrapper / navigation callbacks |
| --- | --- | --- |
| Active Home tab, baseline helper 62 | `INTERACTION_NOT_ACTUATED` | 0 / 0 |
| Inactive Home tab, baseline helper 62 | `ASSERTION_FAILED` | 0 / 0 |
| Active or inactive Home tab, helper 70 | Passed | 1 / 1 |
| Unfocused owning scene, helper 70 | `ASSERTION_FAILED` | 0 / 0 |
| Each shipped host payload, helper 70 | Passed | 1 / 1 |

</details>

<details>
<summary>Rendered replay-contract documentation</summary>

<img src="https://github.com/user-attachments/assets/8bbe1a11-11d3-4fb7-bdb5-7cacfb972962" width="400" alt="Rendered actions documentation describing the replay press and route-ownership contract" />

</details>

Live provider tracing is deferred to independent QA: after starting below one-minute load 10 with no competing native build, the final owned baseline attempt compiled but failed with `SIMULATOR_INSTALL_RACE` (`IXErrorDomain` code 2, missing install placeholder). Its logs, earlier startup failures, load history, and synthetic evidence are preserved externally. These results do not establish real-device acceptance.

Independent QA remains required on this final head: real tab replay, direct-root and Expo-root layouts, retained inactive content, and distinct-control negative counters. The earlier QA failure remains preserved. Android native selector ambiguity is outside this correction and awaits its separate scope decision; no Android acceptance is claimed.

Fixes Lykhoyda/rn-dev-agent#951.

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"025805a5aeca993c3875f479233fc595d19bb371","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->
